### PR TITLE
add escape html for validation Prestashop

### DIFF
--- a/alma/views/templates/hook/_partials/displayPayment_deferred.tpl
+++ b/alma/views/templates/hook/_partials/displayPayment_deferred.tpl
@@ -66,7 +66,7 @@
                 </p>
             </div>
             {if $option.isInPageEnabled}
-                <div id="alma-inpage-payment-option-{$option.paymentOptionKey}" class="alma-inpage-payment-options" data-apimode="{$apiMode}" data-merchantid="{$merchantId}" data-isinpageenabled="{$option.isInPageEnabled}" data-installment="{$option.pnx}" data-purchaseamount="{$creditInfo.totalCart}" data-locale="{$option.locale}"></div>
+                <div id="alma-inpage-payment-option-{$option.paymentOptionKey|escape:'htmlall':'UTF-8'}" class="alma-inpage-payment-options" data-apimode="{$apiMode|escape:'htmlall':'UTF-8'}" data-merchantid="{$merchantId|escape:'htmlall':'UTF-8'}" data-isinpageenabled="{$option.isInPageEnabled|escape:'htmlall':'UTF-8'}" data-installment="{$option.pnx|escape:'htmlall':'UTF-8'}" data-purchaseamount="{$creditInfo.totalCart|escape:'htmlall':'UTF-8'}" data-locale="{$option.locale|escape:'htmlall':'UTF-8'}"></div>
             {/if}
         </div>
     {/if}    

--- a/alma/views/templates/hook/_partials/displayPayment_pnx.tpl
+++ b/alma/views/templates/hook/_partials/displayPayment_pnx.tpl
@@ -67,7 +67,7 @@
                 </p>
             </div>
             {if $option.isInPageEnabled}
-                <div id="alma-inpage-payment-option-{$option.paymentOptionKey}" class="alma-inpage-payment-options" data-apimode="{$apiMode}" data-merchantid="{$merchantId}" data-isinpageenabled="{$option.isInPageEnabled}" data-installment="{$option.pnx}" data-purchaseamount="{$creditInfo.totalCart}" data-locale="{$option.locale}"></div>
+                <div id="alma-inpage-payment-option-{$option.paymentOptionKey|escape:'htmlall':'UTF-8'}" class="alma-inpage-payment-options" data-apimode="{$apiMode|escape:'htmlall':'UTF-8'}" data-merchantid="{$merchantId|escape:'htmlall':'UTF-8'}" data-isinpageenabled="{$option.isInPageEnabled|escape:'htmlall':'UTF-8'}" data-installment="{$option.pnx|escape:'htmlall':'UTF-8'}" data-purchaseamount="{$creditInfo.totalCart|escape:'htmlall':'UTF-8'}" data-locale="{$option.locale|escape:'htmlall':'UTF-8'}"></div>
             {/if}
         </div>
     {/if}

--- a/alma/views/templates/hook/payment_button_deferred.tpl
+++ b/alma/views/templates/hook/payment_button_deferred.tpl
@@ -25,7 +25,7 @@
         {$desc|escape:'htmlall':'UTF-8'}
     </p>
     {if $isInPageEnabled}
-        <div class="alma-inpage" data-apimode="{$apiMode}" data-merchantid="{$merchantId}" data-isinpageenabled="{$isInPageEnabled}" data-installment="{$installment}" data-purchaseamount="{$creditInfo.totalCart}" data-locale="{$locale}"></div>
+        <div class="alma-inpage" data-apimode="{$apiMode|escape:'htmlall':'UTF-8'}" data-merchantid="{$merchantId|escape:'htmlall':'UTF-8'}" data-isinpageenabled="{$isInPageEnabled|escape:'htmlall':'UTF-8'}" data-installment="{$installment|escape:'htmlall':'UTF-8'}" data-purchaseamount="{$creditInfo.totalCart|escape:'htmlall':'UTF-8'}" data-locale="{$locale|escape:'htmlall':'UTF-8'}"></div>
     {else}
         {include file="modules/alma/views/templates/hook/_partials/deferred.tpl" plans=$plans}
     {/if}

--- a/alma/views/templates/hook/payment_button_pnx.tpl
+++ b/alma/views/templates/hook/payment_button_pnx.tpl
@@ -25,7 +25,7 @@
         {$desc|escape:'htmlall':'UTF-8'}
     </p>
     {if $isInPageEnabled}
-        <div class="alma-inpage" data-apimode="{$apiMode}" data-merchantid="{$merchantId}" data-isinpageenabled="{$isInPageEnabled}" data-installment="{$installment}" data-purchaseamount="{$creditInfo.totalCart}" data-locale="{$locale}"></div>
+        <div class="alma-inpage" data-apimode="{$apiMode|escape:'htmlall':'UTF-8'}" data-merchantid="{$merchantId|escape:'htmlall':'UTF-8'}" data-isinpageenabled="{$isInPageEnabled|escape:'htmlall':'UTF-8'}" data-installment="{$installment|escape:'htmlall':'UTF-8'}" data-purchaseamount="{$creditInfo.totalCart|escape:'htmlall':'UTF-8'}" data-locale="{$locale|escape:'htmlall':'UTF-8'}"></div>
     {else}
         {include file="modules/alma/views/templates/hook/_partials/feePlan.tpl" plans=$plans creditInfo=$creditInfo oneLiner=false}
     {/if}


### PR DESCRIPTION
### Reason for change

[Add escape for validation Prestashop](https://linear.app/almapay/issue/MPP-521/fix-prestashop-declined-publication-module)

### Code changes

add `|escape:'htmlall':'UTF-8'` in template smarty

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)