### PR TITLE
Feat/mpp 89 basket items in payment only for credit

### DIFF
--- a/alma/lib/Model/CartData.php
+++ b/alma/lib/Model/CartData.php
@@ -115,7 +115,7 @@ class CartData
             if (isset($productRow['gift'])) {
                 $isGift = (bool) $productRow['gift'];
             } else {
-                $isGift = isset($productRow['is_gift']) ? (bool) $productRow['is_gift'] : null;
+                $isGift = isset($productRow['is_gift']) && (bool)$productRow['is_gift'];
             }
 
             $pictureUrl = $productHelper->getImageLink($productRow);

--- a/alma/lib/Model/CartData.php
+++ b/alma/lib/Model/CartData.php
@@ -104,9 +104,9 @@ class CartData
             $product = new Product(null, false, $cart->id_lang);
             $product->hydrate($productRow);
             $pid = (int) $product->id;
-            $manufacturer_name = isset($productRow['manufacturer_name']) ? $productRow['manufacturer_name'] : null;
-            if (!$manufacturer_name && isset($productsDetails[$pid])) {
-                $manufacturer_name = $productsDetails[$pid]['manufacturer_name'];
+            $manufacturerName = isset($productRow['manufacturer_name']) ? $productRow['manufacturer_name'] : null;
+            if (!$manufacturerName && isset($productsDetails[$pid])) {
+                $manufacturerName = $productsDetails[$pid]['manufacturer_name'];
             }
 
             $unitPrice = self::includeTaxes($cart) ? (float) $productRow['price_wt'] : (float) $productRow['price'];
@@ -128,7 +128,7 @@ class CartData
 
             $data = [
                 'sku' => $productRow['reference'],
-                'vendor' => $manufacturer_name,
+                'vendor' => $manufacturerName,
                 'title' => $productRow['name'],
                 'variant_title' => null,
                 'quantity' => (int) $productRow['cart_quantity'],

--- a/alma/lib/Model/CartHelper.php
+++ b/alma/lib/Model/CartHelper.php
@@ -61,6 +61,7 @@ class CartHelper
         $ordersData = [];
         $orders = $this->getOrdersByCustomer($idCustomer, 10);
         $orderStateHelper = new OrderStateHelper($this->context);
+        $productHelper = new ProductHelper();
 
         $carrier = new CarrierHelper($this->context);
         foreach ($orders as $order) {
@@ -75,7 +76,7 @@ class CartHelper
 
             $cartItems = [];
             try {
-                $cartItems = CartData::getCartItems($cart);
+                $cartItems = CartData::getCartItems($cart, $productHelper);
             } catch (PrestaShopDatabaseException $e) {
                 $msg = '[Alma] cart items for previous cart ordered no found';
                 Logger::instance()->warning($msg);

--- a/alma/lib/Model/CartHelper.php
+++ b/alma/lib/Model/CartHelper.php
@@ -24,6 +24,7 @@
 
 namespace Alma\PrestaShop\Model;
 
+use Alma\PrestaShop\Repositories\ProductRepository;
 use Alma\PrestaShop\Utils\Logger;
 use Cart;
 use Context;
@@ -62,6 +63,7 @@ class CartHelper
         $orders = $this->getOrdersByCustomer($idCustomer, 10);
         $orderStateHelper = new OrderStateHelper($this->context);
         $productHelper = new ProductHelper();
+        $productRepository = new ProductRepository();
 
         $carrier = new CarrierHelper($this->context);
         foreach ($orders as $order) {
@@ -76,7 +78,7 @@ class CartHelper
 
             $cartItems = [];
             try {
-                $cartItems = CartData::getCartItems($cart, $productHelper);
+                $cartItems = CartData::getCartItems($cart, $productHelper, $productRepository);
             } catch (PrestaShopDatabaseException $e) {
                 $msg = '[Alma] cart items for previous cart ordered no found';
                 Logger::instance()->warning($msg);

--- a/alma/lib/Model/PaymentData.php
+++ b/alma/lib/Model/PaymentData.php
@@ -29,6 +29,7 @@ if (!defined('_PS_VERSION_')) {
 }
 
 use Address;
+use Alma\PrestaShop\Repositories\ProductRepository;
 use Alma\PrestaShop\Utils\Logger;
 use Alma\PrestaShop\Utils\Settings;
 use Alma\PrestaShop\Utils\SettingsCustomFields;
@@ -236,6 +237,7 @@ class PaymentData
         $carrierHelper = new CarrierHelper($context);
         $cartHelper = new CartHelper($context);
         $productHelper = new ProductHelper();
+        $productRepository = new ProductRepository();
 
         return [
             'new_customer' => self::isNewCustomer($customer->id),
@@ -246,7 +248,7 @@ class PaymentData
                 'created' => strtotime($cart->date_add),
                 'payment_method' => PaymentData::PAYMENT_METHOD,
                 'shipping_method' => $carrierHelper->getParentCarrierNameById($cart->id_carrier),
-                'items' => CartData::getCartItems($cart, $productHelper),
+                'items' => CartData::getCartItems($cart, $productHelper, $productRepository),
             ],
             'previous_orders' => [
                 $cartHelper->previousCartOrdered($customer->id),

--- a/alma/lib/Model/PaymentData.php
+++ b/alma/lib/Model/PaymentData.php
@@ -189,7 +189,6 @@ class PaymentData
                     'state_province' => $idStateShipping > 0 ? State::getNameById((int) $idStateShipping) : '',
                 ],
                 'shipping_info' => ShippingData::shippingInfo($cart),
-                'cart' => CartData::cartInfo($cart),
                 'billing_address' => [
                     'line1' => $billingAddress->address1,
                     'postal_code' => $billingAddress->postcode,
@@ -215,6 +214,9 @@ class PaymentData
         if (Settings::isDeferredTriggerLimitDays($feePlans)) {
             $dataPayment['payment']['deferred'] = 'trigger';
             $dataPayment['payment']['deferred_description'] = SettingsCustomFields::getDescriptionPaymentTriggerByLang($context->language->id);
+        }
+        if ($feePlans['installmentsCount'] > 4) {
+            $dataPayment['payment']['cart'] = CartData::cartInfo($cart);
         }
 
         return $dataPayment;

--- a/alma/lib/Model/PaymentData.php
+++ b/alma/lib/Model/PaymentData.php
@@ -233,6 +233,7 @@ class PaymentData
     {
         $carrierHelper = new CarrierHelper($context);
         $cartHelper = new CartHelper($context);
+        $productHelper = new ProductHelper();
 
         return [
             'new_customer' => self::isNewCustomer($customer->id),
@@ -241,9 +242,9 @@ class PaymentData
             'current_order' => [
                 'purchase_amount' => almaPriceToCents($purchaseAmount),
                 'created' => strtotime($cart->date_add),
-                'payment_method' => self::PAYMENT_METHOD,
+                'payment_method' => PaymentData::PAYMENT_METHOD,
                 'shipping_method' => $carrierHelper->getParentCarrierNameById($cart->id_carrier),
-                'items' => CartData::getCartItems($cart),
+                'items' => CartData::getCartItems($cart, $productHelper),
             ],
             'previous_orders' => [
                 $cartHelper->previousCartOrdered($customer->id),

--- a/alma/lib/Model/ProductHelper.php
+++ b/alma/lib/Model/ProductHelper.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * 2018-2023 Alma SAS
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Model;
+
+use Cart;
+use Db;
+use DbQuery;
+use PrestaShopDatabaseException;
+use PrestaShopException;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Class ProductHelper.
+ *
+ * Use for Product
+ */
+class ProductHelper
+{
+    /**
+     * @param Cart $cart
+     * @param array $products
+     *
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    public function getProductsCombinations($cart, $products)
+    {
+        $sql = new DbQuery();
+        $sql->select('CONCAT(p.`id_product`, "-", pa.`id_product_attribute`) as `unique_id`');
+
+        $combinationName = new DbQuery();
+        $combinationName->select('GROUP_CONCAT(DISTINCT CONCAT(agl.`name`, " - ", al.`name`) SEPARATOR ", ")');
+        $combinationName->from('product_attribute', 'pa2');
+        $combinationName->innerJoin(
+            'product_attribute_combination',
+            'pac',
+            'pac.`id_product_attribute` = pa2.`id_product_attribute`'
+        );
+        $combinationName->innerJoin('attribute', 'a', 'a.`id_attribute` = pac.`id_attribute`');
+        $combinationName->innerJoin(
+            'attribute_lang',
+            'al',
+            'a.id_attribute = al.id_attribute AND al.`id_lang` = ' . $cart->id_lang
+        );
+        $combinationName->innerJoin('attribute_group', 'ag', 'ag.`id_attribute_group` = a.`id_attribute_group`');
+        $combinationName->innerJoin(
+            'attribute_group_lang',
+            'agl',
+            'ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . $cart->id_lang
+        );
+        $combinationName->where(
+            'pa2.`id_product` = p.`id_product` AND pa2.`id_product_attribute` = pa.`id_product_attribute`'
+        );
+
+        /* @noinspection PhpUnhandledExceptionInspection */
+        $sql->select("({$combinationName->build()}) as combination_name");
+
+        $sql->from('product', 'p');
+        $sql->innerJoin('product_attribute', 'pa', 'pa.`id_product` = p.`id_product`');
+
+        // DbQuery::where joins all where clauses with `) AND (` so for ORs we need a fully built where condition
+        $where = '';
+        $op = '';
+        foreach ($products as $productRow) {
+            if (!isset($productRow['id_product_attribute']) || !(int) $productRow['id_product_attribute']) {
+                continue;
+            }
+
+            $where .= "{$op}(p.`id_product` = {$productRow['id_product']}";
+            $where .= " AND pa.`id_product_attribute` = {$productRow['id_product_attribute']})";
+            $op = ' OR ';
+        }
+        $sql->where($where);
+
+        $db = Db::getInstance();
+        $combinationsNames = [];
+
+        try {
+            $results = $db->query($sql);
+        } catch (PrestaShopDatabaseException $e) {
+            return $combinationsNames;
+        }
+
+        while ($result = $db->nextRow($results)) {
+            $combinationsNames[$result['unique_id']] = $result['combination_name'];
+        }
+
+        return $combinationsNames;
+    }
+}

--- a/alma/lib/Model/ProductHelper.php
+++ b/alma/lib/Model/ProductHelper.php
@@ -168,6 +168,13 @@ class ProductHelper
         );
     }
 
+    /**
+     * @param $product
+     * @param $productRow
+     * @param $cart
+     * @return string
+     * @throws PrestaShopException
+     */
     public function getProductLink($product, $productRow, $cart)
     {
         $link = Context::getContext()->link;
@@ -186,12 +193,16 @@ class ProductHelper
         );
     }
 
+    /**
+     * @param $name
+     * @return string
+     */
     private static function getFormattedImageTypeName($name)
     {
         if (version_compare(_PS_VERSION_, '1.7', '>=')) {
             return ImageType::getFormattedName($name);
-        } else {
-            return ImageType::getFormatedName($name);
         }
+
+        return ImageType::getFormatedName($name);
     }
 }

--- a/alma/lib/Repositories/ProductRepository.php
+++ b/alma/lib/Repositories/ProductRepository.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * 2018-2023 Alma SAS
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Repositories;
+
+use Cart;
+use Db;
+use DbQuery;
+use PrestaShopDatabaseException;
+use PrestaShopException;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Class ProductRepository.
+ *
+ * Use for Product
+ */
+class ProductRepository
+{
+    /**
+     * Get the product combinations
+     *
+     * @param Cart $cart
+     * @param array $products
+     *
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    public function getProductsCombinations($cart, $products)
+    {
+        $sql = new DbQuery();
+        $sql->select('CONCAT(p.`id_product`, "-", pa.`id_product_attribute`) as `unique_id`');
+
+        $combinationName = new DbQuery();
+        $combinationName->select('GROUP_CONCAT(DISTINCT CONCAT(agl.`name`, " - ", al.`name`) SEPARATOR ", ")');
+        $combinationName->from('product_attribute', 'pa2');
+        $combinationName->innerJoin(
+            'product_attribute_combination',
+            'pac',
+            'pac.`id_product_attribute` = pa2.`id_product_attribute`'
+        );
+        $combinationName->innerJoin('attribute', 'a', 'a.`id_attribute` = pac.`id_attribute`');
+        $combinationName->innerJoin(
+            'attribute_lang',
+            'al',
+            'a.id_attribute = al.id_attribute AND al.`id_lang` = ' . $cart->id_lang
+        );
+        $combinationName->innerJoin('attribute_group', 'ag', 'ag.`id_attribute_group` = a.`id_attribute_group`');
+        $combinationName->innerJoin(
+            'attribute_group_lang',
+            'agl',
+            'ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . $cart->id_lang
+        );
+        $combinationName->where(
+            'pa2.`id_product` = p.`id_product` AND pa2.`id_product_attribute` = pa.`id_product_attribute`'
+        );
+
+        /* @noinspection PhpUnhandledExceptionInspection */
+        $sql->select("({$combinationName->build()}) as combination_name");
+
+        $sql->from('product', 'p');
+        $sql->innerJoin('product_attribute', 'pa', 'pa.`id_product` = p.`id_product`');
+
+        // DbQuery::where joins all where clauses with `) AND (` so for ORs we need a fully built where condition
+        $where = '';
+        $op = '';
+        foreach ($products as $productRow) {
+            if (!isset($productRow['id_product_attribute']) || !(int) $productRow['id_product_attribute']) {
+                continue;
+            }
+
+            $where .= "{$op}(p.`id_product` = {$productRow['id_product']}";
+            $where .= " AND pa.`id_product_attribute` = {$productRow['id_product_attribute']})";
+            $op = ' OR ';
+        }
+        $sql->where($where);
+
+        $db = Db::getInstance();
+        $combinationsNames = [];
+
+        try {
+            $results = $db->query($sql);
+        } catch (PrestaShopDatabaseException $e) {
+            return $combinationsNames;
+        }
+
+        while ($result = $db->nextRow($results)) {
+            $combinationsNames[$result['unique_id']] = $result['combination_name'];
+        }
+
+        return $combinationsNames;
+    }
+
+    /**
+     * @param array $products
+     * @return array
+     */
+    public function getProductsDetails($products)
+    {
+        $sql = new DbQuery();
+        $sql->select('p.`id_product`, p.`is_virtual`, m.`name` as manufacturer_name');
+        $sql->from('product', 'p');
+        $sql->innerJoin('manufacturer', 'm', 'm.`id_manufacturer` = p.`id_manufacturer`');
+
+        $in = [];
+        foreach ($products as $productRow) {
+            $in[] = $productRow['id_product'];
+        }
+
+        $in = implode(', ', $in);
+        $sql->where("p.`id_product` IN ({$in})");
+
+        $db = Db::getInstance();
+        $productsDetails = [];
+
+        try {
+            $results = $db->query($sql);
+        } catch (PrestaShopDatabaseException $e) {
+            return $productsDetails;
+        }
+
+        if ($results !== false) {
+            while ($result = $db->nextRow($results)) {
+                $productsDetails[(int) $result['id_product']] = $result;
+            }
+        }
+
+        return $productsDetails;
+    }
+
+}

--- a/alma/tests/unit/lib/Model/CartDataTest.php
+++ b/alma/tests/unit/lib/Model/CartDataTest.php
@@ -75,32 +75,48 @@ class CartDataTest extends TestCase
             'Two products in cart' => [
                 'items' => [
                     $this->getProduct(1, 1),
-                    $this->getProduct(3, 2),
+                    $this->getProduct(3, 2)
                 ],
                 'result' => [
                     $this->expectedProduct(1, 1),
                     $this->expectedProduct(3, 2)
                 ]
             ],
-            'Three products in cart' => [
+            'Virtual products in cart' => [
                 'items' => [
-                    $this->getProduct(1, 1),
-                    $this->getProduct(3, 2),
-                    $this->getProduct(2, 4)
+                    $this->getProduct(4, 8, false, true)
                 ],
                 'result' => [
-                    $this->expectedProduct(1, 1),
-                    $this->expectedProduct(3, 2),
-                    $this->expectedProduct(2, 4)
+                    $this->expectedProduct(4, 8)
                 ]
             ],
+            'Gift products in cart' => [
+                'items' => [
+                    $this->getProduct(2, 4, true, false)
+                ],
+                'result' => [
+                    $this->expectedProduct(2, 4, true)
+                ]
+            ],
+            'Virtual products in cart and Simple product' => [
+                'items' => [
+                    $this->getProduct(4, 8, false, true),
+                    $this->getProduct(1, 1),
+
+                ],
+                'result' => [
+                    $this->expectedProduct(4, 8),
+                    $this->expectedProduct(1, 1),
+
+                ]
+            ]
         ];
     }
 
     /**
      * @return array
      */
-    public function getProduct($id, $idProductAttribute)
+    public function getProduct($id, $idProductAttribute, $isGift = false, $isVirtual = false)
     {
         $product = $this->createMock(Product::class);
         $product->id = $id;
@@ -108,11 +124,15 @@ class CartDataTest extends TestCase
         $product->reference = 'test_' . $id;
         $product->name = 'Product ' . $id;
         $product->category = 'category_test';
-        $product->is_gift = false;
+        if ($isGift) {
+            $product->is_gift = true;
+        }
         $product->price_wt = 280.000000;
         $product->price = 280.000000;
         $product->total_wt = 280.000000;
-        $product->is_virtual = false;
+        if ($isVirtual) {
+            $product->is_virtual = $isVirtual;
+        }
         $product->cart_quantity = 1;
         $product->id_product_attribute = $idProductAttribute;
 
@@ -122,7 +142,7 @@ class CartDataTest extends TestCase
     /**
      * @return array
      */
-    public function expectedProduct($id, $idProductAttribute)
+    public function expectedProduct($id, $idProductAttribute, $isGift = false)
     {
         $vendor = $this->getVendor();
         $combination = $this->getCombinations();
@@ -136,11 +156,11 @@ class CartDataTest extends TestCase
             "quantity" => 1,
             "unit_price" => 28000,
             "line_price" => 28000,
-            "is_gift" => false,
+            "is_gift" => $isGift,
             "categories" => ["category_test"],
             "url" => "http://prestashop-a-1-7-8-7.local.test/1-1-product_test.html#/1-size-s/8-color-white",
             "picture_url" => "http://prestashop-a-1-7-8-7.local.test/1-large_default/product_test.jpg",
-            "requires_shipping" => true,
+            "requires_shipping" => !$vendor[$id]['is_virtual'],
             "taxes_included" => true
         ];
     }
@@ -152,19 +172,24 @@ class CartDataTest extends TestCase
     {
         return [
             "1" => [
-                "id_product" => "1",
-                "is_virtual" => "0",
+                "id_product" => 1,
+                "is_virtual" => false,
                 "manufacturer_name" => "Manufacturer Test"
             ],
             "2" => [
-                "id_product" => "2",
-                "is_virtual" => "0",
-                "manufacturer_name" => "Toto Design"
+                "id_product" => 2,
+                "is_virtual" => false,
+                "manufacturer_name" => "Gift Product"
             ],
             "3" => [
-                "id_product" => "3",
-                "is_virtual" => "0",
+                "id_product" => 3,
+                "is_virtual" => false,
                 "manufacturer_name" => "Studio Design"
+            ],
+            "4" => [
+                "id_product" => 4,
+                "is_virtual" => true,
+                "manufacturer_name" => "Virtual Product"
             ]
         ];
     }
@@ -177,7 +202,8 @@ class CartDataTest extends TestCase
         return [
             "1-1" => "Color - White, Size - S",
             "2-4" => "Color - White, Size - L",
-            "3-2" => "Color - Black, Size - S"
+            "3-2" => "Color - Black, Size - S",
+            "4-8" => "Storage - 1Go"
         ];
     }
 }

--- a/alma/tests/unit/lib/Model/CartDataTest.php
+++ b/alma/tests/unit/lib/Model/CartDataTest.php
@@ -36,11 +36,21 @@ class CartDataTest extends TestCase
         $expectedItems = [];
         $cart = $this->createMock(Cart::class);
         $product = $this->createMock(Product::class);
-        $product->id = 1;
+        $product->id_product = 1;
         $product->name = 'Product Test';
+        $product->price_wt = 280.000000;
+        $product->price = 280.000000;
+        $product->total_wt = 280.000000;
+        $product->id_image = 1;
+        $product->is_virtual = false;
+        $product->cart_quantity = 1;
+        $product->id_product_attribute = 1;
 
-        $summaryDetailsMock = ['products' => [$product], 'gift_products'=>[]];
+        $combinationsNamesMock = ["1-1" => "Color - White, Size - S"];
+
+        $summaryDetailsMock = ['products' => [(array) $product], 'gift_products'=>[]];
         $cart->method('getSummaryDetails')->willReturn($summaryDetailsMock);
+        $cart->method('getProductsCombinations')->willReturn($combinationsNamesMock);
         $returnItems = CartData::getCartItems($cart);
         $this->assertEquals($expectedItems, $returnItems);
     }

--- a/alma/tests/unit/lib/Model/CartDataTest.php
+++ b/alma/tests/unit/lib/Model/CartDataTest.php
@@ -24,52 +24,24 @@
 
 namespace Alma\PrestaShop\Tests\Unit\Lib\Model;
 
-use Address;
-use Alma\PrestaShop\Model\PaymentData;
-use Context;
-use Customer;
-use Language;
-use PHPUnit\Framework\TestCase;
+use Alma\PrestaShop\Model\CartData;
 use Cart;
-use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CartProduct;
+use PHPUnit\Framework\TestCase;
 use Product;
 
-class PaymentDataTest extends TestCase
+class CartDataTest extends TestCase
 {
-    /**
-     * @return void
-     * @throws \Exception
-     */
-    public function testdataFromCart()
+    public function testGetCartItems()
     {
-        $this->markTestSkipped(
-            'Need refacto'
-        );
-        $expectedDataPayment = [];
-        $address = $this->createMock(Address::class);
-        $address->id = 1;
-        $address->id_customer = 1;
-        $address->address1 = '1 rue de Rivoli';
+        $expectedItems = [];
+        $cart = $this->createMock(Cart::class);
         $product = $this->createMock(Product::class);
         $product->id = 1;
         $product->name = 'Product Test';
-        $summaryDetailsMock = ['products' => [], 'gift_products'=>[]];
-        $cart = $this->createMock(Cart::class);
-        $cart->method('getSummaryDetails')->willReturn($summaryDetailsMock);
-        $cart->id_customer = 1;
-        $cart->id_address_delivery = 1;
-        $cart->id_address_invoice = 1;
-        $context = $this->createMock(Context::class);
-        $language = $this->createMock(Language::class);
-        $language->iso_code = 'fr';
-        $context->language = $language;
-        $customer = $this->createMock(Customer::class);
-        $customer->firstname = 'Benjamin';
-        $customer->id = 1;
-        $context->customer = $customer;
-        $feePlans = [];
-        $returnData = PaymentData::dataFromCart($cart, $context, $feePlans,true);
 
-        $this->assertEquals($expectedDataPayment, $returnData);
+        $summaryDetailsMock = ['products' => [$product], 'gift_products'=>[]];
+        $cart->method('getSummaryDetails')->willReturn($summaryDetailsMock);
+        $returnItems = CartData::getCartItems($cart);
+        $this->assertEquals($expectedItems, $returnItems);
     }
 }

--- a/alma/tests/unit/lib/Model/CartDataTest.php
+++ b/alma/tests/unit/lib/Model/CartDataTest.php
@@ -26,6 +26,7 @@ namespace Alma\PrestaShop\Tests\Unit\Lib\Model;
 
 use Alma\PrestaShop\Model\CartData;
 use Alma\PrestaShop\Model\ProductHelper;
+use Alma\PrestaShop\Repositories\ProductRepository;
 use Cart;
 use PHPUnit\Framework\TestCase;
 use Product;
@@ -41,15 +42,18 @@ class CartDataTest extends TestCase
     public function testGetCartItems($items, $expected)
     {
         $cart = $this->createMock(Cart::class);
+        $productRepository = $this->createMock(ProductRepository::class);
+        $productRepository->method('getProductsCombinations')->willReturn($this->getCombinations());
+        $productRepository->method('getProductsDetails')->willReturn($this->getVendor());
+
         $productHelper = $this->createMock(ProductHelper::class);
-        $productHelper->method('getProductsCombinations')->willReturn($this->getCombinations());
         $productHelper->method('getImageLink')->willReturn('http://prestashop-a-1-7-8-7.local.test/1-large_default/product_test.jpg');
         $productHelper->method('getProductLink')->willReturn('http://prestashop-a-1-7-8-7.local.test/1-1-product_test.html#/1-size-s/8-color-white');
-        $productHelper->method('getProductsDetails')->willReturn($this->getVendor());
+
 
         $summaryDetailsMock = ['products' => $items, 'gift_products'=>[]];
         $cart->method('getSummaryDetails')->willReturn($summaryDetailsMock);
-        $returnItems = CartData::getCartItems($cart, $productHelper);
+        $returnItems = CartData::getCartItems($cart, $productHelper, $productRepository);
         $this->assertEquals($expected, $returnItems);
     }
 

--- a/alma/tests/unit/lib/Model/CartDataTest.php
+++ b/alma/tests/unit/lib/Model/CartDataTest.php
@@ -36,6 +36,9 @@ class CartDataTest extends TestCase
         $expectedItems = [];
         $cart = $this->createMock(Cart::class);
         $product = $this->createMock(Product::class);
+        $productHelper = $this->createMock(ProductHelper::class);
+        $productHelper->method('getProductsCombinations')->willReturn( ["1-1" => "Color - White, Size - S"]);
+        $product->id = 1;
         $product->id_product = 1;
         $product->name = 'Product Test';
         $product->price_wt = 280.000000;
@@ -46,11 +49,8 @@ class CartDataTest extends TestCase
         $product->cart_quantity = 1;
         $product->id_product_attribute = 1;
 
-        $combinationsNamesMock = ["1-1" => "Color - White, Size - S"];
-
         $summaryDetailsMock = ['products' => [(array) $product], 'gift_products'=>[]];
         $cart->method('getSummaryDetails')->willReturn($summaryDetailsMock);
-        $cart->method('getProductsCombinations')->willReturn($combinationsNamesMock);
         $returnItems = CartData::getCartItems($cart);
         $this->assertEquals($expectedItems, $returnItems);
     }

--- a/alma/tests/unit/lib/Model/CartDataTest.php
+++ b/alma/tests/unit/lib/Model/CartDataTest.php
@@ -25,33 +25,159 @@
 namespace Alma\PrestaShop\Tests\Unit\Lib\Model;
 
 use Alma\PrestaShop\Model\CartData;
+use Alma\PrestaShop\Model\ProductHelper;
 use Cart;
 use PHPUnit\Framework\TestCase;
 use Product;
 
 class CartDataTest extends TestCase
 {
-    public function testGetCartItems()
+    /**
+     * @dataProvider productsDataProvider
+     * @return void
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    public function testGetCartItems($items, $expected)
     {
-        $expectedItems = [];
         $cart = $this->createMock(Cart::class);
-        $product = $this->createMock(Product::class);
         $productHelper = $this->createMock(ProductHelper::class);
-        $productHelper->method('getProductsCombinations')->willReturn( ["1-1" => "Color - White, Size - S"]);
-        $product->id = 1;
-        $product->id_product = 1;
-        $product->name = 'Product Test';
+        $productHelper->method('getProductsCombinations')->willReturn($this->getCombinations());
+        $productHelper->method('getImageLink')->willReturn('http://prestashop-a-1-7-8-7.local.test/1-large_default/product_test.jpg');
+        $productHelper->method('getProductLink')->willReturn('http://prestashop-a-1-7-8-7.local.test/1-1-product_test.html#/1-size-s/8-color-white');
+        $productHelper->method('getProductsDetails')->willReturn($this->getVendor());
+
+        $summaryDetailsMock = ['products' => $items, 'gift_products'=>[]];
+        $cart->method('getSummaryDetails')->willReturn($summaryDetailsMock);
+        $returnItems = CartData::getCartItems($cart, $productHelper);
+        $this->assertEquals($expected, $returnItems);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function productsDataProvider()
+    {
+
+        return [
+            'Zero product in cart' => [
+                'items' => [],
+                'result' => []
+            ],
+            'One product in cart' => [
+                'items' => [
+                    $this->getProduct(1, 1),
+                ],
+                'result' => [
+                    $this->expectedProduct(1, 1),
+                ]
+            ],
+            'Two products in cart' => [
+                'items' => [
+                    $this->getProduct(1, 1),
+                    $this->getProduct(3, 2),
+                ],
+                'result' => [
+                    $this->expectedProduct(1, 1),
+                    $this->expectedProduct(3, 2)
+                ]
+            ],
+            'Three products in cart' => [
+                'items' => [
+                    $this->getProduct(1, 1),
+                    $this->getProduct(3, 2),
+                    $this->getProduct(2, 4)
+                ],
+                'result' => [
+                    $this->expectedProduct(1, 1),
+                    $this->expectedProduct(3, 2),
+                    $this->expectedProduct(2, 4)
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getProduct($id, $idProductAttribute)
+    {
+        $product = $this->createMock(Product::class);
+        $product->id = $id;
+        $product->id_product = $id;
+        $product->reference = 'test_' . $id;
+        $product->name = 'Product ' . $id;
+        $product->category = 'category_test';
+        $product->is_gift = false;
         $product->price_wt = 280.000000;
         $product->price = 280.000000;
         $product->total_wt = 280.000000;
-        $product->id_image = 1;
         $product->is_virtual = false;
         $product->cart_quantity = 1;
-        $product->id_product_attribute = 1;
+        $product->id_product_attribute = $idProductAttribute;
 
-        $summaryDetailsMock = ['products' => [(array) $product], 'gift_products'=>[]];
-        $cart->method('getSummaryDetails')->willReturn($summaryDetailsMock);
-        $returnItems = CartData::getCartItems($cart);
-        $this->assertEquals($expectedItems, $returnItems);
+        return (array) $product;
+    }
+
+    /**
+     * @return array
+     */
+    public function expectedProduct($id, $idProductAttribute)
+    {
+        $vendor = $this->getVendor();
+        $combination = $this->getCombinations();
+        $keyCombination = $id . "-" . $idProductAttribute;
+
+        return [
+            "sku" => "test_" . $id,
+            "vendor" => $vendor[$id]["manufacturer_name"],
+            "title" => "Product " . $id,
+            "variant_title" => $combination[$keyCombination],
+            "quantity" => 1,
+            "unit_price" => 28000,
+            "line_price" => 28000,
+            "is_gift" => false,
+            "categories" => ["category_test"],
+            "url" => "http://prestashop-a-1-7-8-7.local.test/1-1-product_test.html#/1-size-s/8-color-white",
+            "picture_url" => "http://prestashop-a-1-7-8-7.local.test/1-large_default/product_test.jpg",
+            "requires_shipping" => true,
+            "taxes_included" => true
+        ];
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getVendor()
+    {
+        return [
+            "1" => [
+                "id_product" => "1",
+                "is_virtual" => "0",
+                "manufacturer_name" => "Manufacturer Test"
+            ],
+            "2" => [
+                "id_product" => "2",
+                "is_virtual" => "0",
+                "manufacturer_name" => "Toto Design"
+            ],
+            "3" => [
+                "id_product" => "3",
+                "is_virtual" => "0",
+                "manufacturer_name" => "Studio Design"
+            ]
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCombinations()
+    {
+        return [
+            "1-1" => "Color - White, Size - S",
+            "2-4" => "Color - White, Size - L",
+            "3-2" => "Color - Black, Size - S"
+        ];
     }
 }

--- a/alma/tests/unit/lib/Model/PaymentDataTest.php
+++ b/alma/tests/unit/lib/Model/PaymentDataTest.php
@@ -68,7 +68,7 @@ class PaymentDataTest extends TestCase
         $customer->id = 1;
         $context->customer = $customer;
         $feePlans = [];
-        $returnData = PaymentData::dataFromCart($cart, $context, $feePlans,true);
+        $returnData = PaymentData::dataFromCart($cart, $context, $feePlans, true);
 
         $this->assertEquals($expectedDataPayment, $returnData);
     }

--- a/alma/tests/unit/lib/Model/PaymentDataTest.php
+++ b/alma/tests/unit/lib/Model/PaymentDataTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * 2018-2023 Alma SAS
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Lib\Model;
+
+use Address;
+use Alma\PrestaShop\Model\PaymentData;
+use Context;
+use Customer;
+use Language;
+use PHPUnit\Framework\TestCase;
+use Cart;
+use Product;
+
+class PaymentDataTest extends TestCase
+{
+    public function testdataFromCart()
+    {
+        $expectedDataPayment = [];
+        $product = $this->createMock(Product::class);
+        $product->id = 1;
+        $cart = $this->createMock(Cart::class);
+        $cart->id_customer = 1;
+        $cart->id_address_delivery = 1;
+        $cart->id_address_invoice = 1;
+        //$cart->setProductCustomizedDatas();
+        var_dump($cart);
+        $context = $this->createMock(Context::class);
+        $language = $this->createMock(Language::class);
+        $language->iso_code = 'fr';
+        $context->language = $language;
+        $customer = $this->createMock(Customer::class);
+        $customer->firstname = 'Benjamin';
+        $context->customer = $customer;
+        $address = $this->createMock(Address::class);
+        $address->id = 1;
+        $address->id_customer = 1;
+        $address->address1 = "1 rue de Rivoli";
+        $feePlans = [];
+        $returnData = PaymentData::dataFromCart($cart, $context, $feePlans,true);
+
+        $this->assertEquals($expectedDataPayment, $returnData);
+    }
+}

--- a/alma/tests/unit/lib/Model/PaymentDataTest.php
+++ b/alma/tests/unit/lib/Model/PaymentDataTest.php
@@ -31,6 +31,7 @@ use Customer;
 use Language;
 use PHPUnit\Framework\TestCase;
 use Cart;
+use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CartProduct;
 use Product;
 
 class PaymentDataTest extends TestCase
@@ -38,25 +39,27 @@ class PaymentDataTest extends TestCase
     public function testdataFromCart()
     {
         $expectedDataPayment = [];
+        $address = $this->createMock(Address::class);
+        $address->id = 1;
+        $address->id_customer = 1;
+        $address->address1 = '1 rue de Rivoli';
         $product = $this->createMock(Product::class);
         $product->id = 1;
+        $product->name = 'Product Test';
+        $summaryDetailsMock = ['products' => [], 'gift_products'=>[]];
         $cart = $this->createMock(Cart::class);
+        $cart->method('getSummaryDetails')->willReturn($summaryDetailsMock);
         $cart->id_customer = 1;
         $cart->id_address_delivery = 1;
         $cart->id_address_invoice = 1;
-        //$cart->setProductCustomizedDatas();
-        var_dump($cart);
         $context = $this->createMock(Context::class);
         $language = $this->createMock(Language::class);
         $language->iso_code = 'fr';
         $context->language = $language;
         $customer = $this->createMock(Customer::class);
         $customer->firstname = 'Benjamin';
+        $customer->id = 1;
         $context->customer = $customer;
-        $address = $this->createMock(Address::class);
-        $address->id = 1;
-        $address->id_customer = 1;
-        $address->address1 = "1 rue de Rivoli";
         $feePlans = [];
         $returnData = PaymentData::dataFromCart($cart, $context, $feePlans,true);
 


### PR DESCRIPTION
### Reason for change

We send the cart in payload payment only for credit (>4x) + Unit test for getCartItem

[Linear task](https://linear.app/almapay/issue/MPP-89/basket-items-in-payment-only-for-credit)

### Code changes

In payload for payment we add condition if installment > 4 + Unit test for getCartItem

### How to test

_As a reviewer, you are encouraged to test the PR locally._

Make a payment with multi product in cart, with virtual product in cart, with gift product in cart. 
Same test for > 4 installment and < 4 installment and check if cart is sent in dashboard Alma for installment > 4

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)