### PR TITLE
[insurance] Explo insurance in quick view (speed buy) in the modal

### DIFF
--- a/alma/controllers/hook/FrontHeaderHookController.php
+++ b/alma/controllers/hook/FrontHeaderHookController.php
@@ -89,7 +89,7 @@ class FrontHeaderHookController extends FrontendHookController
      */
     public function displayWidgetOnProductPage()
     {
-        return SettingsHelper::showProductEligibility() && $this->iAmInProductPage();
+        return SettingsHelper::showProductEligibility() && ($this->iAmInProductPage() || $this->iAmInHomePage());
     }
 
     /**
@@ -106,6 +106,14 @@ class FrontHeaderHookController extends FrontendHookController
     private function iAmInProductPage()
     {
         return 'product' == $this->controller->php_self || 'ProductController' == get_class($this->controller);
+    }
+
+    /**
+     * @return bool
+     */
+    private function iAmInHomePage()
+    {
+        return 'index' == $this->controller->php_self || 'IndexController' == get_class($this->controller);
     }
 
     /**

--- a/alma/lib/Helpers/SettingsHelper.php
+++ b/alma/lib/Helpers/SettingsHelper.php
@@ -622,7 +622,7 @@ class SettingsHelper
      */
     public static function getProductPriceQuerySelector()
     {
-        return static::get('ALMA_PRODUCT_PRICE_SELECTOR', '[itemprop=price],#our_price_display');
+        return static::get('ALMA_PRODUCT_PRICE_SELECTOR', '[itemprop=price],#our_price_display,.modal-body .current-price-value');
     }
 
     /**


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/MPP-1033/explo-insurance-in-quick-view-speed-buy-in-the-modal)

### Code changes

Add asset insurance and the widget in the home page
And add selector css for price for the widget in the default configuration

### How to test

Install the module and enable Insurance.
Go to the home page and click to the quick view on the product home page

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->