### PR TITLE
cast to array to fix warning if object

### DIFF
--- a/alma/lib/Utils/Settings.php
+++ b/alma/lib/Utils/Settings.php
@@ -394,7 +394,7 @@ class Settings
     {
         $categories = self::get('ALMA_EXCLUDED_CATEGORIES');
         if (null !== $categories && 'null' !== $categories) {
-            return json_decode($categories);
+            return (array) json_decode($categories);
         }
 
         return [];


### PR DESCRIPTION
When I exclude categories, I get an error because `Settings::getExcludedCategories()` returns an object instead of an array