### PR TITLE
Feat/mpp 506/activate in page v2 automatically if in page v1 was activated

### DIFF
--- a/alma/lib/Helpers/ApiHelper.php
+++ b/alma/lib/Helpers/ApiHelper.php
@@ -82,14 +82,14 @@ class ApiHelper
         $value = 1;
 
         if (property_exists($merchant, $merchantKey)) {
-            $value = (int) $merchant->$merchantKey;
+            $value = $merchant->$merchantKey;
         }
 
-        SettingsHelper::updateValue($configKey, $value);
+        SettingsHelper::updateValue($configKey, (int) $value);
 
         // If Inpage not allowed we ensure that inpage is deactivated in database
         if (0 === $value) {
-            SettingsHelper::updateValue(InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, $value);
+            SettingsHelper::updateValue(InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, (int) $value);
         }
     }
 }

--- a/alma/upgrade/upgrade-3.0.0.php
+++ b/alma/upgrade/upgrade-3.0.0.php
@@ -21,7 +21,11 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
+
+use Alma\PrestaShop\Forms\InpageAdminFormBuilder;
+use Alma\PrestaShop\Helpers\ApiHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
+use Alma\PrestaShop\Helpers\SettingsHelper;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -32,8 +36,12 @@ function upgrade_module_3_0_0($module)
     $module->registerHooks();
 
     try {
-        \Alma\PrestaShop\Helpers\ApiHelper::getMerchant($module);
+        ApiHelper::getMerchant($module);
     } catch (\Exception $e) {
+    }
+
+    if (Configuration::get('ALMA_ACTIVATE_FRAGMENT') == 1) {
+        SettingsHelper::updateValue(InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, 1);
     }
 
     if (version_compare(_PS_VERSION_, '1.5.5.0', '<')) {

--- a/alma/upgrade/upgrade-3.0.0.php
+++ b/alma/upgrade/upgrade-3.0.0.php
@@ -40,9 +40,11 @@ function upgrade_module_3_0_0($module)
     } catch (\Exception $e) {
     }
 
-    if (Configuration::get('ALMA_ACTIVATE_FRAGMENT') == 1) {
-        SettingsHelper::updateValue(InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, 1);
-    }
+    // Migration value option of In-Page v1 to In-Page v2
+    SettingsHelper::updateValue(
+        InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE,
+        Configuration::get('ALMA_ACTIVATE_FRAGMENT')
+    );
 
     if (version_compare(_PS_VERSION_, '1.5.5.0', '<')) {
         Tools::clearCache();

--- a/alma/upgrade/upgrade-3.0.0.php
+++ b/alma/upgrade/upgrade-3.0.0.php
@@ -21,7 +21,6 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
-
 use Alma\PrestaShop\Forms\InpageAdminFormBuilder;
 use Alma\PrestaShop\Helpers\ApiHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Activate inpage v2 automatically](https://linear.app/almapay/issue/MPP-506/activate-in-page-v2-automatically-if-in-page-v1-was-activated)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Migration to 3.0.0 to activate automatically the inpage v2 if inpage v1 is activated

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Installe old version of our module 2.11.2 with inpage v1, activate inpage and update the module in 3.0.0 and check if inpage is always activated

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->

- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)