### PR TITLE
Fix: Inpage for Prestashop version before 16.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.3
+
+- fix: issue modal In-Page on Prestashop before 16.0.12
+
 ## v3.0.2
 
 - fix: issue modal In-Page with jQuery noConflict

--- a/alma/CHANGELOG.md
+++ b/alma/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.3
+
+- fix: issue modal In-Page on Prestashop before 16.0.12
+
 ## v3.0.2
 
 - fix: issue modal In-Page with jQuery noConflict

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -30,7 +30,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 
 class Alma extends PaymentModule
 {
-    const VERSION = '3.0.2';
+    const VERSION = '3.0.3';
 
     public $_path;
     public $local_path;
@@ -65,7 +65,7 @@ class Alma extends PaymentModule
     {
         $this->name = 'alma';
         $this->tab = 'payments_gateways';
-        $this->version = '3.0.2';
+        $this->version = '3.0.3';
         $this->author = 'Alma';
         $this->need_instance = false;
         $this->bootstrap = true;

--- a/alma/lib/Traits/AjaxTrait.php
+++ b/alma/lib/Traits/AjaxTrait.php
@@ -102,6 +102,6 @@ trait AjaxTrait
      */
     protected function ajaxRenderBefore16012($value)
     {
-        exit(\Tools::jsonEncode($value));
+        exit($value);
     }
 }


### PR DESCRIPTION
### Reason for change

[issue inpage prestashop < 16.0.12](https://linear.app/almapay/issue/MPP-541/fix-prestashop-1531)

### Code changes

Remove json_encode in return because we json_encode before

### How to test

_As a reviewer, you are encouraged to test the PR locally._

Make payment In-Page in Prestashop before 16.0.12

### Checklist for authors and reviewers

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)