### PR TITLE
[develop] Fix css notification SOC in module page

### DIFF
--- a/alma/views/css/admin/almaPage.css
+++ b/alma/views/css/admin/almaPage.css
@@ -160,7 +160,8 @@ fieldset .form-alma.disabled::before{
     top: 49%;
 }
 
-.bootstrap .alma.alert {
+.bootstrap .alma.alert,
+#main-div .alma.alert{
     font-family: 'Public-Sans', sans-serif;
     font-weight: 300;
     padding-left: 180px;
@@ -171,53 +172,64 @@ fieldset .form-alma.disabled::before{
     border-radius: 4px;
 }
 
-.bootstrap .alma.alert h2, .bootstrap .alma.alert .btn {
+.bootstrap .alma.alert h2, .bootstrap .alma.alert .btn,
+#main-div .alma.alert h2, #main-div .alma.alert .btn{
     font-family: 'Eina04-Bold', sans-serif;
     font-weight: 400;
 }
 
-.bootstrap .alma.alert b{
+.bootstrap .alma.alert b,
+#main-div .alma.alert b{
     font-weight: 600;
 }
 
-.bootstrap .alma.alert .h2, .bootstrap .alma.alert h2 {
+.bootstrap .alma.alert .h2, .bootstrap .alma.alert h2,
+#main-div .alma.alert .h2, #main-div .alma.alert h2{
     font-size: 24px;
 }
 
-.bootstrap .alma.alert.alert-info {
+.bootstrap .alma.alert.alert-info,
+#main-div .alma.alert.alert-info{
     background-color: #E9F4FF;
     border: 1px solid #E1E4E6;
     color: #00425D;
     font-size: 16px;
 }
 
-.bootstrap .alma.alert.alert-info:before {
+.bootstrap .alma.alert.alert-info:before,
+#main-div .alma.alert.alert-info:before{
     content: '';
 }
 
-.bootstrap .alma.alert ul {
+.bootstrap .alma.alert ul,
+#main-div .alma.alert ul{
     list-style-type: disc;
     padding-left: 40px;
 }
 
-.bootstrap .alma.alert.alert-info a:not(.btn) {
+.bootstrap .alma.alert.alert-info a:not(.btn),
+#main-div .alma.alert.alert-info a:not(.btn){
     color: #00425D;
     text-decoration: underline;
 }
 
-.bootstrap .alma.alert .btn {
+.bootstrap .alma.alert .btn,
+#main-div .alma.alert .btn{
     line-height: 1;
     padding: 12px 16px;
     border: 2px solid transparent;
     border-radius: 4px;
     text-transform: uppercase;
+    text-decoration: none;
 }
-.bootstrap .alma.alert .btn.btn-default {
+.bootstrap .alma.alert .btn.btn-default,
+#main-div .alma.alert .btn.btn-default{
     background: #FFFFFF;
     border-color: #00425D;
     color: #00425D;
 }
-.bootstrap .alma.alert .btn.btn-primary {
+.bootstrap .alma.alert .btn.btn-primary,
+#main-div .alma.alert .btn.btn-primary{
     background: #00425D;
     border-color: #00425D;
     color: #FFFFFF;


### PR DESCRIPTION
### Reason for change

[Merchant issue](https://github.com/alma/alma-installments-prestashop/issues/241)
[Linear task](https://linear.app/almapay/issue/MPP-905/fix-display-notification-soc-in-module-page)

### Code changes

Add sublevel to selector the CSS notification block SOC

### How to test

Install our module
Enable the live mode
Go to the Module Manager
And see the notification of Share of Checkout in the module manager page

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->