### PR TITLE
hotfix: Pay now is broken if In-Page is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.1
+
+- fix: Pay now if In-Page is disabled
+
 ## v3.1.0
 
 - feat: In-Page: Now we use the setForm in payment option and refactored to vanilla Javascript (we don't use Jquery anymore)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.1.1
 
-- fix: Pay now if In-Page is disabled
+- hotfix: Pay now is broken if In-Page is disabled
 
 ## v3.1.0
 

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -30,7 +30,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 
 class Alma extends PaymentModule
 {
-    const VERSION = '3.1.0';
+    const VERSION = '3.1.1';
 
     public $_path;
     public $local_path;
@@ -65,7 +65,7 @@ class Alma extends PaymentModule
     {
         $this->name = 'alma';
         $this->tab = 'payments_gateways';
-        $this->version = '3.1.0';
+        $this->version = '3.1.1';
         $this->author = 'Alma';
         $this->need_instance = false;
         $this->bootstrap = true;

--- a/alma/controllers/hook/PaymentOptionsHookController.php
+++ b/alma/controllers/hook/PaymentOptionsHookController.php
@@ -142,7 +142,6 @@ class PaymentOptionsHookController extends FrontendHookController
             if ($isPayNow) {
                 $textPaymentButton = SettingsCustomFieldsHelper::getPayNowButtonTitleByLang($idLang);
                 $descPaymentButton = SettingsCustomFieldsHelper::getPayNowButtonDescriptionByLang($idLang);
-                $isInPageEnabled = true;
             }
 
             $action = $this->context->link->getModuleLink(

--- a/alma/views/templates/hook/_partials/feePlan.tpl
+++ b/alma/views/templates/hook/_partials/feePlan.tpl
@@ -27,7 +27,9 @@
 {capture assign='total'}{l s='Total' mod='alma'}{/capture}
 {capture assign='firstAmount'}{almaFormatPrice cents=$plans[0].total_amount}{/capture}
 {capture assign='fees'}{almaFormatPrice cents=$plans[0].customer_fee}{/capture}
-{capture assign='nextAmounts'}{almaFormatPrice cents=$plans[1].total_amount}{/capture}
+{if $installmentsCount > 1}
+    {capture assign='nextAmounts'}{almaFormatPrice cents=$plans[1].total_amount}{/capture}
+{/if}
 
 {if $oneLiner}
     <span class="alma-fee-plan--description">


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/MPP-903/🏃-p1x-tresors-dargan)

### Code changes

We don't display form for in page in Pay now Payment

### How to test

Disable In-page and make a payment Pay now

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->