### PR TITLE
feat MPP-519 Return in payment step in prestashop 1.6 on cancel payment

### DIFF
--- a/alma/lib/Model/PaymentData.php
+++ b/alma/lib/Model/PaymentData.php
@@ -184,7 +184,7 @@ class PaymentData
                 'deferred_days' => $feePlans['deferredDays'],
                 'deferred_months' => $feePlans['deferredMonths'],
                 'purchase_amount' => PriceHelper::convertPriceToCents($purchaseAmount),
-                'customer_cancel_url' => $context->link->getPageLink('order'),
+                'customer_cancel_url' => $context->link->getPageLink('order&step=3'),
                 'return_url' => $context->link->getModuleLink('alma', 'validation'),
                 'ipn_callback_url' => $context->link->getModuleLink('alma', 'ipn'),
                 'shipping_address' => [


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Return to the payment step after cancel in Prestashop 1.6](https://linear.app/almapay/issue/MPP-519/return-in-payment-step-in-prestashop-16-on-cancel-payment)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We add the step 3 for step payment in the return url for cancel

### How to test

_As a reviewer, you are encouraged to test the PR locally._

Make a payment and clic Exit in Checkout Alma to see if we return in the payment page in Prestashop 1.6

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->

- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)