### PR TITLE
Fix hook case sensitive on Prestashop 8.1.0

### DIFF
--- a/alma/lib/Helpers/HookHelper.php
+++ b/alma/lib/Helpers/HookHelper.php
@@ -50,7 +50,6 @@ class HookHelper
         'moduleRoutes' => 'all',
         'actionAdminControllerInitBefore' => 'all',
         'header' => 'all',
-        'Header' => 'all',
         'displayHeader' => 'all',
         'displayBackOfficeHeader' => 'all',
         'displayShoppingCartFooter' => 'all',


### PR DESCRIPTION
### Reason for change

Our module doesn't install in Prestashop 8.1.0

[Fix install Prestashop 8.1.0](https://linear.app/almapay/issue/MPP-567/fix-hook-case-sensitive-on-prestashop-810)

### Code changes

Remove Hook Header with `H` because this Prestashop version is not case-sensitive

### How to test

Install our last module version in Prestashop 8.1.0

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)