### PR TITLE
Fix/int 1524 optimisation call api widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.11.0
+
+- Unification of the widget hook per product page and for Prestashop 1.6
+
 ## v2.10.0
 
 - Optimise your performance with insights on share of checkout

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -31,7 +31,7 @@ require_once _PS_MODULE_DIR_ . 'alma/autoloader.php';
 
 class Alma extends PaymentModule
 {
-    const VERSION = '2.10.0';
+    const VERSION = '2.11.0';
 
     public $_path;
     public $local_path;
@@ -46,7 +46,7 @@ class Alma extends PaymentModule
     {
         $this->name = 'alma';
         $this->tab = 'payments_gateways';
-        $this->version = '2.10.0';
+        $this->version = '2.11.0';
         $this->author = 'Alma';
         $this->need_instance = false;
         $this->bootstrap = true;

--- a/alma/controllers/hook/DisplayProductPriceBlockHookController.php
+++ b/alma/controllers/hook/DisplayProductPriceBlockHookController.php
@@ -109,6 +109,10 @@ class DisplayProductPriceBlockHookController extends FrontendHookController
             $refreshPrice = $productAttributeId === null;
         }
 
+        if (Tools::getValue('id_product') != $productId) {
+            return null;
+        }
+
         $psVersion = 'ps15';
         if (version_compare(_PS_VERSION_, '1.7', '>=')) {
             $psVersion = 'ps17';

--- a/alma/controllers/hook/DisplayProductPriceBlockHookController.php
+++ b/alma/controllers/hook/DisplayProductPriceBlockHookController.php
@@ -51,7 +51,7 @@ class DisplayProductPriceBlockHookController extends FrontendHookController
             if (version_compare(_PS_VERSION_, '1.7', '>')) {
                 $skip = $params['type'] === 'price' || (!in_array($params['type'], ['price', 'after_price']));
             } elseif (version_compare(_PS_VERSION_, '1.6', '>')) {
-                $skip = $params['type'] !== 'weight';
+                $skip = $params['type'] !== 'after_price';
             } else {
                 $skip = !in_array($params['type'], ['price', 'after_price']);
             }


### PR DESCRIPTION
Optimisation Call API Eligibility for Widget
If the ID Product is different of ID Product page displayed, we don't call the widget.
And we change the type of Hook for Prestashop 1.6 from weight to after_price.
It the same of other Prestashop, it's more logical and it's fixe the optimisation for PS 1.6