### PR TITLE
fix call method l() ActivationException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.0.3
 
 - fix: issue modal In-Page on Prestashop before 16.0.12
+- fix: issue error when merchant not allow to create payments
 
 ## v3.0.2
 

--- a/alma/CHANGELOG.md
+++ b/alma/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.0.3
 
 - fix: issue modal In-Page on Prestashop before 16.0.12
+- fix: issue error when merchant not allow to create payments
 
 ## v3.0.2
 

--- a/alma/exceptions/ActivationException.php
+++ b/alma/exceptions/ActivationException.php
@@ -37,7 +37,7 @@ class ActivationException extends AlmaException
     public function __construct($module)
     {
         $message = sprintf(
-            $module - l('Your Alma account needs to be activated before you can use Alma on your shop.<br>Go to your <a href="%1$s" target="_blank">Alma dashboard</a> to activate your account.<br><a href="#">Refresh</a> the page when ready.', 'ActivationException'),
+            $module->l('Your Alma account needs to be activated before you can use Alma on your shop.<br>Go to your <a href="%1$s" target="_blank">Alma dashboard</a> to activate your account.<br><a href="#">Refresh</a> the page when ready.', 'ActivationException'),
             LinkHelper::getAlmaDashboardUrl(SettingsHelper::getActiveMode(), 'settings')
         );
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Error bad call method l](https://linear.app/almapay/issue/MPP-593/fix-error-if-activationexception-executed)

### Code changes

fix syntaxe call method ->l

### How to test

Use API_KEY with account can't create payment

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)