### PR TITLE
Fix/int 574 if intl class not exist

### DIFF
--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -151,7 +151,7 @@ function getDateFormat($locale, $timestamp)
 {
     try {
         if (!class_exists(IntlDateFormatter::class)) {
-            throw new IntlException('IntlDateFormatter: is not available');
+            throw new Exception('IntlDateFormatter: is not available');
         }
         $formatter = new IntlDateFormatter($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
         if ($formatter === null) {
@@ -159,10 +159,21 @@ function getDateFormat($locale, $timestamp)
         }
 
         return $formatter->format($timestamp);
-    } catch (IntlException $e) {
-        $date = new DateTime();
-        $date->setTimestamp($timestamp);
-
-        return $date->format('d/m/Y');
+    } catch (Exception $e) {
+        return getFrenchDateFormat($timestamp);
     }
+}
+
+/**
+ * fallback for when IntlDateFormatter is not available
+ *
+ * @param string $timestamp
+ * @return string
+ */
+function getFrenchDateFormat($timestamp)
+{
+    $date = new DateTime();
+    $date->setTimestamp($timestamp);
+
+    return $date->format('d/m/Y');
 }

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -154,7 +154,9 @@ function getDateFormat($locale, $timestamp)
             $formatter = new IntlDateFormatter($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
             return $formatter->format($timestamp);
         }
-    } catch (Exception $e) {}
+    } catch (Exception $e) {
+        // We don't need to deal with this Exception because a fallback exists in default return statement
+    }
 
     return getFrenchDateFormat($timestamp);
 }

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -155,7 +155,7 @@ function getDateFormat($locale, $timestamp)
             return $formatter->format($timestamp);
         }
     } catch (Exception $e) {
-        // do what you want or nothing
+        throw new Exception('IntlDateFormatter is not available');
     }
 
     return getFrenchDateFormat($timestamp);

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -150,7 +150,7 @@ function almaFormatPrice($cents, $id_currency = null)
 function getDateFormat($locale, $timestamp)
 {
     try {
-        if(!class_exists(IntlDateFormatter::class)) {
+        if (!class_exists(IntlDateFormatter::class)) {
             throw new IntlException('IntlDateFormatter: is not available');
         }
         $formatter = new IntlDateFormatter($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -151,7 +151,7 @@ function getDateFormat($locale, $timestamp)
 {
     try {
         if (!class_exists(IntlDateFormatter::class)) {
-            throw new Exception('IntlDateFormatter: is not available');
+            return getFrenchDateFormat($timestamp);
         }
         $formatter = new IntlDateFormatter($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
         if ($formatter === null) {

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -154,9 +154,7 @@ function getDateFormat($locale, $timestamp)
             $formatter = new IntlDateFormatter($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
             return $formatter->format($timestamp);
         }
-    } catch (Exception $e) {
-        throw new Exception('IntlDateFormatter is not available');
-    }
+    } catch (Exception $e) {}
 
     return getFrenchDateFormat($timestamp);
 }

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -160,7 +160,8 @@ function getDateFormat($locale, $timestamp)
 
         return $formatter->format($timestamp);
     } catch (IntlException $e) {
-        $date = new DateTime($timestamp);
+        $date = new DateTime();
+        $date->setTimestamp($timestamp);
 
         return $date->format('d/m/Y');
     }

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -150,6 +150,9 @@ function almaFormatPrice($cents, $id_currency = null)
 function getDateFormat($locale, $timestamp)
 {
     try {
+        if(!class_exists(IntlDateFormatter::class)) {
+            throw new IntlException('IntlDateFormatter: is not available');
+        }
         $formatter = new IntlDateFormatter($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
         if ($formatter === null) {
             throw new IntlException(intl_get_error_message());
@@ -159,6 +162,6 @@ function getDateFormat($locale, $timestamp)
     } catch (IntlException $e) {
         $date = new DateTime($timestamp);
 
-        return $date->format('m/d/Y');
+        return $date->format('d/m/Y');
     }
 }

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -168,6 +168,7 @@ function getDateFormat($locale, $timestamp)
  * fallback for when IntlDateFormatter is not available
  *
  * @param string $timestamp
+ *
  * @return string
  */
 function getFrenchDateFormat($timestamp)

--- a/alma/lib/Utils/functions.php
+++ b/alma/lib/Utils/functions.php
@@ -150,18 +150,15 @@ function almaFormatPrice($cents, $id_currency = null)
 function getDateFormat($locale, $timestamp)
 {
     try {
-        if (!class_exists(IntlDateFormatter::class)) {
-            return getFrenchDateFormat($timestamp);
+        if (class_exists(IntlDateFormatter::class)) {
+            $formatter = new IntlDateFormatter($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
+            return $formatter->format($timestamp);
         }
-        $formatter = new IntlDateFormatter($locale, IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
-        if ($formatter === null) {
-            throw new IntlException(intl_get_error_message());
-        }
-
-        return $formatter->format($timestamp);
     } catch (Exception $e) {
-        return getFrenchDateFormat($timestamp);
+        // do what you want or nothing
     }
+
+    return getFrenchDateFormat($timestamp);
 }
 
 /**


### PR DESCRIPTION
For some merchant, the intl module is not activated, (which isn't not compliant with prestashop recommandations).
We have to provide something for them