### PR TITLE
[develop] Hotfix/run center 51 in page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- hotfix: Select payment In-Page without open the modal and try to pay with other payment method
+
 ## v3.1.1
 
 - hotfix: Pay now is broken if In-Page is disabled

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -30,7 +30,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 
 class Alma extends PaymentModule
 {
-    const VERSION = '3.1.1';
+    const VERSION = '3.1.2';
 
     public $_path;
     public $local_path;
@@ -65,7 +65,7 @@ class Alma extends PaymentModule
     {
         $this->name = 'alma';
         $this->tab = 'payments_gateways';
-        $this->version = '3.1.1';
+        $this->version = '3.1.2';
         $this->author = 'Alma';
         $this->need_instance = false;
         $this->bootstrap = true;

--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -29,28 +29,29 @@ window.addEventListener("load", function() {
 });
 
 function onloadAlma() {
-    let radioButtons = document.querySelectorAll('input[name="payment-option"][data-module-name=alma]');
+    let radioButtons = document.querySelectorAll('input[name="payment-option"]');
 
     //Prestashop 1.7+
     radioButtons.forEach(function (input) {
         input.addEventListener("change", function () {
             let paymentOptionId = input.getAttribute('id');
             let blockForm = document.querySelector('#pay-with-' + paymentOptionId + '-form');
-            let formInpage = blockForm.querySelector('.alma-inpage');
             removeAlmaEventsFromPaymentButton();
             if (inPage !== undefined) {
                 inPage.unmount();
             }
-            if (this.dataset.moduleName === 'alma' && this.checked && formInpage) {
-                let installment = formInpage.dataset.installment;
-                if (installment === '1') {
-                    blockForm.hidden = true;
+            if (this.dataset.moduleName === 'alma') {
+                let formInpage = blockForm.querySelector('.alma-inpage');
+                if (this.checked && formInpage) {
+                    let installment = formInpage.dataset.installment;
+                    if (installment === '1') {
+                        blockForm.hidden = true;
+                    }
+                    let url = formInpage.dataset.action;
+
+                    inPage = createAlmaIframe(formInpage);
+                    mapPaymentButtonToAlmaPaymentCreation(url, inPage, input);
                 }
-                let url = formInpage.dataset.action;
-
-                inPage = createAlmaIframe(formInpage);
-
-                mapPaymentButtonToAlmaPaymentCreation(url, inPage, input);
             }
         });
     });


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/MPP-1016/🏃-center-51-in-page)

### Code changes

Unmount and remove event for each payment button selector to fix if the modal isn't open before to change payment method

### How to test

**For Prestashop 1.7**
Install our module
Activate In-Page option.
Select payment Alma with In-Page but don't click to Place Order !
And without open the modal, change the payment method and try to pay with the new payment method.

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->