### PR TITLE
[insurance] Insurance feature with other theme prestashop

### DIFF
--- a/alma/controllers/hook/DisplayCartExtraProductActionsHookController.php
+++ b/alma/controllers/hook/DisplayCartExtraProductActionsHookController.php
@@ -26,12 +26,12 @@ namespace Alma\PrestaShop\Controllers\Hook;
 
 use Alma\PrestaShop\Exceptions\InsuranceNotFoundException;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
+use Alma\PrestaShop\Helpers\ImageHelper;
 use Alma\PrestaShop\Helpers\InsuranceHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Hooks\FrontendHookController;
 use Alma\PrestaShop\Repositories\AlmaInsuranceProductRepository;
 use Alma\PrestaShop\Repositories\ProductRepository;
-use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Attribute\QueryResult\Attribute;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -56,6 +56,14 @@ class DisplayCartExtraProductActionsHookController extends FrontendHookControlle
      * @var AlmaInsuranceProductRepository
      */
     protected $almaInsuranceProductRepository;
+    /**
+     * @var ImageHelper
+     */
+    protected $imageHelper;
+    /**
+     * @var \Link
+     */
+    protected $link;
 
     /**
      * @param $module
@@ -65,6 +73,8 @@ class DisplayCartExtraProductActionsHookController extends FrontendHookControlle
         $this->insuranceHelper = new InsuranceHelper();
         $this->productRepository = new ProductRepository();
         $this->almaInsuranceProductRepository = new AlmaInsuranceProductRepository();
+        $this->imageHelper = new ImageHelper();
+        $this->link = new \Link;
         parent::__construct($module);
     }
 
@@ -107,7 +117,7 @@ class DisplayCartExtraProductActionsHookController extends FrontendHookControlle
 
         $resultInsurance = [];
 
-        if($product->id !== $insuranceProductId){
+        if ($product->id !== $insuranceProductId) {
             $almaInsurances = $this->almaInsuranceProductRepository->getIdsByCartIdAndShopAndProduct(
                 $product,
                 $cart->id,
@@ -117,22 +127,24 @@ class DisplayCartExtraProductActionsHookController extends FrontendHookControlle
             foreach ($almaInsurances as $almaInsurance) {
                 $almaInsuranceProduct = new \ProductCore((int)$almaInsurance['id_product_insurance']);
                 $almaProductAttribute = new \CombinationCore((int)$almaInsurance['id_product_attribute_insurance']);
+                $idImage = $almaInsuranceProduct->getImages($this->context->language->id)[0]['id_image'];
+                $linkRewrite = $almaInsuranceProduct->link_rewrite[$this->context->language->id];
                 $resultInsurance[$almaInsurance['id_alma_insurance_product']] = [
                     'insuranceProduct' => $almaInsuranceProduct,
                     'insuranceProductAttribute' => $almaProductAttribute,
-                    'price' => $almaInsurance['price']
+                    'price' => $almaInsurance['price'],
+                    'name' => $almaInsuranceProduct->name[$this->context->language->id],
+                    'urlImage' => '//' . $this->link->getImageLink(
+                        $linkRewrite,
+                        $idImage,
+                        $this->imageHelper->getFormattedImageTypeName('cart')
+                    ),
                 ];
             }
-
         }{
-        // Create a link with the good path
-        /**
-         * @var \LinkCore $link
-         */
-        $link = new \Link;
 
-        $ajaxLinkRemoveProduct = $link->getModuleLink('alma','insurance', ["action" => "removeProductFromCart"]);
-        $ajaxLinkRemoveAssociation = $link->getModuleLink('alma','insurance', ["action" => "removeAssociation"]);
+        $ajaxLinkRemoveProduct = $this->link->getModuleLink('alma', 'insurance', ["action" => "removeProductFromCart"]);
+        $ajaxLinkRemoveAssociation = $this->link->getModuleLink('alma', 'insurance', ["action" => "removeAssociation"]);
 
             $this->context->smarty->assign([
                 'idCart' => $cart->id,

--- a/alma/lib/Helpers/ImageHelper.php
+++ b/alma/lib/Helpers/ImageHelper.php
@@ -79,4 +79,18 @@ class ImageHelper
             );
         }
     }
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getFormattedImageTypeName($name)
+    {
+        if (version_compare(_PS_VERSION_, '1.7', '>=')) {
+            return \ImageType::getFormattedName($name);
+        }
+
+        return \ImageType::getFormatedName($name);
+    }
 }

--- a/alma/views/templates/hook/_partials/cartProducts.tpl
+++ b/alma/views/templates/hook/_partials/cartProducts.tpl
@@ -1,7 +1,7 @@
 <div class="row py-1">
-    <div class="col-md-11">
+    <div class="col-md-11 row">
 
-        <div class="product-line-grid-left col-md-2 col-xs-6">
+        <div class="product-line-grid-left col-md-3 col-xs-6">
             <span class="product-image media-middle" style="height:50px;">
                 {if $product.default_image}
                     <img src="{$product.default_image.bySize.cart_default.url}" alt="{$product.name|escape:'quotes'}" loading="lazy">
@@ -34,11 +34,11 @@
                  </span>
             </div>
             <div class="product-line-grid-left col-md-2 col-xs-6">
-                    <span class="product-image media-middle" style="height:50px;">
-                        <img src="/modules/alma/views/img/alma-insurance.jpg">
-                    </span>
+                <span class="product-image media-middle" style="height:50px;">
+                    <img src="{$associatedInsurances[$idAlmaInsuranceProduct]['urlImage']}" alt="{$associatedInsurances[$idAlmaInsuranceProduct]['name']}" loading="lazy">
+                </span>
             </div>
-            <div class="product-line-grid-left col-md-4 col-xs-12">
+            <div class="product-line-grid-left col-md-3 col-xs-12">
                 <div class="product-line-info">
                 {$associatedInsurance.insuranceProduct->getFieldByLang('name', $idLanguage)|escape:'htmlall':'UTF-8'}
                 </div>


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/MPP-1032/test-insurance-feature-with-other-template-prestashop)

### Code changes

We get the insurance image product with the method Prestashop getImageLink
We fix the item insurance in cart page for integration with bootstrap css

### How to test

Install our module, enable Insurance option, Install the WareHouse theme
And try to buy an insurance

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->