### PR TITLE
FIX :  When a discount refund or a credit is generated, we *must not*…

### DIFF
--- a/alma/controllers/hook/refund.php
+++ b/alma/controllers/hook/refund.php
@@ -38,8 +38,8 @@ class AlmaRefundController extends AlmaAdminHookController
 {
     public function run($params)
     {
-        // When a discount refund is generated, we *must not* refund the customer via Alma
-        if (Tools::isSubmit('generateDiscountRefund') || Tools::isSubmit('generateDiscount')) {
+        // When a discount refund or a credit is generated, we *must not* refund the customer via Alma
+        if (Tools::isSubmit('generateDiscountRefund') || Tools::isSubmit('generateDiscount') || Tools::isSubmit('generateCreditSlip')) {
             return;
         }
 


### PR DESCRIPTION
I noticed in Prestashop 1.5, partial refund does not trigger alma refund.
Is it normal ?