### PR TITLE
Clear the partial refund amount after a partial refund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.0.3
 
 - fix: issue modal In-Page on Prestashop before 16.0.12
+- fix: Clear the partial refund amount after a partial refund
 
 ## v3.0.2
 

--- a/alma/CHANGELOG.md
+++ b/alma/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.0.3
 
 - fix: issue modal In-Page on Prestashop before 16.0.12
+- fix: Clear the partial refund amount after a partial refund
 
 ## v3.0.2
 

--- a/alma/views/templates/hook/_partials/refunds.tpl
+++ b/alma/views/templates/hook/_partials/refunds.tpl
@@ -68,14 +68,15 @@
                     }
                     if (data.totalRefundAmount >= data.totalOrderAmount) {
                         $form.addClass('disabled')
-                    };
+                    }
                 })
                 .fail(function (data) {
                     var jsondata = JSON.parse(data.responseText);                    
                     $('.alma-danger').html(jsondata.message).show();
                 })
                 .always(function(){
-                    $($form.find('[type=submit]')).attr("disabled", false);
+                    $($form.find('[type=submit]')).attr('disabled', false);
+                    $($form.find('input[id=amount]')).val('');
                 });
 
                 return false;

--- a/alma/views/templates/hook/order_refund_bs3.tpl
+++ b/alma/views/templates/hook/order_refund_bs3.tpl
@@ -83,12 +83,11 @@
                 </div>
             </div>
             <div class="form-group" id="amountDisplay" style="display: none">
-                <label class="control-label col-lg-2 required"> {$wording.labelAmoutRefundPartial|escape:'htmlall':'UTF-8'}</label>
+                <label class="control-label col-lg-2 required" for="amount"> {$wording.labelAmoutRefundPartial|escape:'htmlall':'UTF-8'}</label>
                 <div class="col-lg-2">
                     <div class="input-group">
                         <span class="input-group-addon">{$order.currencySymbol|escape:'htmlall':'UTF-8'}</span>
-                        <input type="text" class="alma" value="" name="amount"
-                               placeholder="{$wording.placeholderInputRefundPartial|escape:'htmlall':'UTF-8'}"/>
+                        <input type="text" class="alma" value="" name="amount" id="amount" placeholder="{$wording.placeholderInputRefundPartial|escape:'htmlall':'UTF-8'}"/>
                     </div>
                 </div>
             </div>

--- a/alma/views/templates/hook/order_refund_ps15.tpl
+++ b/alma/views/templates/hook/order_refund_ps15.tpl
@@ -84,7 +84,7 @@
             <div class="clear"></div>
         </div>
         <div style="display:none;" id="amountDisplay">
-            <label>
+            <label for="amount">
                 {$wording.labelAmoutRefundPartial|escape:'htmlall':'UTF-8'}
             </label>
             <div class="margin-form">


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Clear the partial refund amount after a partial refund](https://linear.app/almapay/issue/MPP-589/clear-the-partial-refund-amount-after-a-partial-refund)

### Code changes

Add jquery code to clear value input after refund and add id amount in input amount on Prestashop 1.6

### How to test

Make a partial refund and see if the value is cleaned

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features


### Non applicable

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)