### PR TITLE
Don't boucle of all api_key when you select one mode with api_key

### DIFF
--- a/alma/controllers/hook/GetContentHookController.php
+++ b/alma/controllers/hook/GetContentHookController.php
@@ -394,7 +394,11 @@ final class GetContentHookController extends AdminHookController
 
         foreach ($modes as $mode) {
             $key = (ALMA_MODE_LIVE == $mode ? $liveKey : $testKey);
-            if (!$key || ConstantsHelper::OBSCURE_VALUE === $key) {
+            if (
+                !$key ||
+                ConstantsHelper::OBSCURE_VALUE === $key ||
+                SettingsHelper::getActiveMode() !== $mode
+            ) {
                 continue;
             }
 

--- a/alma/exceptions/ActivationException.php
+++ b/alma/exceptions/ActivationException.php
@@ -36,9 +36,16 @@ class ActivationException extends AlmaException
      */
     public function __construct($module)
     {
-        $message = sprintf(
-            $module->l('Your Alma account needs to be activated before you can use Alma on your shop.<br>Go to your <a href="%1$s" target="_blank">Alma dashboard</a> to activate your account.<br><a href="#">Refresh</a> the page when ready.', 'ActivationException'),
-            LinkHelper::getAlmaDashboardUrl(SettingsHelper::getActiveMode(), 'settings')
+        $message = $module->l('Your Alma account needs to be activated before you can use Alma on your shop.', 'ActivationException')
+        . sprintf(
+                $module->l('Go to your %1$sAlma dashboard%2$s to activate your account.', 'ActivationException'),
+                '<a href="' . LinkHelper::getAlmaDashboardUrl(SettingsHelper::getActiveMode(), 'settings') . '" target="_blank">',
+                '</a>'
+            )
+        . sprintf(
+            $module->l('%1$sRefresh%2$s the page when ready.', 'ActivationException'),
+            '<a href="#">',
+            '</a>'
         );
 
         parent::__construct($message);

--- a/alma/exceptions/WrongCredentialsException.php
+++ b/alma/exceptions/WrongCredentialsException.php
@@ -36,9 +36,10 @@ class WrongCredentialsException extends AlmaException
      */
     public function __construct($module)
     {
-        $message = sprintf(
-            $module->l('Could not connect to Alma using your API keys.<br>Please double check your keys on your %s Alma dashboard %s.', 'WrongCredentialsException'),
-            sprintf('<a href="%1$s" target="_blank">', LinkHelper::getAlmaDashboardUrl(SettingsHelper::getActiveMode(), 'api')),
+        $message = $module->l('Could not connect to Alma using your API keys.', 'WrongCredentialsException')
+        . sprintf(
+            $module->l('Please double check your keys on your %1$sAlma dashboard%2$s.', 'WrongCredentialsException'),
+            '<a href="' . LinkHelper::getAlmaDashboardUrl(SettingsHelper::getActiveMode(), 'api') . '" target="_blank">',
             '</a>'
         );
 

--- a/alma/translations/en.php
+++ b/alma/translations/en.php
@@ -67,7 +67,11 @@ $_MODULE['<{alma}prestashop>paymentoptionshookcontroller_1dd1c5fb7f25cd41b291d43
 $_MODULE['<{alma}prestashop>paymentoptionshookcontroller_96b0141273eabab320119c467cdcaf17'] = 'Total';
 $_MODULE['<{alma}prestashop>paymentoptionshookcontroller_9bbd94e0a507283ae202812ea1bd6f20'] = '%s month later';
 $_MODULE['<{alma}prestashop>paymentoptionshookcontroller_9088921432b295dfe6f02863b2dc0ff8'] = '0 € today then %1$s on %2$s';
-$_MODULE['<{alma}prestashop>wrongcredentialsexception_9c2a0378c6c1a5fbb47a5d4546caa1c9'] = 'Could not connect to Alma using your API keys. Please double check your keys on your %s Alma dashboard %s.';
+$_MODULE['<{alma}prestashop>activationexception_775ab97c1b3d6e302ff6c35731e221fc'] = 'Your Alma account needs to be activated before you can use Alma on your shop.';
+$_MODULE['<{alma}prestashop>activationexception_29078267ae901ff90213dc0960ad24c2'] = 'Go to your %1$sAlma dashboard%2$s to activate your account.';
+$_MODULE['<{alma}prestashop>activationexception_aabe795eef98c70dab6d990341398cec'] = '%1$sRefresh%2$s the page when ready.';
+$_MODULE['<{alma}prestashop>wrongcredentialsexception_cc76de47de858ac2fa2964f534ecfdfb'] = 'Could not connect to Alma using your API keys.';
+$_MODULE['<{alma}prestashop>wrongcredentialsexception_733b6ddadc31fd97174b0cfe69b584c9'] = 'Please double check your keys on your %1$sAlma dashboard%2$s.';
 $_MODULE['<{alma}prestashop>abstractalmaadminformbuilder_c9cc8cce247e49bae79f15173ce97354'] = 'Save';
 $_MODULE['<{alma}prestashop>apiadminformbuilder_fe1d478b2e434b92277b47f0cf62e040'] = 'API Mode';
 $_MODULE['<{alma}prestashop>apiadminformbuilder_0e95e5facc2cad62d6458c65164c4455'] = 'Use Test mode until you are ready to take real orders with Alma. In Test mode, only admins can see Alma on cart/checkout pages.';


### PR DESCRIPTION
### Reason for change

If your account has one api_key not activated, we throw an error ever if the mode selected is the api_key validated

[Don't boucle of all api_key when you select one mode with api_key](https://linear.app/almapay/issue/MPP-597/dont-boucle-of-all-api-key-when-you-select-one-mode-with-api-key)

### Code changes

We check the getMerchant only for the mode selected

### How to test

Use an account with sandbox validated and live not validated and enter the both api_key and select the sandbox mode

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)