### PR TITLE
Handle feature flag insurance in BO

### DIFF
--- a/alma/controllers/admin/AdminAlmaInsurance.php
+++ b/alma/controllers/admin/AdminAlmaInsurance.php
@@ -21,48 +21,19 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
-use Alma\PrestaShop\Forms\InpageAdminFormBuilder;
-use Alma\PrestaShop\Helpers\ApiHelper;
-use Alma\PrestaShop\Helpers\ConstantsHelper;
-use Alma\PrestaShop\Helpers\SettingsHelper;
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
-function upgrade_module_3_0_0($module)
+class AdminAlmaInsuranceController extends ModuleAdminController
 {
-    $module->registerHooks();
-
-    try {
-        $apiHelper = new ApiHelper();
-        $apiHelper->getMerchant($module);
-    } catch (\Exception $e) {
+    /**
+     * @return void
+     * @throws SmartyException
+     */
+    public function initContent()
+    {
+        parent::initContent();
+        $content = $this->context->smarty->fetch(_PS_MODULE_DIR_ . 'alma/views/templates/admin/insurance.tpl');
+        $this->context->smarty->assign(array(
+            'content' => $this->content . $content,
+        ));
     }
-
-    // Migration value option of In-Page v1 to In-Page v2
-    SettingsHelper::updateValue(
-        InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE,
-        Configuration::get('ALMA_ACTIVATE_FRAGMENT')
-    );
-
-    if (version_compare(_PS_VERSION_, '1.5.5.0', '<')) {
-        Tools::clearCache();
-
-        return $module->uninstallTabs() && $module->installTabs();
-    }
-
-    if (version_compare(_PS_VERSION_, ConstantsHelper::PRESTASHOP_VERSION_1_7_0_2, '<=')) {
-        Tools::clearSmartyCache();
-        if (version_compare(_PS_VERSION_, '1.6.0.2', '>')) {
-            Tools::clearXMLCache();
-        }
-
-        return $module->uninstallTabs() && $module->installTabs();
-    }
-
-    Tools::clearAllCache();
-    Tools::clearXMLCache();
-
-    return $module->uninstallTabs() && $module->installTabs();
 }

--- a/alma/controllers/hook/GetContentHookController.php
+++ b/alma/controllers/hook/GetContentHookController.php
@@ -57,6 +57,11 @@ use Alma\PrestaShop\Logger;
 
 final class GetContentHookController extends AdminHookController
 {
+    /**
+     * @var ApiHelper $apiHelper
+     */
+    protected $apiHelper;
+
     /** @var ApiKeyHelper */
     private $apiKeyHelper;
 
@@ -123,6 +128,7 @@ final class GetContentHookController extends AdminHookController
      */
     public function __construct($module)
     {
+        $this->apiHelper = new ApiHelper();
         $this->apiKeyHelper = new ApiKeyHelper();
         parent::__construct($module);
     }
@@ -194,7 +200,7 @@ final class GetContentHookController extends AdminHookController
 
         // Try to get merchant from configured API key/mode
         try {
-            $merchant = ApiHelper::getMerchant($this->module);
+            $merchant = $this->apiHelper->getMerchant($this->module);
         } catch (\Exception $e) {
             $this->context->smarty->assign(
                 [
@@ -413,7 +419,7 @@ final class GetContentHookController extends AdminHookController
 
             // Try to get merchant from configured API key/mode
             try {
-                ApiHelper::getMerchant($this->module, $alma);
+                $this->apiHelper->getMerchant($this->module, $alma);
             } catch (\Exception $e) {
                 $this->context->smarty->assign(
                     [
@@ -461,7 +467,7 @@ final class GetContentHookController extends AdminHookController
         $merchant = null;
 
         try {
-            $merchant = ApiHelper::getMerchant($this->module);
+            $merchant = $this->apiHelper->getMerchant($this->module);
         } catch (\Exception $e) {
             Logger::instance()->error($e->getMessage());
         }

--- a/alma/lib/Helpers/Admin/InsuranceHelper.php
+++ b/alma/lib/Helpers/Admin/InsuranceHelper.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Helpers\Admin;
+
+use Alma\PrestaShop\Helpers\ConstantsHelper;
+use PrestaShop\PrestaShop\Adapter\Entity\Tab;
+
+class InsuranceHelper
+{
+    /**
+     * @var array
+     *
+     */
+    protected static $tabInsuranceDescription = [
+        'position' => 3,
+        'icon' => 'not_interested',
+    ];
+
+    /**
+     * @var TabsHelper
+     */
+    private $tabsHelper;
+
+    public function __construct()
+    {
+        $this->tabsHelper = new TabsHelper();
+    }
+
+    /**
+     * @param int $isAllowInsurance
+     * @return bool|null
+     * @throws \PrestaShopException
+     */
+    public function handleBOMenu($module, $isAllowInsurance) {
+        /**
+         * @var Tab|object $tab
+         */
+        $tab = \Tab::getInstanceFromClassName(ConstantsHelper::BO_CONTROLLER_INSURANCE_CLASSNAME);
+
+        // Remove tab if the tab exists and we are not allowed to have it
+        if (
+            $tab->id
+            && !$isAllowInsurance
+        ) {
+            return $this->tabsHelper->uninstallTab(ConstantsHelper::BO_CONTROLLER_INSURANCE_CLASSNAME);
+        }
+
+        // Add tab if the tab not exists and we are allowed to have it
+        if (
+            !$tab->id
+            && $isAllowInsurance
+        ) {
+            return $this->tabsHelper->installTab(
+                ConstantsHelper::ALMA_MODULE_NAME,
+                ConstantsHelper::BO_CONTROLLER_INSURANCE_CLASSNAME,
+                $module->l('Insurance'),
+                ConstantsHelper::ALMA_MODULE_NAME,
+                static::$tabInsuranceDescription['position'],
+                static::$tabInsuranceDescription['icon']
+            );
+        }
+
+        return null;
+    }
+}

--- a/alma/lib/Helpers/Admin/TabsHelper.php
+++ b/alma/lib/Helpers/Admin/TabsHelper.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Helpers\Admin;
+
+class TabsHelper
+{
+    /**
+     * Add Alma in backoffice menu.
+     *
+     * @param $moduleName
+     * @param string $class class controller
+     * @param string $name tab title
+     * @param null $parent parent class name
+     * @param null $position order in menu
+     * @param null $icon fontAwesome class icon
+     *
+     * @return bool if save successfully
+     * @throws \PrestaShopException
+     */
+    public function installTab($moduleName, $class, $name, $parent = null, $position = null, $icon = null)
+    {
+        $tab = \Tab::getInstanceFromClassName($class);
+        $tab->active = false !== $name;
+        $tab->class_name = $class;
+        $tab->name = [];
+
+        if ($position) {
+            $tab->position = $position;
+        }
+
+        foreach (\Language::getLanguages(true) as $lang) {
+            $tab->name[$lang['id_lang']] = $name;
+        }
+
+        $tab->id_parent = 0;
+        if ($parent) {
+            if (version_compare(_PS_VERSION_, '1.7', '>=') && $icon) {
+                $tab->icon = $icon;
+            }
+
+            $parentTab = \Tab::getInstanceFromClassName($parent);
+            $tab->id_parent = $parentTab->id;
+        }
+
+        $tab->module = $moduleName;
+
+
+        return $tab->save();
+    }
+
+    /**
+     * @params string $class
+     * @return bool
+     * @throws \PrestaShopException
+     */
+    public function uninstallTab($class)
+    {
+        $tab = \Tab::getInstanceFromClassName($class);
+        if (!\Validate::isLoadedObject($tab)) {
+            return true;
+        }
+
+        return $tab->delete();
+    }
+}

--- a/alma/lib/Helpers/ConstantsHelper.php
+++ b/alma/lib/Helpers/ConstantsHelper.php
@@ -30,6 +30,7 @@ if (!defined('_PS_VERSION_')) {
 
 class ConstantsHelper
 {
+    const ALMA_MODULE_NAME = 'alma';
     const INPAGE_SCRIPT_PATH = 'views/js/alma-inpage.js';
     const INPAGE_JS_URL = 'https://cdn.jsdelivr.net/npm/@alma/in-page@2.x.x/dist/index.umd.js';
     const WIDGETS_CSS_URL = 'https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/widgets.min.css';
@@ -55,4 +56,10 @@ class ConstantsHelper
     const ALMA_KEY_PAYNOW = 'general_1_0_0';
 
     const ALMA_ALLOW_INPAGE = 'ALMA_ALLOW_INPAGE';
+
+    const ALMA_ALLOW_INSURANCE = 'ALMA_ALLOW_INSURANCE';
+
+    const ALMA_ACTIVATE_INSURANCE = 'ALMA_ACTIVATE_INSURANCE';
+
+    const BO_CONTROLLER_INSURANCE_CLASSNAME = 'AdminAlmaInsurance';
 }

--- a/alma/lib/Helpers/SettingsHelper.php
+++ b/alma/lib/Helpers/SettingsHelper.php
@@ -148,6 +148,7 @@ class SettingsHelper
             'ALMA_PRODUCT_WDGT_NOT_ELGBL',
             'ALMA_CATEGORIES_WDGT_NOT_ELGBL',
             ConstantsHelper::ALMA_ALLOW_INPAGE,
+            ConstantsHelper::ALMA_ALLOW_INSURANCE,
         ];
 
         foreach ($configKeys as $configKey) {

--- a/alma/translations/en.php
+++ b/alma/translations/en.php
@@ -172,6 +172,7 @@ $_MODULE['<{alma}prestashop>customfieldshelper_6ed45ebd72fcca0fc0c271128e9d7b7b'
 $_MODULE['<{alma}prestashop>orderhelper_7960c85fd5916169fc5038a2192094f8'] = 'Error: Could not find Alma transaction';
 $_MODULE['<{alma}prestashop>refundhelper_446ae76a36687f9dbc62430e7006ca91'] = 'We regret to inform you that there was an issue during the payment process, your Alma payment will be fully refunded. Please retry your payment to complete your order.';
 $_MODULE['<{alma}prestashop>refundhelper_448edd2d5c593906afa202847b8d79c0'] = 'We apologize for the inconvenience, but there was an issue during the payment process, and we were unable to refund your Alma payment. To fix this, we kindly ask you to contact our support team with your payment reference: %s. Our team will be happy to assist you in ensuring that you receive your full refund. Thank you for your cooperation.';
+$_MODULE['<{alma}prestashop>insurancehelper_eaff1bdf24fcffe0e14e29a1bff51a12'] = 'Insurance';
 $_MODULE['<{alma}prestashop>paymentvalidation_efa820507b1951ee5722003639b1a0b0'] = 'Alma Monthly Installments are not available for this currency';
 $_MODULE['<{alma}prestashop>paymentvalidation_1d879e270cfb195f257aab3116618d8b'] = 'Alma - +%d days payment';
 $_MODULE['<{alma}prestashop>paymentvalidation_2ea09287a94f2bc88b459fc7d5a31b6b'] = 'Alma - Pay now';

--- a/alma/views/templates/admin/insurance.tpl
+++ b/alma/views/templates/admin/insurance.tpl
@@ -1,0 +1,5 @@
+<div class="alma--insurance-iframe">
+    JE SUIS UN SUPER IFRAME !
+    MERCI CAMILLE !
+    V2
+</div>


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/MPP-723/handle-the-insurance-feature-flag-from-alma)

### Code changes

- flag name : feature:cms:insurance
- Retrieve the feature flag in the API from the endpoint /me/extended-data
- Save the information it in the CMS Database in the field ALMA_ALLOW_INSURANCE
- Create the menu link + page to go to the insurance's configuration if the flag insurance is allowed

### How to test

Change bool 1 or 0 in file alma/lib/Helpers/ApiHelper.php line 97 `$isAllowInsurance`
Check in Dashboard Prestashop if the Insurance menu displayed or disappear depending the flag
And click in the menu to see the temporary message
