### PR TITLE
Validation module for release 3.1.0

### DIFF
--- a/alma/controllers/admin/AdminAlmaCategories.php
+++ b/alma/controllers/admin/AdminAlmaCategories.php
@@ -23,6 +23,10 @@
  */
 use Alma\PrestaShop\Helpers\SettingsHelper;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class AdminAlmaCategoriesController extends ModuleAdminController
 {
     public static $excludedCategories = [];

--- a/alma/controllers/admin/AdminAlmaConfig.php
+++ b/alma/controllers/admin/AdminAlmaConfig.php
@@ -23,6 +23,10 @@
  */
 use Alma\PrestaShop\Helpers\LinkHelper;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class AdminAlmaConfigController extends ModuleAdminController
 {
     public function init()

--- a/alma/controllers/admin/AdminAlmaRefunds.php
+++ b/alma/controllers/admin/AdminAlmaRefunds.php
@@ -30,6 +30,10 @@ use Alma\PrestaShop\Helpers\RefundHelper;
 use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Traits\AjaxTrait;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class AdminAlmaRefundsController extends ModuleAdminController
 {
     use AjaxTrait;

--- a/alma/controllers/admin/AdminAlmaShareOfCheckout.php
+++ b/alma/controllers/admin/AdminAlmaShareOfCheckout.php
@@ -21,6 +21,10 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class AdminAlmaShareOfCheckoutController extends ModuleAdminController
 {
     use Alma\PrestaShop\Traits\AjaxTrait;

--- a/alma/controllers/front/ipn.php
+++ b/alma/controllers/front/ipn.php
@@ -21,9 +21,6 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
 
 use Alma\PrestaShop\API\MismatchException;
 use Alma\PrestaShop\Exceptions\RefundException;
@@ -31,6 +28,10 @@ use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Traits\AjaxTrait;
 use Alma\PrestaShop\Validators\PaymentValidation;
 use Alma\PrestaShop\Validators\PaymentValidationError;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 /**
  * AlmaIpnModuleFrontController

--- a/alma/controllers/front/payment.php
+++ b/alma/controllers/front/payment.php
@@ -21,9 +21,6 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
 
 use Alma\API\ParamsError;
 use Alma\PrestaShop\Helpers\ClientHelper;
@@ -31,6 +28,10 @@ use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Model\PaymentData;
 use Alma\PrestaShop\Traits\AjaxTrait;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 class AlmaPaymentModuleFrontController extends ModuleFrontController
 {

--- a/alma/controllers/front/validation.php
+++ b/alma/controllers/front/validation.php
@@ -21,13 +21,14 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
 
 use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Validators\PaymentValidation;
 use Alma\PrestaShop\Validators\PaymentValidationError;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 class AlmaValidationModuleFrontController extends ModuleFrontController
 {

--- a/alma/exceptions/ActivationException.php
+++ b/alma/exceptions/ActivationException.php
@@ -27,6 +27,10 @@ namespace Alma\PrestaShop\Exceptions;
 use Alma\PrestaShop\Helpers\LinkHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class ActivationException extends AlmaException
 {
     /**

--- a/alma/exceptions/AlmaException.php
+++ b/alma/exceptions/AlmaException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Exceptions;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class AlmaException extends \Exception
 {
 }

--- a/alma/exceptions/ApiMerchantsException.php
+++ b/alma/exceptions/ApiMerchantsException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Exceptions;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class ApiMerchantsException extends AlmaException
 {
 }

--- a/alma/exceptions/ClientException.php
+++ b/alma/exceptions/ClientException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Exceptions;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class ClientException extends AlmaException
 {
 }

--- a/alma/exceptions/MissingParameterException.php
+++ b/alma/exceptions/MissingParameterException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Exceptions;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class MissingParameterException extends AlmaException
 {
     /**

--- a/alma/exceptions/PaymentNotFoundException.php
+++ b/alma/exceptions/PaymentNotFoundException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Exceptions;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class PaymentNotFoundException extends AlmaException
 {
 }

--- a/alma/exceptions/RefundException.php
+++ b/alma/exceptions/RefundException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Exceptions;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class RefundException extends AlmaException
 {
     /**

--- a/alma/exceptions/RenderPaymentException.php
+++ b/alma/exceptions/RenderPaymentException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Exceptions;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class RenderPaymentException extends AlmaException
 {
 }

--- a/alma/exceptions/ShareOfCheckoutException.php
+++ b/alma/exceptions/ShareOfCheckoutException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Exceptions;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class ShareOfCheckoutException extends AlmaException
 {
 }

--- a/alma/exceptions/WrongCredentialsException.php
+++ b/alma/exceptions/WrongCredentialsException.php
@@ -27,6 +27,10 @@ namespace Alma\PrestaShop\Exceptions;
 use Alma\PrestaShop\Helpers\LinkHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class WrongCredentialsException extends AlmaException
 {
     /**

--- a/alma/lib/API/MismatchException.php
+++ b/alma/lib/API/MismatchException.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\API;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 /**
  * MismatchException
  */

--- a/alma/lib/Helpers/ApiHelper.php
+++ b/alma/lib/Helpers/ApiHelper.php
@@ -30,6 +30,10 @@ use Alma\PrestaShop\Exceptions\ApiMerchantsException;
 use Alma\PrestaShop\Exceptions\WrongCredentialsException;
 use Alma\PrestaShop\Forms\InpageAdminFormBuilder;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class ApiHelper
 {
     /**

--- a/alma/lib/Helpers/CustomFieldsHelper.php
+++ b/alma/lib/Helpers/CustomFieldsHelper.php
@@ -24,13 +24,13 @@
 
 namespace Alma\PrestaShop\Helpers;
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
 use Alma\PrestaShop\Forms\ExcludedCategoryAdminFormBuilder;
 use Alma\PrestaShop\Forms\PaymentButtonAdminFormBuilder;
 use Alma\PrestaShop\Forms\PaymentOnTriggeringAdminFormBuilder;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 /**
  * Class CustomFieldsHelper

--- a/alma/lib/Helpers/EligibilityHelper.php
+++ b/alma/lib/Helpers/EligibilityHelper.php
@@ -24,14 +24,14 @@
 
 namespace Alma\PrestaShop\Helpers;
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
 use Alma\API\Endpoints\Results\Eligibility;
 use Alma\API\RequestError;
 use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Model\PaymentData;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 class EligibilityHelper
 {

--- a/alma/lib/Helpers/SettingsCustomFieldsHelper.php
+++ b/alma/lib/Helpers/SettingsCustomFieldsHelper.php
@@ -24,13 +24,13 @@
 
 namespace Alma\PrestaShop\Helpers;
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
 use Alma\PrestaShop\Forms\ExcludedCategoryAdminFormBuilder;
 use Alma\PrestaShop\Forms\PaymentButtonAdminFormBuilder;
 use Alma\PrestaShop\Forms\PaymentOnTriggeringAdminFormBuilder;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 /**
  * Class SettingsCustomFields

--- a/alma/lib/Hooks/FrontendHookController.php
+++ b/alma/lib/Hooks/FrontendHookController.php
@@ -24,11 +24,11 @@
 
 namespace Alma\PrestaShop\Hooks;
 
+use Alma\PrestaShop\Helpers\SettingsHelper;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
-
-use Alma\PrestaShop\Helpers\SettingsHelper;
 
 abstract class FrontendHookController extends HookController
 {

--- a/alma/lib/Logger.php
+++ b/alma/lib/Logger.php
@@ -24,13 +24,13 @@
 
 namespace Alma\PrestaShop;
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 class Logger extends AbstractLogger
 {

--- a/alma/lib/Model/CartData.php
+++ b/alma/lib/Model/CartData.php
@@ -24,14 +24,14 @@
 
 namespace Alma\PrestaShop\Model;
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
 use Alma\PrestaShop\Helpers\PriceHelper;
 use Alma\PrestaShop\Helpers\ProductHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Repositories\ProductRepository;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 class CartData
 {

--- a/alma/lib/Model/PaymentData.php
+++ b/alma/lib/Model/PaymentData.php
@@ -24,10 +24,6 @@
 
 namespace Alma\PrestaShop\Model;
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
 use Alma\API\Lib\PaymentValidator;
 use Alma\API\ParamsError;
 use Alma\PrestaShop\Helpers\CarrierHelper;
@@ -38,6 +34,10 @@ use Alma\PrestaShop\Helpers\SettingsCustomFieldsHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Repositories\ProductRepository;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 class PaymentData
 {

--- a/alma/lib/Model/ShippingData.php
+++ b/alma/lib/Model/ShippingData.php
@@ -24,11 +24,11 @@
 
 namespace Alma\PrestaShop\Model;
 
+use Alma\PrestaShop\Helpers\PriceHelper;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
-
-use Alma\PrestaShop\Helpers\PriceHelper;
 
 class ShippingData
 {

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -32,6 +32,10 @@ use Alma\PrestaShop\Helpers\RefundHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Logger;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class PaymentValidation
 {
     /** @var \Context */

--- a/alma/lib/Validators/PaymentValidationError.php
+++ b/alma/lib/Validators/PaymentValidationError.php
@@ -24,6 +24,10 @@
 
 namespace Alma\PrestaShop\Validators;
 
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 class PaymentValidationError extends \Exception
 {
     public $cart;

--- a/alma/lib/smarty.php
+++ b/alma/lib/smarty.php
@@ -21,6 +21,10 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
 if (class_exists('\Context')) {
     $smarty = \Context::getContext()->smarty;
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/MPP-838/validation-module-for-release-310)

### Code changes

To ensure that PHP files are executed in the PrestaShop context, you must add the following code to the start of all PHP files: if (!defined('_PS_VERSION_')) { exit; }

### How to test

Make E2E Test

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->