### PR TITLE
Use mocked iframe to test to integrate config in bo

### DIFF
--- a/alma/CHANGELOG.md
+++ b/alma/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.1.0
 
-- feat: In-Page: Now we use the setForm in payment option. We also refactored the code to vanilla Javascript (we don't use Jquery anymore)```
+- feat: In-Page: Now we use the setForm in payment option and refactored to vanilla Javascript (we don't use Jquery anymore)```
 
 ## v3.0.3
 

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -343,6 +343,8 @@ class Alma extends PaymentModule
 
     /**
      * @return bool
+     *
+     * @throws PrestaShopException
      */
     public function installTabs()
     {

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -366,6 +366,7 @@ class Alma extends PaymentModule
 
     /**
      * @return bool
+     *
      * @throws PrestaShopException
      */
     public function uninstallTabs()

--- a/alma/composer.json
+++ b/alma/composer.json
@@ -6,7 +6,8 @@
         "phpunit/phpunit": "^5",
         "mockery/mockery": "^1.3",
         "phpcompatibility/php-compatibility": "10.x-dev",
-        "prestashop/php-dev-tools": "^3.16"
+        "prestashop/php-dev-tools": "^3.16",
+        "phpunit/php-code-coverage": "^4"
     },
     "require": {
         "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1",

--- a/alma/controllers/admin/AdminAlmaInsurance.php
+++ b/alma/controllers/admin/AdminAlmaInsurance.php
@@ -36,4 +36,12 @@ class AdminAlmaInsuranceController extends ModuleAdminController
             'content' => $this->content . $content,
         ));
     }
+
+    public function ajaxProcessInsurance()
+    {
+        $this->ajaxRender(json_encode([
+            'success' => true,
+        ]));
+        exit;
+    }
 }

--- a/alma/controllers/admin/AdminAlmaInsurance.php
+++ b/alma/controllers/admin/AdminAlmaInsurance.php
@@ -24,6 +24,12 @@
 
 class AdminAlmaInsuranceController extends ModuleAdminController
 {
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
     /**
      * @return void
      * @throws SmartyException

--- a/alma/controllers/admin/AdminAlmaInsurance.php
+++ b/alma/controllers/admin/AdminAlmaInsurance.php
@@ -22,32 +22,39 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
 
+use Alma\PrestaShop\Helpers\Admin\InsuranceHelper;
+
 class AdminAlmaInsuranceController extends ModuleAdminController
 {
+    /**
+     * @var InsuranceHelper
+     */
+    private $insuranceHelper;
+
     public function __construct()
     {
         $this->bootstrap = true;
+        $this->insuranceHelper = new InsuranceHelper();
         parent::__construct();
     }
 
     /**
      * @return void
+     *
      * @throws SmartyException
      */
     public function initContent()
     {
         parent::initContent();
-        $content = $this->context->smarty->fetch(_PS_MODULE_DIR_ . 'alma/views/templates/admin/insurance.tpl');
-        $this->context->smarty->assign(array(
-            'content' => $this->content . $content,
-        ));
-    }
 
-    public function ajaxProcessInsurance()
-    {
-        $this->ajaxRender(json_encode([
-            'success' => true,
-        ]));
-        exit;
+        $this->context->smarty->assign([
+            'iframeUrl' => $this->insuranceHelper->constructIframeUrlWithParams(),
+        ]);
+
+        $content = $this->context->smarty->fetch(_PS_MODULE_DIR_ . 'alma/views/templates/admin/insurance.tpl');
+
+        $this->context->smarty->assign([
+            'content' => $this->content . $content,
+        ]);
     }
 }

--- a/alma/controllers/admin/AdminAlmaInsurance.php
+++ b/alma/controllers/admin/AdminAlmaInsurance.php
@@ -23,24 +23,35 @@
  */
 
 use Alma\PrestaShop\Helpers\Admin\InsuranceHelper;
+use Alma\PrestaShop\Helpers\ConfigurationHelper;
+use Alma\PrestaShop\Logger;
+use Alma\PrestaShop\Traits\AjaxTrait;
 
 class AdminAlmaInsuranceController extends ModuleAdminController
 {
+    use AjaxTrait;
+
     /**
      * @var InsuranceHelper
      */
     private $insuranceHelper;
+    /**
+     * @var ConfigurationHelper
+     */
+    private $configurationHelper;
 
     public function __construct()
     {
         $this->bootstrap = true;
         $this->insuranceHelper = new InsuranceHelper();
+        $this->configurationHelper = new ConfigurationHelper();
         parent::__construct();
     }
 
     /**
      * @return void
      *
+     * @throws PrestaShopException
      * @throws SmartyException
      */
     public function initContent()
@@ -49,6 +60,7 @@ class AdminAlmaInsuranceController extends ModuleAdminController
 
         $this->context->smarty->assign([
             'iframeUrl' => $this->insuranceHelper->constructIframeUrlWithParams(),
+            'token' => \Tools::getAdminTokenLite('AdminAlmaInsurance'),
         ]);
 
         $content = $this->context->smarty->fetch(_PS_MODULE_DIR_ . 'alma/views/templates/admin/insurance.tpl');
@@ -56,5 +68,34 @@ class AdminAlmaInsuranceController extends ModuleAdminController
         $this->context->smarty->assign([
             'content' => $this->content . $content,
         ]);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws PrestaShopException
+     */
+    public function ajaxProcessSaveConfigInsurance()
+    {
+        try {
+            $config = Tools::getValue('config');
+
+            $this->insuranceHelper->saveConfigInsurance($config, $this->module);
+
+            $this->ajaxRenderAndExit(json_encode([
+                    'success' => true,
+                    'message' => $this->module->l('Your configuration has been saved'),
+                ])
+            );
+        } catch (\Exception $e) {
+            Logger::instance()->error('Error creating Alma configuration insurance: ' . $e->getMessage());
+            $this->ajaxRenderAndExit(json_encode([
+                    'error' => [
+                        'msg' => $this->module->l('Error creating Alma configuration insurance: ' . $e->getMessage()),
+                        'code' => $e->getCode(),
+                    ],
+                ])
+            );
+        }
     }
 }

--- a/alma/controllers/hook/GetContentHookController.php
+++ b/alma/controllers/hook/GetContentHookController.php
@@ -58,7 +58,7 @@ use Alma\PrestaShop\Logger;
 final class GetContentHookController extends AdminHookController
 {
     /**
-     * @var ApiHelper $apiHelper
+     * @var ApiHelper
      */
     protected $apiHelper;
 

--- a/alma/exceptions/WrongParamsException.php
+++ b/alma/exceptions/WrongParamsException.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Exceptions;
+
+class WrongParamsException extends AlmaException
+{
+    /**
+     * Constructor.
+     *
+     * @param object $module
+     * @param array $errorKeyConfig
+     */
+    public function __construct($module, $errorKeyConfig)
+    {
+        $message = sprintf(
+            $module->l('Error(s) key(s): %1$s.', 'WrongParamsException'),
+            implode(', ', array_keys($errorKeyConfig))
+        );
+
+        parent::__construct($message);
+    }
+}

--- a/alma/lib/Helpers/Admin/InsuranceHelper.php
+++ b/alma/lib/Helpers/Admin/InsuranceHelper.php
@@ -27,7 +27,6 @@ namespace Alma\PrestaShop\Helpers\Admin;
 use Alma\PrestaShop\Exceptions\WrongParamsException;
 use Alma\PrestaShop\Helpers\ConfigurationHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
-use PrestaShop\PrestaShop\Adapter\Entity\Tab;
 
 class InsuranceHelper
 {
@@ -54,11 +53,11 @@ class InsuranceHelper
     /**
      * @var TabsHelper
      */
-    private $tabsHelper;
+    public $tabsHelper;
     /**
      * @var ConfigurationHelper
      */
-    private $configurationHelper;
+    public $configurationHelper;
 
     public function __construct()
     {
@@ -75,11 +74,7 @@ class InsuranceHelper
      */
     public function handleBOMenu($module, $isAllowInsurance)
     {
-        /**
-         * @var Tab|object $tab
-         */
-        $tab = \Tab::getInstanceFromClassName(ConstantsHelper::BO_CONTROLLER_INSURANCE_CLASSNAME);
-
+        $tab = $this->tabsHelper->getInstanceFromClassName(ConstantsHelper::BO_CONTROLLER_INSURANCE_CLASSNAME);
         // Remove tab if the tab exists and we are not allowed to have it
         if (
             $tab->id

--- a/alma/lib/Helpers/Admin/InsuranceHelper.php
+++ b/alma/lib/Helpers/Admin/InsuranceHelper.php
@@ -35,7 +35,7 @@ class InsuranceHelper
      */
     protected static $tabInsuranceDescription = [
         'position' => 3,
-        'icon' => 'not_interested',
+        'icon' => 'security',
     ];
 
     /**

--- a/alma/lib/Helpers/Admin/InsuranceHelper.php
+++ b/alma/lib/Helpers/Admin/InsuranceHelper.php
@@ -25,6 +25,7 @@
 namespace Alma\PrestaShop\Helpers\Admin;
 
 use Alma\PrestaShop\Helpers\ConstantsHelper;
+use Alma\PrestaShop\Helpers\SettingsHelper;
 use PrestaShop\PrestaShop\Adapter\Entity\Tab;
 
 class InsuranceHelper
@@ -43,9 +44,15 @@ class InsuranceHelper
      */
     private $tabsHelper;
 
+    /**
+     * @var SettingsHelper
+     */
+    private $settingsHelper;
+
     public function __construct()
     {
         $this->tabsHelper = new TabsHelper();
+        $this->settingsHelper = new SettingsHelper();
     }
 
     /**
@@ -83,5 +90,34 @@ class InsuranceHelper
         }
 
         return null;
+    }
+
+    /**
+     * Instantiate default db values if insurance is activated or remove it
+     *
+     * @param bool $isAllowInsurance
+     * @return void
+     */
+    public function handleDefaultInsuranceFieldValues($isAllowInsurance)
+    {
+        $isAlmaInsuranceActivated = $this->settingsHelper->hasKey(ConstantsHelper::ALMA_ACTIVATE_INSURANCE);
+
+        // If insurance is allowed and do not exists in db
+        if (
+            $isAllowInsurance
+            && !$isAlmaInsuranceActivated
+        ) {
+            foreach (ConstantsHelper::$fieldsBoInsurance as $configKey) {
+                $this->settingsHelper->updateValueV2($configKey, 0);
+            }
+        }
+
+        // If insurance is not allowed and exists in db
+        if (
+            !$isAllowInsurance
+            && $isAlmaInsuranceActivated
+        ) {
+            $this->settingsHelper->deleteByNames(ConstantsHelper::$fieldsBoInsurance);
+        }
     }
 }

--- a/alma/lib/Helpers/Admin/TabsHelper.php
+++ b/alma/lib/Helpers/Admin/TabsHelper.php
@@ -24,6 +24,8 @@
 
 namespace Alma\PrestaShop\Helpers\Admin;
 
+use PrestaShop\PrestaShop\Adapter\Entity\Tab;
+
 class TabsHelper
 {
     /**
@@ -37,12 +39,10 @@ class TabsHelper
      * @param null $icon fontAwesome class icon
      *
      * @return bool if save successfully
-     *
-     * @throws \PrestaShopException
      */
     public function installTab($moduleName, $class, $name, $parent = null, $position = null, $icon = null)
     {
-        $tab = \Tab::getInstanceFromClassName($class);
+        $tab = $this->getInstanceFromClassName($class);
         $tab->active = false !== $name;
         $tab->class_name = $class;
         $tab->name = [];
@@ -61,7 +61,7 @@ class TabsHelper
                 $tab->icon = $icon;
             }
 
-            $parentTab = \Tab::getInstanceFromClassName($parent);
+            $parentTab = $this->getInstanceFromClassName($parent);
             $tab->id_parent = $parentTab->id;
         }
 
@@ -79,11 +79,24 @@ class TabsHelper
      */
     public function uninstallTab($class)
     {
-        $tab = \Tab::getInstanceFromClassName($class);
+        $tab = $this->getInstanceFromClassName($class);
         if (!\Validate::isLoadedObject($tab)) {
             return true;
         }
 
         return $tab->delete();
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return \Tab
+     */
+    public function getInstanceFromClassName($className)
+    {
+        /*
+         * @var Tab|object $tab
+         */
+        return \Tab::getInstanceFromClassName($className);
     }
 }

--- a/alma/lib/Helpers/Admin/TabsHelper.php
+++ b/alma/lib/Helpers/Admin/TabsHelper.php
@@ -37,6 +37,7 @@ class TabsHelper
      * @param null $icon fontAwesome class icon
      *
      * @return bool if save successfully
+     *
      * @throws \PrestaShopException
      */
     public function installTab($moduleName, $class, $name, $parent = null, $position = null, $icon = null)
@@ -66,13 +67,14 @@ class TabsHelper
 
         $tab->module = $moduleName;
 
-
         return $tab->save();
     }
 
     /**
      * @params string $class
+     *
      * @return bool
+     *
      * @throws \PrestaShopException
      */
     public function uninstallTab($class)

--- a/alma/lib/Helpers/ApiHelper.php
+++ b/alma/lib/Helpers/ApiHelper.php
@@ -34,10 +34,9 @@ use Alma\PrestaShop\Helpers\Admin\InsuranceHelper;
 class ApiHelper
 {
     /**
-     * @var InsuranceHelper $insuranceHelper
+     * @var InsuranceHelper
      */
     protected $insuranceHelper;
-
 
     public function __construct()
     {
@@ -47,6 +46,7 @@ class ApiHelper
     /**
      * @param $module
      * @param null $alma
+     *
      * @return Merchant|null
      *
      * @throws ActivationException
@@ -96,10 +96,13 @@ class ApiHelper
     /**
      * @param $module
      * @param $merchant
+     *
      * @return void
+     *
      * @throws \PrestaShopException
      */
-    protected function handleInsuranceFlag($module, $merchant) {
+    protected function handleInsuranceFlag($module, $merchant)
+    {
         $isAllowInsurance = $this->saveFeatureFlag(
             $merchant,
             'cms_insurance',
@@ -116,7 +119,7 @@ class ApiHelper
      * @param string $merchantKey
      * @param string $configKey
      *
-     * @return integer
+     * @return int
      */
     protected function saveFeatureFlag($merchant, $merchantKey, $configKey, $formSettingName)
     {

--- a/alma/lib/Helpers/ApiHelper.php
+++ b/alma/lib/Helpers/ApiHelper.php
@@ -108,6 +108,7 @@ class ApiHelper
         );
 
         $this->insuranceHelper->handleBOMenu($module, $isAllowInsurance);
+        $this->insuranceHelper->handleDefaultInsuranceFieldValues($isAllowInsurance);
     }
 
     /**

--- a/alma/lib/Helpers/ConfigurationHelper.php
+++ b/alma/lib/Helpers/ConfigurationHelper.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Helpers;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class ConfigurationHelper
+{
+    /**
+     * Get several configuration values (in one language only).
+     *
+     * @throws \PrestaShopException
+     *
+     * @param array $keys Keys wanted
+     * @param int $idLang Language ID
+     * @param int $idShopGroup
+     * @param int $idShop
+     *
+     * @return array Values
+     */
+    public function getMultiple($keys, $idLang = null, $idShopGroup = null, $idShop = null)
+    {
+        // @todo verify in PS 1.5
+        return \Configuration::getMultiple($keys, $idLang, $idShopGroup, $idShop);
+    }
+
+    /**
+     * Check if the key exists in database
+     *
+     * @param string $configKey
+     *
+     * @return bool
+     */
+    public function hasKey($configKey)
+    {
+        $idShop = \Shop::getContextShopID(true);
+        $idShopGroup = \Shop::getContextShopGroupID(true);
+
+        return \Configuration::hasKey($configKey, null, $idShopGroup, $idShop);
+    }
+
+    /**
+     * Update value in config.
+     *
+     * @param string $configKey
+     * @param string $value
+     *
+     * @return bool
+     */
+    public function updateValue($configKey, $value)
+    {
+        $idShop = \Shop::getContextShopID(true);
+        $idShopGroup = \Shop::getContextShopGroupID(true);
+
+        return \Configuration::updateValue($configKey, $value, false, $idShopGroup, $idShop);
+    }
+
+    /**
+     * Delete the key in database
+     *
+     * @param $configKey
+     *
+     * @return void
+     */
+    public function deleteByName($configKey)
+    {
+        \Configuration::deleteByName($configKey);
+    }
+
+    /**
+     * Delete the keys in database
+     *
+     * @param array $configKeys
+     *
+     * @return void
+     */
+    public function deleteByNames($configKeys)
+    {
+        foreach ($configKeys as $configKey) {
+            $this->deleteByName($configKey);
+        }
+    }
+}

--- a/alma/lib/Helpers/ConfigurationHelper.php
+++ b/alma/lib/Helpers/ConfigurationHelper.php
@@ -44,7 +44,6 @@ class ConfigurationHelper
      */
     public function getMultiple($keys, $idLang = null, $idShopGroup = null, $idShop = null)
     {
-        // @todo verify in PS 1.5
         return \Configuration::getMultiple($keys, $idLang, $idShopGroup, $idShop);
     }
 

--- a/alma/lib/Helpers/ConstantsHelper.php
+++ b/alma/lib/Helpers/ConstantsHelper.php
@@ -60,6 +60,22 @@ class ConstantsHelper
     const ALMA_ALLOW_INSURANCE = 'ALMA_ALLOW_INSURANCE';
 
     const ALMA_ACTIVATE_INSURANCE = 'ALMA_ACTIVATE_INSURANCE';
+    const ALMA_SHOW_INSURANCE_WIDGET_PRODUCT = 'ALMA_SHOW_INSURANCE_WIDGET_PRODUCT';
+    const ALMA_SHOW_INSURANCE_WIDGET_CART = 'ALMA_SHOW_INSURANCE_WIDGET_CART';
+    const ALMA_SHOW_INSURANCE_POPUP_CART = 'ALMA_SHOW_INSURANCE_POPUP_CART';
 
     const BO_CONTROLLER_INSURANCE_CLASSNAME = 'AdminAlmaInsurance';
+    const BO_URL_IFRAME_CONFIGURATION_INSURANCE = 'https://poc-iframe.dev.almapay.com/almaBackOfficeConfiguration.html';
+
+    /**
+     * Insurance form fields
+     *
+     * @var string[]
+     */
+    public static $fieldsBoInsurance = [
+        self::ALMA_ACTIVATE_INSURANCE,
+        self::ALMA_SHOW_INSURANCE_WIDGET_PRODUCT,
+        self::ALMA_SHOW_INSURANCE_WIDGET_CART,
+        self::ALMA_SHOW_INSURANCE_POPUP_CART,
+    ];
 }

--- a/alma/lib/Helpers/ConstantsHelper.php
+++ b/alma/lib/Helpers/ConstantsHelper.php
@@ -65,7 +65,7 @@ class ConstantsHelper
     const ALMA_SHOW_INSURANCE_POPUP_CART = 'ALMA_SHOW_INSURANCE_POPUP_CART';
 
     const BO_CONTROLLER_INSURANCE_CLASSNAME = 'AdminAlmaInsurance';
-    const BO_URL_IFRAME_CONFIGURATION_INSURANCE = 'https://poc-iframe.dev.almapay.com/almaBackOfficeConfiguration.html';
+    const BO_URL_IFRAME_CONFIGURATION_INSURANCE = 'https://protect.staging.almapay.com/almaBackOfficeConfiguration.html';
 
     /**
      * Insurance form fields

--- a/alma/lib/Helpers/ConstantsHelper.php
+++ b/alma/lib/Helpers/ConstantsHelper.php
@@ -66,6 +66,7 @@ class ConstantsHelper
 
     const BO_CONTROLLER_INSURANCE_CLASSNAME = 'AdminAlmaInsurance';
     const BO_URL_IFRAME_CONFIGURATION_INSURANCE = 'https://protect.staging.almapay.com/almaBackOfficeConfiguration.html';
+    const DOMAIN_URL_INSURANCE = 'https://protect.staging.almapay.com';
 
     /**
      * Insurance form fields

--- a/alma/lib/Helpers/ConstantsHelper.php
+++ b/alma/lib/Helpers/ConstantsHelper.php
@@ -65,8 +65,8 @@ class ConstantsHelper
     const ALMA_SHOW_INSURANCE_POPUP_CART = 'ALMA_SHOW_INSURANCE_POPUP_CART';
 
     const BO_CONTROLLER_INSURANCE_CLASSNAME = 'AdminAlmaInsurance';
-    const BO_URL_IFRAME_CONFIGURATION_INSURANCE = 'https://protect.staging.almapay.com/almaBackOfficeConfiguration.html';
     const DOMAIN_URL_INSURANCE = 'https://protect.staging.almapay.com';
+    const BO_URL_IFRAME_CONFIGURATION_INSURANCE = self::DOMAIN_URL_INSURANCE . '/almaBackOfficeConfiguration.html';
 
     /**
      * Insurance form fields

--- a/alma/lib/Helpers/SettingsHelper.php
+++ b/alma/lib/Helpers/SettingsHelper.php
@@ -84,8 +84,23 @@ class SettingsHelper
     }
 
     /**
+     * Check if the key exists in database
+     *
+     * @param string $configKey
+     * @return bool
+     */
+    public function hasKey($configKey)
+    {
+        $idShop = \Shop::getContextShopID(true);
+        $idShopGroup = \Shop::getContextShopGroupID(true);
+
+        return \Configuration::hasKey($configKey, null, $idShopGroup, $idShop);
+    }
+
+    /**
      * Update value in config.
      *
+     * @deprecated use updateValueV2
      * @param string $configKey
      * @param string $value
      *
@@ -96,6 +111,46 @@ class SettingsHelper
         $idShop = \Shop::getContextShopID(true);
         $idShopGroup = \Shop::getContextShopGroupID(true);
         \Configuration::updateValue($configKey, $value, false, $idShopGroup, $idShop);
+    }
+
+    /**
+     * Update value in config.
+     *
+     * @param string $configKey
+     * @param string $value
+     *
+     * @return bool
+     */
+    public function updateValueV2($configKey, $value)
+    {
+        $idShop = \Shop::getContextShopID(true);
+        $idShopGroup = \Shop::getContextShopGroupID(true);
+
+        return \Configuration::updateValue($configKey, $value, false, $idShopGroup, $idShop);
+    }
+
+    /**
+     * Delete the key in database
+     *
+     * @param $configKey
+     * @return void
+     */
+    public function deleteByName($configKey)
+    {
+        \Configuration::deleteByName($configKey);
+    }
+
+    /**
+     * Delete the keys in database
+     *
+     * @param array $configKeys
+     * @return void
+     */
+    public function deleteByNames($configKeys)
+    {
+        foreach ($configKeys as $configKey) {
+            $this->deleteByName($configKey);
+        }
     }
 
     /**
@@ -149,6 +204,10 @@ class SettingsHelper
             'ALMA_CATEGORIES_WDGT_NOT_ELGBL',
             ConstantsHelper::ALMA_ALLOW_INPAGE,
             ConstantsHelper::ALMA_ALLOW_INSURANCE,
+            ConstantsHelper::ALMA_ACTIVATE_INSURANCE,
+            ConstantsHelper::ALMA_SHOW_INSURANCE_WIDGET_PRODUCT,
+            ConstantsHelper::ALMA_SHOW_INSURANCE_WIDGET_CART,
+            ConstantsHelper::ALMA_SHOW_INSURANCE_POPUP_CART,
         ];
 
         foreach ($configKeys as $configKey) {

--- a/alma/lib/Helpers/SettingsHelper.php
+++ b/alma/lib/Helpers/SettingsHelper.php
@@ -84,23 +84,10 @@ class SettingsHelper
     }
 
     /**
-     * Check if the key exists in database
-     *
-     * @param string $configKey
-     * @return bool
-     */
-    public function hasKey($configKey)
-    {
-        $idShop = \Shop::getContextShopID(true);
-        $idShopGroup = \Shop::getContextShopGroupID(true);
-
-        return \Configuration::hasKey($configKey, null, $idShopGroup, $idShop);
-    }
-
-    /**
      * Update value in config.
      *
-     * @deprecated use updateValueV2
+     * @deprecated use ConfigurationHelper::updateValue
+     *
      * @param string $configKey
      * @param string $value
      *
@@ -111,46 +98,6 @@ class SettingsHelper
         $idShop = \Shop::getContextShopID(true);
         $idShopGroup = \Shop::getContextShopGroupID(true);
         \Configuration::updateValue($configKey, $value, false, $idShopGroup, $idShop);
-    }
-
-    /**
-     * Update value in config.
-     *
-     * @param string $configKey
-     * @param string $value
-     *
-     * @return bool
-     */
-    public function updateValueV2($configKey, $value)
-    {
-        $idShop = \Shop::getContextShopID(true);
-        $idShopGroup = \Shop::getContextShopGroupID(true);
-
-        return \Configuration::updateValue($configKey, $value, false, $idShopGroup, $idShop);
-    }
-
-    /**
-     * Delete the key in database
-     *
-     * @param $configKey
-     * @return void
-     */
-    public function deleteByName($configKey)
-    {
-        \Configuration::deleteByName($configKey);
-    }
-
-    /**
-     * Delete the keys in database
-     *
-     * @param array $configKeys
-     * @return void
-     */
-    public function deleteByNames($configKeys)
-    {
-        foreach ($configKeys as $configKey) {
-            $this->deleteByName($configKey);
-        }
     }
 
     /**

--- a/alma/phpunit.ci.xml
+++ b/alma/phpunit.ci.xml
@@ -15,5 +15,12 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
+    <logging>
+        <log type="coverage-clover" target="./build/logs/clover.xml"/>
+    </logging>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory>./tests/Unit/Helper/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/alma/tests/Unit/Helper/InsuranceHelperTest.php
+++ b/alma/tests/Unit/Helper/InsuranceHelperTest.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Helper;
+
+use Alma\PrestaShop\Exceptions\WrongParamsException;
+use Alma\PrestaShop\Helpers\Admin\InsuranceHelper;
+use Alma\PrestaShop\Helpers\Admin\TabsHelper;
+use Alma\PrestaShop\Helpers\ConfigurationHelper;
+use Alma\PrestaShop\Helpers\ConstantsHelper;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceHelperTest extends TestCase
+{
+    /**
+     * @property $tabWithId
+     */
+    protected $tabWithId;
+
+    /**
+     * @property $tabWithoutId
+     */
+    protected $tabWithoutId;
+
+    /**
+     * @property $configurationHelperMock
+     */
+    protected $configurationHelper;
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->module = $this->createMock(\Module::class);
+        $this->tabWithId = new \Tab();
+        $this->tabWithId->id = 1;
+        $this->tabWithoutId = new \Tab();
+        $this->tabHelper = $this->createMock(TabsHelper::class);
+        $this->insuranceHelper = new InsuranceHelper();
+        $this->insuranceHelper->tabsHelper = $this->tabHelper;
+        $this->configurationHelperMock = $this->createMock(ConfigurationHelper::class);
+        $this->insuranceHelper->configurationHelper = $this->configurationHelperMock;
+    }
+
+    protected function tearDown()
+    {
+        $this->tabHelper = null;
+        $this->insuranceHelper = null;
+    }
+
+    /**
+     * @dataProvider dataTabInsuranceDataProvider
+     *
+     * @param $moduleName
+     * @param $class
+     * @param $name
+     * @param $parent
+     * @param $position
+     * @param $icon
+     *
+     * @return void
+     *
+     * @throws \PrestaShopException
+     */
+    public function testTabInstalledWithAllowFlagAndTabNotInstalled($moduleName, $class, $name, $parent, $position, $icon)
+    {
+        $this->tabHelper->method('getInstanceFromClassName')->willReturn($this->tabWithoutId);
+        $this->tabHelper->method('installTab');
+        $this->tabHelper->expects($this->once())->method('installTab')->with(
+            $moduleName,
+            $class,
+            $name,
+            $parent,
+            $position,
+            $icon
+        );
+
+        $this->insuranceHelper->handleBOMenu($this->module, true);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws \PrestaShopException
+     */
+    public function testTabUninstalledWithDisallowFlagAndTabInstalled()
+    {
+        $this->tabHelper->method('getInstanceFromClassName')->willReturn($this->tabWithId);
+        $this->tabHelper->method('uninstallTab');
+        $this->tabHelper->expects($this->once())->method('uninstallTab')->with(ConstantsHelper::BO_CONTROLLER_INSURANCE_CLASSNAME);
+
+        $this->insuranceHelper->handleBOMenu($this->module, false);
+    }
+
+    /**
+     * @dataProvider isAllowInsuranceDataProvider
+     *
+     * @param $isAllowInsurance
+     * @param $tab
+     *
+     * @return void
+     *
+     * @throws \PrestaShopException
+     */
+    public function testTabMethodNotCalledWithWrongParams($isAllowInsurance, $tab)
+    {
+        $this->tabHelper->method('getInstanceFromClassName')->willReturn($tab);
+
+        $this->tabHelper->expects($this->never())->method('installTab');
+        $this->tabHelper->expects($this->never())->method('uninstallTab');
+
+        $this->assertNull($this->insuranceHelper->handleBOMenu($this->module, $isAllowInsurance));
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateValueIfFlagIsAllowAndInsuranceIsDisabled()
+    {
+        $this->configurationHelperMock->method('hasKey')->willReturn(false);
+        $this->configurationHelperMock->expects($this->exactly(4))->method('updateValue')->withConsecutive(
+            [ConstantsHelper::ALMA_ACTIVATE_INSURANCE, 0],
+            [ConstantsHelper::ALMA_SHOW_INSURANCE_WIDGET_PRODUCT, 0],
+            [ConstantsHelper::ALMA_SHOW_INSURANCE_WIDGET_CART, 0],
+            [ConstantsHelper::ALMA_SHOW_INSURANCE_POPUP_CART, 0]
+        );
+        $this->insuranceHelper->handleDefaultInsuranceFieldValues(true);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteByNamesIfFlagIsDisallowAndInsuranceIsAllow()
+    {
+        $this->configurationHelperMock->method('hasKey')->willReturn(true);
+        $this->configurationHelperMock->expects($this->once())->method('deleteByNames');
+        $this->insuranceHelper->handleDefaultInsuranceFieldValues(false);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws \PrestaShopException
+     */
+    public function testConstructIframeUrlWithParams()
+    {
+        $expected = 'https://protect.staging.almapay.com/almaBackOfficeConfiguration.html?is_insurance_activated=true&is_insurance_on_product_page_activated=false&is_insurance_on_cart_page_activated=false&is_add_to_cart_popup_insurance_activated=true';
+
+        $this->configurationHelperMock->method('getMultiple')->willReturn([
+            'ALMA_ACTIVATE_INSURANCE' => '1',
+            'ALMA_SHOW_INSURANCE_WIDGET_PRODUCT' => '0',
+            'ALMA_SHOW_INSURANCE_WIDGET_CART' => '0',
+            'ALMA_SHOW_INSURANCE_POPUP_CART' => '1',
+        ]);
+        $actual = $this->insuranceHelper->constructIframeUrlWithParams();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws \Alma\PrestaShop\Exceptions\WrongParamsException
+     */
+    public function testSaveConfigInsurance()
+    {
+        $this->configurationHelperMock->method('updateValue');
+        $this->configurationHelperMock->expects($this->exactly(4))->method('updateValue')->withConsecutive(
+            [ConstantsHelper::ALMA_ACTIVATE_INSURANCE, 1],
+            [ConstantsHelper::ALMA_SHOW_INSURANCE_WIDGET_PRODUCT, 1],
+            [ConstantsHelper::ALMA_SHOW_INSURANCE_WIDGET_CART, 0],
+            [ConstantsHelper::ALMA_SHOW_INSURANCE_POPUP_CART, 1]
+        );
+        $this->insuranceHelper->saveConfigInsurance([
+            'is_insurance_activated' => '1',
+            'is_insurance_on_product_page_activated' => '1',
+            'is_insurance_on_cart_page_activated' => '0',
+            'is_add_to_cart_popup_insurance_activated' => '1',
+        ], $this->module);
+    }
+
+    /**
+     * @runInSeparateProcess
+     *
+     * @return void
+     *
+     * @throws WrongParamsException
+     */
+    public function testDontSaveConfigInsuranceWithWrongKeysAndThrowException()
+    {
+        $this->configurationHelperMock->method('updateValue');
+        $this->configurationHelperMock->expects($this->never())->method('updateValue');
+        $this->expectException(WrongParamsException::class);
+        $this->insuranceHelper->saveConfigInsurance([
+            'is_insurance_activated' => '1',
+            'is_insurance_on_product_page_activated' => '1',
+            'is_insurance_on_cart_page_activated' => '0',
+            'is_add_to_cart_popup_insurance_activated' => '1',
+            'key_false' => '0',
+        ], $this->module);
+    }
+
+    /**
+     * @return array
+     */
+    public function isAllowInsuranceDataProvider()
+    {
+        $tabWithoutId = new \Tab();
+        $tabWithId = new \Tab();
+        $tabWithId->id = 1;
+
+        return [
+            'is allow' => [
+                'isAllowInsurance' => true,
+                'tab' => $tabWithId,
+            ],
+            'is disallow' => [
+                'isDisallowInsurance' => false,
+                'tab' => $tabWithoutId,
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function dataTabInsuranceDataProvider()
+    {
+        return [
+            'install tab' => [
+                'moduleName' => 'alma',
+                'class' => 'AdminAlmaInsurance',
+                'name' => null,
+                'parent' => 'alma',
+                'position' => 3,
+                'icon' => 'security',
+            ],
+        ];
+    }
+}

--- a/alma/views/css/admin/almaPage.css
+++ b/alma/views/css/admin/almaPage.css
@@ -238,3 +238,9 @@ fieldset .form-alma.disabled::before{
     border: 1px solid #b5bdc0;
     background-color: #ddd;
 }
+
+.alma-insurance-iframe{
+    border: 0;
+    padding: 0;
+    margin: 0;
+}

--- a/alma/views/templates/admin/insurance.tpl
+++ b/alma/views/templates/admin/insurance.tpl
@@ -21,11 +21,10 @@
 
 <script type="module">
     let currentResolve
-
     let save = document.getElementById('alma_config_form_submit_btn');
     save.addEventListener('click', async () => {
         let messageCallback = (e) => {
-            if (currentResolve) {
+            if (currentResolve && e.origin === '{Alma\PrestaShop\Helpers\ConstantsHelper::DOMAIN_URL_INSURANCE}') {
                 currentResolve(e.data)
                 $.ajax({
                     type: 'POST',

--- a/alma/views/templates/admin/insurance.tpl
+++ b/alma/views/templates/admin/insurance.tpl
@@ -1,7 +1,21 @@
-<div class="alma--insurance-iframe">
-    <iframe id="config-alma-iframe" width="100%" height="100%" src="https://poc-iframe.dev.almapay.com/backOffice.html?option1=true"></iframe>
+<div class="panel" id="fieldset_8_8">
+    <div class="panel-heading">
+        <img src="/modules/alma/views/img/logos/alma_tiny.svg" alt="Iframe Insurance">Iframe Insurance
+    </div>
+    <div class="form-wrapper">
+
+        <div class="form-group">
+            <div class="alma--insurance-iframe">
+                <iframe id="config-alma-iframe" class="alma-insurance-iframe" width="100%" height="100%" src="https://poc-iframe.dev.almapay.com/backOffice.html?option1=true"></iframe>
+            </div>
+        </div>
+    </div><!-- /.form-wrapper -->
+    <div class="panel-footer">
+        <button type="submit" value="1" id="alma_config_form_submit_btn_8" name="alma_config_form" class="button btn btn-default pull-right">
+            <i class="process-icon-save"></i> Save
+        </button>
+    </div>
 </div>
-<button>Save</button>
 <script type="module">
     window.addEventListener('message', async function(event) {
         try {

--- a/alma/views/templates/admin/insurance.tpl
+++ b/alma/views/templates/admin/insurance.tpl
@@ -6,7 +6,7 @@
 
         <div class="form-group">
             <div class="alma--insurance-iframe">
-                <iframe id="config-alma-iframe" class="alma-insurance-iframe" width="100%" height="100%" src="https://poc-iframe.dev.almapay.com/backOffice.html?option1=true"></iframe>
+                <iframe id="config-alma-iframe" class="alma-insurance-iframe" width="100%" height="100%" src="{Alma\PrestaShop\Helpers\ConstantsHelper::BO_URL_IFRAME_CONFIGURATION_INSURANCE}"></iframe>
             </div>
         </div>
     </div><!-- /.form-wrapper -->

--- a/alma/views/templates/admin/insurance.tpl
+++ b/alma/views/templates/admin/insurance.tpl
@@ -20,18 +20,13 @@
 </div>
 
 <script type="module">
-    const almaGetInsuranceConfigurationData = () => {
-        const almaInsuranceIframe = document.getElementById('config-alma-iframe').contentWindow;
-        almaInsuranceIframe.postMessage('send_alma_data_insurance_config', '*')
-    }
-
-    // TODO : fix the multiple request
+    let currentResolve
 
     let save = document.getElementById('alma_config_form_submit_btn');
     save.addEventListener('click', async () => {
-        window.getData = almaGetInsuranceConfigurationData();
-        window.addEventListener('message', (e) => {
-            if (e.origin === 'https://poc-iframe.dev.almapay.com') {
+        let messageCallback = (e) => {
+            if (currentResolve) {
+                currentResolve(e.data)
                 $.ajax({
                     type: 'POST',
                     url: 'ajax-tab.php',
@@ -54,12 +49,21 @@
                         }
                     });
             }
-        });
+        }
 
+        const almaGetInsuranceConfigurationData = () => {
+            const iframe = document.getElementById('config-alma-iframe').contentWindow
+
+            const promise = new Promise((resolve) => {
+                currentResolve = resolve
+                iframe.postMessage('send value', '*')
+                window.addEventListener('message', messageCallback)
+            }).then((data) => {
+                currentResolve = null
+                window.removeEventListener('message', messageCallback)
+            })
+        }
+        window.getData = almaGetInsuranceConfigurationData
         almaGetInsuranceConfigurationData()
     });
-
-
-
-
 </script>

--- a/alma/views/templates/admin/insurance.tpl
+++ b/alma/views/templates/admin/insurance.tpl
@@ -1,3 +1,6 @@
+<div class="alert alert-success alma-success"  style="display:none" data-alert="success"></div>
+<div class="alert alert-danger alma-danger" style="display:none" data-alert="danger"></div>
+
 <div class="panel" id="fieldset_0">
     <div class="panel-heading">
         <img src="/modules/alma/views/img/logos/alma_tiny.svg" alt="{l s='Configuration' mod='alma'}">{l s='Configuration' mod='alma'}
@@ -17,27 +20,46 @@
 </div>
 
 <script type="module">
-    window.addEventListener('message', async function(event) {
-        try {
-            let response = await fetch('ajax-tab.php'
-            {
-                method: "POST"
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                data: {
-                    ajax: true,
-                    controller: 'AdminAlmaInsurance',
-                }
-            });
-            let data = await response.json();
+    const almaGetInsuranceConfigurationData = () => {
+        const almaInsuranceIframe = document.getElementById('config-alma-iframe').contentWindow;
+        almaInsuranceIframe.postMessage('send_alma_data_insurance_config', '*')
+    }
 
-        } catch(e) {
-            console.log(e);
-        }
-        if (event.data) {
-            // faire un check de l'origine
-            console.log('checked', event.data)}
-        }
-    )
+    // TODO : fix the multiple request
+
+    let save = document.getElementById('alma_config_form_submit_btn');
+    save.addEventListener('click', async () => {
+        window.getData = almaGetInsuranceConfigurationData();
+        window.addEventListener('message', (e) => {
+            if (e.origin === 'https://poc-iframe.dev.almapay.com') {
+                $.ajax({
+                    type: 'POST',
+                    url: 'ajax-tab.php',
+                    dataType: 'json',
+                    data: {
+                        ajax: true,
+                        controller: 'AdminAlmaInsurance',
+                        action: 'SaveConfigInsurance',
+                        token: '{$token}',
+                        config: e.data
+                    },
+                })
+                    .success(function(data) {
+                        $('.alma-success').html(data.message).show();
+                    })
+                    .error(function(e) {
+                        if (e.status !== 200) {
+                            let jsonData = JSON.parse(e.responseText);
+                            $('.alma-danger').html(jsonData.error.msg).show();
+                        }
+                    });
+            }
+        });
+
+        almaGetInsuranceConfigurationData()
+    });
+
+
+
+
 </script>

--- a/alma/views/templates/admin/insurance.tpl
+++ b/alma/views/templates/admin/insurance.tpl
@@ -1,21 +1,21 @@
-<div class="panel" id="fieldset_8_8">
+<div class="panel" id="fieldset_0">
     <div class="panel-heading">
-        <img src="/modules/alma/views/img/logos/alma_tiny.svg" alt="Iframe Insurance">Iframe Insurance
+        <img src="/modules/alma/views/img/logos/alma_tiny.svg" alt="{l s='Configuration' mod='alma'}">{l s='Configuration' mod='alma'}
     </div>
     <div class="form-wrapper">
-
         <div class="form-group">
             <div class="alma--insurance-iframe">
-                <iframe id="config-alma-iframe" class="alma-insurance-iframe" width="100%" height="100%" src="{Alma\PrestaShop\Helpers\ConstantsHelper::BO_URL_IFRAME_CONFIGURATION_INSURANCE}"></iframe>
+                <iframe id="config-alma-iframe" class="alma-insurance-iframe" width="100%" height="100%" src="{$iframeUrl}"></iframe>
             </div>
         </div>
     </div><!-- /.form-wrapper -->
     <div class="panel-footer">
-        <button type="submit" value="1" id="alma_config_form_submit_btn_8" name="alma_config_form" class="button btn btn-default pull-right">
-            <i class="process-icon-save"></i> Save
+        <button type="submit" value="1" id="alma_config_form_submit_btn" name="alma_config_form" class="button btn btn-default pull-right">
+            <i class="process-icon-save"></i> {l s='Save' mod='alma'}
         </button>
     </div>
 </div>
+
 <script type="module">
     window.addEventListener('message', async function(event) {
         try {

--- a/alma/views/templates/admin/insurance.tpl
+++ b/alma/views/templates/admin/insurance.tpl
@@ -1,5 +1,29 @@
 <div class="alma--insurance-iframe">
-    JE SUIS UN SUPER IFRAME !
-    MERCI CAMILLE !
-    V2
+    <iframe id="config-alma-iframe" width="100%" height="100%" src="https://poc-iframe.dev.almapay.com/backOffice.html?option1=true"></iframe>
 </div>
+<button>Save</button>
+<script type="module">
+    window.addEventListener('message', async function(event) {
+        try {
+            let response = await fetch('ajax-tab.php'
+            {
+                method: "POST"
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                data: {
+                    ajax: true,
+                    controller: 'AdminAlmaInsurance',
+                }
+            });
+            let data = await response.json();
+
+        } catch(e) {
+            console.log(e);
+        }
+        if (event.data) {
+            // faire un check de l'origine
+            console.log('checked', event.data)}
+        }
+    )
+</script>


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/MPP-718/prestashop-use-mocked-iframe-to-test-to-integrate-config-in-bo)

### Code changes

- Retrieve data from the DB to send to the iframe [DOC](https://www.notion.so/almapay/CMS-Widgets-iFrame-s-integrations-11cf4ad1a969435a8ed61d58aadab7b3?pvs=4#e114f68b29cf4d6ba0e28a6311deaaa7)
- Send data to iframe to display form with values
- When the save button in the BO form is clicked, the iframe is called up and returns the data
- We register them in DB
- Display a KO or OK return message

### How to test

- Activate Flag Insurance in your Merchant ID
- Configure the module Alma
- Show the new Insurance tab in the menu Alma
- Save and Change your new configuration in the BO widget Insurance

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)