### PR TITLE
feat: added override option (prestashop like) for hook controllers

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -332,6 +332,13 @@ class Alma extends PaymentModule
 
         require_once dirname(__FILE__) . "/controllers/hook/${hookName}HookController.php";
         $ControllerName = "Alma\PrestaShop\Controllers\Hook\\${hookName}HookController";
+
+        // check if override exist for hook controllers
+        if (file_exists(dirname(__FILE__) . "/../../override/modules/alma/controllers/hook/${hookName}HookController.php")) {
+            require_once dirname(__FILE__) . "/../../override/modules/alma/controllers/hook/${hookName}HookController.php";
+            $ControllerName = "Alma\PrestaShop\Controllers\Hook\\${hookName}HookControllerOverride";
+        }
+
         $controller = new $ControllerName($this);
 
         if ($controller->canRun()) {

--- a/alma/controllers/hook/DisplayPaymentHookController.php
+++ b/alma/controllers/hook/DisplayPaymentHookController.php
@@ -38,7 +38,7 @@ use Language;
 use Media;
 use Tools;
 
-final class DisplayPaymentHookController extends FrontendHookController
+class DisplayPaymentHookController extends FrontendHookController
 {
     /**
      * Payment option for Hook DisplayPayment (Prestashop 1.6)

--- a/alma/controllers/hook/DisplayPaymentReturnHookController.php
+++ b/alma/controllers/hook/DisplayPaymentReturnHookController.php
@@ -35,7 +35,7 @@ use Alma\PrestaShop\Hooks\FrontendHookController;
 use Alma\PrestaShop\Utils\Logger;
 use Alma\PrestaShop\Utils\OrderDataTrait;
 
-final class DisplayPaymentReturnHookController extends FrontendHookController
+class DisplayPaymentReturnHookController extends FrontendHookController
 {
     use OrderDataTrait;
 

--- a/alma/controllers/hook/DisplayProductPriceBlockHookController.php
+++ b/alma/controllers/hook/DisplayProductPriceBlockHookController.php
@@ -35,7 +35,7 @@ use Alma\PrestaShop\Utils\SettingsCustomFields;
 use Product;
 use Tools;
 
-final class DisplayProductPriceBlockHookController extends FrontendHookController
+class DisplayProductPriceBlockHookController extends FrontendHookController
 {
     public function canRun()
     {

--- a/alma/controllers/hook/DisplayShoppingCartFooterHookController.php
+++ b/alma/controllers/hook/DisplayShoppingCartFooterHookController.php
@@ -37,7 +37,7 @@ use Alma\PrestaShop\Utils\SettingsCustomFields;
 use Cart;
 use Media;
 
-final class DisplayShoppingCartFooterHookController extends FrontendHookController
+class DisplayShoppingCartFooterHookController extends FrontendHookController
 {
     public function canRun()
     {

--- a/alma/controllers/hook/FrontHeaderHookController.php
+++ b/alma/controllers/hook/FrontHeaderHookController.php
@@ -31,7 +31,7 @@ if (!defined('_PS_VERSION_')) {
 use Alma\PrestaShop\Hooks\FrontendHookController;
 use Alma\PrestaShop\Utils\Settings;
 
-final class FrontHeaderHookController extends FrontendHookController
+class FrontHeaderHookController extends FrontendHookController
 {
     public function run($params)
     {

--- a/alma/controllers/hook/PaymentOptionsHookController.php
+++ b/alma/controllers/hook/PaymentOptionsHookController.php
@@ -39,7 +39,7 @@ use Media;
 use PrestaShop\PrestaShop\Core\Payment\PaymentOption;
 use Tools;
 
-final class PaymentOptionsHookController extends FrontendHookController
+class PaymentOptionsHookController extends FrontendHookController
 {
     /**
      * Payment option for Hook PaymentOption (Prestashop 1.7)


### PR DESCRIPTION
for Alma pay store we needed a way to override some of the hook controller.
unfortunatly hookcontroller are not real prestahop controller, so using the prestashop override mecanism unless.
We added some code in alma.php to allow this mecanism to work with hook controllers.

we also removed the final key word from some class, to allow us to implements them