### PR TITLE
(JS) : Hide customisation input

### DIFF
--- a/alma/views/js/alma-product.js
+++ b/alma/views/js/alma-product.js
@@ -166,5 +166,35 @@
                 elementInput.setAttribute('value', value);
             }
         }
+
+        // For Insurance, we need to create a customization of the product but this customization should be filled automatically
+        // And should not be displayed for the customer to see
+        function hideInsuranceCustomization() {
+            // First, we find the customization section in the DOM (note: based on className, it's not really stable)
+            const customizationSection = document.getElementsByClassName("product-customization")[0]
+            let customizationItems = undefined
+            if (customizationSection) {
+                // If the customization section exists, we look for the list elements inside
+                customizationItems = customizationSection.getElementsByTagName('li')
+            }
+            // If there is only 1 list element, and if this element includes our insurance_by_alma customization
+            if (customizationItems && customizationItems.length === 1 && customizationItems[0].innerText.includes('insurance_by_alma')) {
+                // Then, we can hide the whole customization section
+                customizationSection.style.display = "none"
+            }
+            // If there are more than 1 list element as customization, it means that the items has others customization that should be displayed
+            if (customizationItems && customizationItems.length > 1) {
+                // So we need to target and hide only our insurance_by_alma customization
+                 for (let i= 0; i < customizationItems.length; i++) {
+                     // If one of the customization listed includes or insurance
+                     if (customizationItems[i].innerText.includes('insurance_by_alma')) {
+                         // Then we remove only the customization listed and keep the other ones
+                         customizationItems[i].style.display = 'none'
+                     }
+                 }
+
+            }
+        }
+        hideInsuranceCustomization()
     });
 })(jQuery);


### PR DESCRIPTION
Fixes MPP-991

This code hides the customization input 
- Hides the whole block if there is only our customization
![Capture d’écran 2023-11-16 à 18 51 26](https://github.com/alma/alma-installments-prestashop/assets/33830009/0af863c4-c8b9-46b3-8e66-b96e3f1398f4)

- Hides only the input if there are other customization
![Capture d’écran 2023-11-16 à 18 51 53](https://github.com/alma/alma-installments-prestashop/assets/33830009/906b4955-390a-4ee1-a098-5905984f9b13)

Note : I'm not sure that selecting elements based on className is really stable, would it be broken for different themes ? I did not find a better way for now :( 