### PR TITLE
error encryption if apikey is null

### DIFF
--- a/alma/lib/Utils/Settings.php
+++ b/alma/lib/Utils/Settings.php
@@ -45,6 +45,7 @@ use Alma\PrestaShop\Model\CategoryAdapter;
 use Category;
 use Configuration;
 use DateTime;
+use Exception;
 use Language;
 use Product;
 use Shop;
@@ -224,6 +225,7 @@ class Settings
      * Get API key of mode selected
      *
      * @return string
+     * @throws Exception
      */
     public static function getActiveAPIKey()
     {
@@ -238,10 +240,14 @@ class Settings
      * Get API key Live
      *
      * @return string|null
+     * @throws Exception
      */
     public static function getLiveKey()
     {
         $apiKey = self::get(ApiAdminFormBuilder::ALMA_LIVE_API_KEY, null);
+        if (!$apiKey) {
+            return false;
+        }
         if (strpos($apiKey, ApiKeyHelper::BEGIN_LIVE_API_KEY) !== false) {
             return $apiKey;
         }
@@ -254,10 +260,14 @@ class Settings
      * Get API key Test
      *
      * @return string|null
+     * @throws Exception
      */
     public static function getTestKey()
     {
         $apiKey = self::get(ApiAdminFormBuilder::ALMA_TEST_API_KEY, null);
+        if (!$apiKey) {
+            return false;
+        }
         if (strpos($apiKey, ApiKeyHelper::BEGIN_TEST_API_KEY) !== false) {
             return $apiKey;
         }


### PR DESCRIPTION
### Reason for change

There was an error with lib Encryption if apikey was null. We can't send null of false to PhpEncryption->decrypt()

### Code changes

I had return false if apikey is null

### How to test

_As a reviewer, you are encouraged to test the PR locally._

Reset the module and got to configuration

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)