### PR TITLE
[develop] Add loader on payment button ps16 if the page isn't completely loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- fix: Add loader payment button on Prestashop 1.6 before loading In-Page
+
 ## v3.1.1
 
 - hotfix: Pay now is broken if In-Page is disabled

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -30,7 +30,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 
 class Alma extends PaymentModule
 {
-    const VERSION = '3.1.1';
+    const VERSION = '3.1.2';
 
     public $_path;
     public $local_path;
@@ -65,7 +65,7 @@ class Alma extends PaymentModule
     {
         $this->name = 'alma';
         $this->tab = 'payments_gateways';
-        $this->version = '3.1.1';
+        $this->version = '3.1.2';
         $this->author = 'Alma';
         $this->need_instance = false;
         $this->bootstrap = true;

--- a/alma/views/css/alma.css
+++ b/alma/views/css/alma.css
@@ -225,6 +225,7 @@ p.payment_module a.disable-arrow-icon {
 .loadingIndicator {
     display: flex;
     flex-direction: column;
+    align-items: center;
     justify-content: center;
     height: 100%;
 }

--- a/alma/views/css/alma.css
+++ b/alma/views/css/alma.css
@@ -206,6 +206,10 @@ p.payment_module a.disable-arrow-icon {
     font-weight: normal;
 }
 
+/**
+-- In-Page
+*/
+
 .alma-loader--wrapper {
     position: fixed;
     left: 0;
@@ -224,4 +228,71 @@ p.payment_module a.disable-arrow-icon {
     align-items: center;
     justify-content: center;
     height: 100%;
+}
+
+a.alma-inpage.ps16.loading::after {
+    content:  "";
+    background: #ccc;
+    opacity: .3;
+}
+
+a.alma-inpage.ps16.loading {
+    height: fit-content;
+    display: flex;
+    column-gap: 6px;
+}
+
+.alma-loader-dot-container {
+    height: fit-content;
+    display: flex;
+    column-gap: 6px;
+}
+
+.dot {
+    width: 8px;
+    height: 8px;
+    background-color: #ff0000;
+    border-radius: 50%;
+}
+
+.one {
+    animation: change-color 1.34s normal 0.1s infinite, bounce 1.34s linear 0s infinite;
+}
+
+.two {
+    animation: change-color 1.34s normal 0.34s infinite, bounce 1.34s linear 0.24s infinite;
+}
+
+.three {
+    animation: change-color 1.34s normal 0.58s infinite, bounce 1.34s linear 0.48s infinite;
+}
+
+@keyframes bounce {
+    0%,
+    40%,
+    63%,
+    100% {
+        transform: translateY(0);
+    }
+
+    26% {
+        transform: translateY(-7px);
+    }
+
+    47% {
+        transform: translateY(1px);
+    }
+}
+
+@keyframes change-color {
+    0%,
+    13%,
+    63%,
+    100% {
+        background-color: #ff0000;
+    }
+
+    40% {
+        background-color: #ff5147;
+    }
 }

--- a/alma/views/css/alma.css
+++ b/alma/views/css/alma.css
@@ -225,33 +225,31 @@ p.payment_module a.disable-arrow-icon {
 .loadingIndicator {
     display: flex;
     flex-direction: column;
-    align-items: center;
     justify-content: center;
     height: 100%;
 }
 
-a.alma-inpage.ps16.loading::after {
-    content:  "";
-    background: #ccc;
-    opacity: .3;
+.alma-inpage.ps16.loading.disabled{
+    pointer-events: none;
 }
 
-a.alma-inpage.ps16.loading {
+.alma-button-with-bkg .alma-loader-dot-container {
     height: fit-content;
-    display: flex;
+    display: flex !important;
     column-gap: 6px;
-}
-
-.alma-loader-dot-container {
-    height: fit-content;
-    display: flex;
-    column-gap: 6px;
+    justify-content: center;
+    margin: auto;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
 }
 
 .dot {
     width: 8px;
     height: 8px;
-    background-color: #ff0000;
+    background-color: #fa5022;
     border-radius: 50%;
 }
 
@@ -289,7 +287,7 @@ a.alma-inpage.ps16.loading {
     13%,
     63%,
     100% {
-        background-color: #ff0000;
+        background-color: #fa5022;
     }
 
     40% {

--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -24,7 +24,18 @@
 let inPage = undefined;
 let paymentButtonEvents = [];
 
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('document.addEventListener DOMContentLoaded');
+});
+
+(function() {
+    console.log('direct function');
+})();
+
+console.log('no load');
+
 window.addEventListener("load", function() {
+    console.log('window.addEventListener load');
     onloadAlma();
 });
 

--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -26,11 +26,15 @@ let paymentButtonEvents = [];
 
 window.addEventListener("load", function() {
     onloadAlma();
+    window.__alma_refreshInpage = onloadAlma;
 });
 
 function removeLoaderButtonPayment(button) {
     button.classList.remove('disabled', 'loading');
-    button.querySelector('.alma-loader-dot-container').remove();
+    let dots = button.querySelector('.alma-loader-dot-container');
+    if (dots) {
+        dots.remove();
+    }
 }
 
 function onloadAlma() {

--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -24,20 +24,14 @@
 let inPage = undefined;
 let paymentButtonEvents = [];
 
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('document.addEventListener DOMContentLoaded');
-});
-
-(function() {
-    console.log('direct function');
-})();
-
-console.log('no load');
-
 window.addEventListener("load", function() {
-    console.log('window.addEventListener load');
     onloadAlma();
 });
+
+function removeLoaderButtonPayment(button) {
+    button.classList.remove('disabled', 'loading');
+    button.querySelector('.alma-loader-dot-container').remove();
+}
 
 function onloadAlma() {
     let radioButtons = document.querySelectorAll('input[name="payment-option"][data-module-name=alma]');
@@ -69,6 +63,7 @@ function onloadAlma() {
     //Prestashop 1.6-
     let paymentButtonsPs16 = document.querySelectorAll(".alma-inpage.ps16");
     paymentButtonsPs16.forEach(function (button) {
+        removeLoaderButtonPayment(button);
         button.addEventListener('click', function (e) {
             e.preventDefault();
             let paymentOptionId = this.getAttribute('id');

--- a/alma/views/templates/hook/_partials/displayPayment_deferred.tpl
+++ b/alma/views/templates/hook/_partials/displayPayment_deferred.tpl
@@ -48,7 +48,14 @@
         <div class="row">
             <div class="col-xs-12">
                 <p class="payment_module">
-                    <a href="{$option.link}" class="{if $option.isInPageEnabled}alma-inpage ps16 loading{/if} {$almaButton} {$iconDisplay}" id="payment-option-{$option.paymentOptionKey}">
+                    <a href="{$option.link}" class="{if $option.isInPageEnabled}alma-inpage ps16 loading disabled{/if} {$almaButton} {$iconDisplay}" id="payment-option-{$option.paymentOptionKey}">
+                        {if $option.isInPageEnabled}
+                            <span class="alma-loader-dot-container">
+                                <span class="dot one"></span>
+                                <span class="dot two"></span>
+                                <span class="dot three"></span>
+                            </span>
+                        {/if}
                         <span class="alma-button--logo">
                             <img src="{$option.logo|escape:'htmlall':'UTF-8'}" alt="Alma">
                         </span>

--- a/alma/views/templates/hook/_partials/displayPayment_deferred.tpl
+++ b/alma/views/templates/hook/_partials/displayPayment_deferred.tpl
@@ -48,7 +48,7 @@
         <div class="row">
             <div class="col-xs-12">
                 <p class="payment_module">
-                    <a href="{$option.link}" class="{if $option.isInPageEnabled}alma-inpage ps16{/if} {$almaButton} {$iconDisplay}" id="payment-option-{$option.paymentOptionKey}">
+                    <a href="{$option.link}" class="{if $option.isInPageEnabled}alma-inpage ps16 loading{/if} {$almaButton} {$iconDisplay}" id="payment-option-{$option.paymentOptionKey}">
                         <span class="alma-button--logo">
                             <img src="{$option.logo|escape:'htmlall':'UTF-8'}" alt="Alma">
                         </span>

--- a/alma/views/templates/hook/_partials/displayPayment_deferred.tpl
+++ b/alma/views/templates/hook/_partials/displayPayment_deferred.tpl
@@ -70,6 +70,7 @@
                             </span>
                         </span>
                     </a>
+                    <script type="text/javascript">window.__alma_refreshInpage && __alma_refreshInpage();</script>
                 </p>
             </div>
             {if $option.isInPageEnabled}

--- a/alma/views/templates/hook/_partials/displayPayment_pnx.tpl
+++ b/alma/views/templates/hook/_partials/displayPayment_pnx.tpl
@@ -72,6 +72,7 @@
                             </span>
                         </span>
                     </a>
+                    <script type="text/javascript">window.__alma_refreshInpage && __alma_refreshInpage();</script>
                 </p>
             </div>
             {if $option.isInPageEnabled}

--- a/alma/views/templates/hook/_partials/displayPayment_pnx.tpl
+++ b/alma/views/templates/hook/_partials/displayPayment_pnx.tpl
@@ -48,7 +48,13 @@
         <div class="row">
             <div class="col-xs-12">
                 <p class="payment_module">
-                    <a href="{$option.link}"  class="{if $option.isInPageEnabled}alma-inpage ps16{/if} {$almaButton} {$iconDisplay}" id="payment-option-{$option.paymentOptionKey}">
+                    <a href="{$option.link}"  class="{if $option.isInPageEnabled}alma-inpage ps16 loading{/if} {$almaButton} {$iconDisplay}" id="payment-option-{$option.paymentOptionKey}">
+                        <span class="alma-loader-dot-container">
+                            <span class="dot one"></span>
+                            <span class="dot two"></span>
+                            <span class="dot three"></span>
+                        </span>
+
                         <span class="alma-button--logo">
                             <img src="{$option.logo|escape:'htmlall':'UTF-8'}" alt="Alma">
                         </span>                        

--- a/alma/views/templates/hook/_partials/displayPayment_pnx.tpl
+++ b/alma/views/templates/hook/_partials/displayPayment_pnx.tpl
@@ -48,12 +48,14 @@
         <div class="row">
             <div class="col-xs-12">
                 <p class="payment_module">
-                    <a href="{$option.link}"  class="{if $option.isInPageEnabled}alma-inpage ps16 loading{/if} {$almaButton} {$iconDisplay}" id="payment-option-{$option.paymentOptionKey}">
-                        <span class="alma-loader-dot-container">
-                            <span class="dot one"></span>
-                            <span class="dot two"></span>
-                            <span class="dot three"></span>
-                        </span>
+                    <a href="{$option.link}" class="{if $option.isInPageEnabled}alma-inpage ps16 loading disabled{/if} {$almaButton} {$iconDisplay}" id="payment-option-{$option.paymentOptionKey}">
+                        {if $option.isInPageEnabled}
+                            <span class="alma-loader-dot-container">
+                                <span class="dot one"></span>
+                                <span class="dot two"></span>
+                                <span class="dot three"></span>
+                            </span>
+                        {/if}
 
                         <span class="alma-button--logo">
                             <img src="{$option.logo|escape:'htmlall':'UTF-8'}" alt="Alma">


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/MPP-937/add-loader-on-payment-button-ps16-if-the-page-isnt-completely-loaded)

### Code changes

Add loader in payment button is page isn't completely loaded to display in-page correctly
https://components.storybook.alma.tech/?path=/story/components-button--button-primary

### How to test

**For Prestashop 1.6**
1st Test
Install our module
Active the in-page option
Active slow 3G in network in console 
And display the payment button with in-page and try to click on it

2nd Test
Active the `one page checkout` in the Preferences > Orders > Order process type, Save
In the front end, make the order, before click to payment button, change the quantity product (with and without eligibility)
And check the loader button and click to pay with Alma and In-Page

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->