### PR TITLE
[insurance] Add the modal confirm on click to the add to cart

### DIFF
--- a/alma/controllers/admin/AdminAlmaInsuranceConfiguration.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceConfiguration.php
@@ -64,9 +64,8 @@ class AdminAlmaInsuranceConfigurationController extends ModuleAdminController
 
         $this->context->smarty->assign([
             'iframeUrl' => $this->insuranceHelper->constructIframeUrlWithParams(),
-            'domainUrl' => $this->insuranceHelper->envUrl(),
+            'domainInsuranceUrl' => $this->insuranceHelper->envUrl(),
             'token' => \Tools::getAdminTokenLite(ConstantsHelper::BO_CONTROLLER_INSURANCE_CONFIGURATION_CLASSNAME),
-            'domainInsuranceUrl' => ConstantsHelper::DOMAIN_URL_INSURANCE,
             'insuranceConfigurationController' => ConstantsHelper::BO_CONTROLLER_INSURANCE_CONFIGURATION_CLASSNAME
 
         ]);

--- a/alma/controllers/admin/AdminAlmaInsuranceConfiguration.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceConfiguration.php
@@ -64,6 +64,7 @@ class AdminAlmaInsuranceConfigurationController extends ModuleAdminController
 
         $this->context->smarty->assign([
             'iframeUrl' => $this->insuranceHelper->constructIframeUrlWithParams(),
+            'domainUrl' => $this->insuranceHelper->envUrl(),
             'token' => \Tools::getAdminTokenLite(ConstantsHelper::BO_CONTROLLER_INSURANCE_CONFIGURATION_CLASSNAME),
             'domainInsuranceUrl' => ConstantsHelper::DOMAIN_URL_INSURANCE,
             'insuranceConfigurationController' => ConstantsHelper::BO_CONTROLLER_INSURANCE_CONFIGURATION_CLASSNAME

--- a/alma/controllers/hook/DisplayProductActionsHookController.php
+++ b/alma/controllers/hook/DisplayProductActionsHookController.php
@@ -28,6 +28,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use Alma\PrestaShop\Helpers\Admin\InsuranceHelper as AdminInsuranceHelper;
+use Alma\PrestaShop\Helpers\ConstantsHelper;
 use Alma\PrestaShop\Helpers\InsuranceHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Hooks\FrontendHookController;
@@ -48,6 +50,7 @@ class DisplayProductActionsHookController extends FrontendHookController
     public function __construct($module)
     {
         $this->insuranceHelper = new InsuranceHelper();
+        $this->adminInsuranceHelper = new AdminInsuranceHelper($module);
         parent::__construct($module);
     }
 
@@ -85,13 +88,11 @@ class DisplayProductActionsHookController extends FrontendHookController
 
         $this->context->smarty->assign([
             'addToCartLink' => $addToCartLink,
-            'oldPSVersion' => $oldPSVersion
+            'oldPSVersion' => $oldPSVersion,
+            'iframeUrl' => $this->adminInsuranceHelper->envUrl() . ConstantsHelper::FO_IFRAME_WIDGET_INSURANCE_PATH,
+            'scriptModalUrl' => $this->adminInsuranceHelper->envUrl() . ConstantsHelper::SCRIPT_MODAL_WIDGET_INSURANCE_PATH,
         ]);
 
-
-        {
         return $this->module->display($this->module->file, 'displayProductActions.tpl');
     }
-}
-
 }

--- a/alma/controllers/hook/DisplayProductActionsHookController.php
+++ b/alma/controllers/hook/DisplayProductActionsHookController.php
@@ -31,7 +31,6 @@ if (!defined('_PS_VERSION_')) {
 use Alma\PrestaShop\Helpers\Admin\InsuranceHelper as AdminInsuranceHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
 use Alma\PrestaShop\Helpers\InsuranceHelper;
-use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Hooks\FrontendHookController;
 
 class DisplayProductActionsHookController extends FrontendHookController
@@ -43,6 +42,10 @@ class DisplayProductActionsHookController extends FrontendHookController
      * @var InsuranceHelper
      */
     protected $insuranceHelper;
+    /**
+     * @var AdminInsuranceHelper
+     */
+    private $adminInsuranceHelper;
 
     /**
      * @param $module
@@ -68,11 +71,13 @@ class DisplayProductActionsHookController extends FrontendHookController
      * @param $params
      *
      * @return mixed
+     * @throws \PrestaShopException
      */
     public function run($params)
     {
         $addToCartLink = '';
         $oldPSVersion = false;
+        $settings = json_encode($this->adminInsuranceHelper->mapDbFieldsWithIframeParams());
 
         if (version_compare(_PS_VERSION_, '1.7', '<')) {
 
@@ -89,6 +94,7 @@ class DisplayProductActionsHookController extends FrontendHookController
         $this->context->smarty->assign([
             'addToCartLink' => $addToCartLink,
             'oldPSVersion' => $oldPSVersion,
+            'settingsInsurance' => $settings,
             'iframeUrl' => $this->adminInsuranceHelper->envUrl() . ConstantsHelper::FO_IFRAME_WIDGET_INSURANCE_PATH,
             'scriptModalUrl' => $this->adminInsuranceHelper->envUrl() . ConstantsHelper::SCRIPT_MODAL_WIDGET_INSURANCE_PATH,
         ]);

--- a/alma/lib/Helpers/Admin/InsuranceHelper.php
+++ b/alma/lib/Helpers/Admin/InsuranceHelper.php
@@ -27,6 +27,7 @@ namespace Alma\PrestaShop\Helpers\Admin;
 use Alma\PrestaShop\Exceptions\WrongParamsException;
 use Alma\PrestaShop\Helpers\ConfigurationHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
+use Alma\PrestaShop\Helpers\SettingsHelper;
 
 class InsuranceHelper
 {
@@ -182,6 +183,18 @@ class InsuranceHelper
 
     /**
      * @return string
+     */
+    public function envUrl()
+    {
+        if (SettingsHelper::getActiveMode() === ALMA_MODE_LIVE) {
+            return ConstantsHelper::DOMAIN_URL_INSURANCE_LIVE;
+        }
+
+        return ConstantsHelper::DOMAIN_URL_INSURANCE_TEST;
+    }
+
+    /**
+     * @return string
      *
      * @throws \PrestaShopException
      */
@@ -189,7 +202,7 @@ class InsuranceHelper
     {
         return sprintf(
             '%s?%s',
-            ConstantsHelper::BO_URL_IFRAME_CONFIGURATION_INSURANCE,
+            $this->envUrl() . ConstantsHelper::BO_IFRAME_CONFIGURATION_INSURANCE_PATH,
             http_build_query($this->mapDbFieldsWithIframeParams())
         );
     }
@@ -199,7 +212,7 @@ class InsuranceHelper
      *
      * @throws \PrestaShopException
      */
-    protected function mapDbFieldsWithIframeParams()
+    public function mapDbFieldsWithIframeParams()
     {
         $mapParams = [];
         $fieldsBoInsurance = $this->configurationHelper->getMultiple(ConstantsHelper::$fieldsBoInsurance);

--- a/alma/lib/Helpers/ConstantsHelper.php
+++ b/alma/lib/Helpers/ConstantsHelper.php
@@ -80,6 +80,8 @@ class ConstantsHelper
     const DOMAIN_URL_INSURANCE_TEST = 'https://protect.sandbox.almapay.com';
     const DOMAIN_URL_INSURANCE_LIVE = 'https://protect.almapay.com';
     const BO_IFRAME_CONFIGURATION_INSURANCE_PATH = '/almaBackOfficeConfiguration.html';
+    const FO_IFRAME_WIDGET_INSURANCE_PATH = '/almaProductInPageWidget.html';
+    const SCRIPT_MODAL_WIDGET_INSURANCE_PATH = '/openInPageModal.js';
 
     const ALMA_INSURANCE_PRODUCT_NAME = 'Insurance by Alma';
     const ALMA_INSURANCE_PRODUCT_REFERENCE = 'alma-insurance';

--- a/alma/lib/Helpers/ConstantsHelper.php
+++ b/alma/lib/Helpers/ConstantsHelper.php
@@ -77,8 +77,9 @@ class ConstantsHelper
     const BO_CONTROLLER_INSURANCE_CLASSNAME = 'AdminAlmaInsurance';
     const BO_CONTROLLER_INSURANCE_CONFIGURATION_CLASSNAME = 'AdminAlmaInsuranceConfiguration';
     const BO_CONTROLLER_INSURANCE_ORDERS_CLASSNAME = 'AdminAlmaInsuranceOrders';
-    const DOMAIN_URL_INSURANCE = 'https://protect.staging.almapay.com';
-    const BO_URL_IFRAME_CONFIGURATION_INSURANCE = self::DOMAIN_URL_INSURANCE . '/almaBackOfficeConfiguration.html';
+    const DOMAIN_URL_INSURANCE_TEST = 'https://protect.sandbox.almapay.com';
+    const DOMAIN_URL_INSURANCE_LIVE = 'https://protect.almapay.com';
+    const BO_IFRAME_CONFIGURATION_INSURANCE_PATH = '/almaBackOfficeConfiguration.html';
 
     const ALMA_INSURANCE_PRODUCT_NAME = 'Insurance by Alma';
     const ALMA_INSURANCE_PRODUCT_REFERENCE = 'alma-insurance';

--- a/alma/views/css/alma-insurance.css
+++ b/alma/views/css/alma-insurance.css
@@ -5,7 +5,7 @@
 .alma-widget-insurance{
     width: 100%;
 }
-#alma-widget-insurance{
+#product-alma-iframe{
     border: 0;
     padding: 0;
     margin: 0;

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -48,6 +48,8 @@
 (function ($) {
     $(function () {
         //Insurance
+        let choiseOk = false;
+
         onloadAddInsuranceInputOnProductAlma();
         if (typeof prestashop !== 'undefined') {
             prestashop.on(
@@ -67,6 +69,18 @@
                 }
             );
         }
+        let addToCart = document.querySelector('.add-to-cart');
+        addToCart.addEventListener("click", function (event) {
+            console.log(choiseOk);
+            if (!choiseOk) {
+                event.preventDefault();
+                event.stopPropagation();
+                openModal('popupModal');
+                console.log(openModal('popupModal'));
+                console.log('add to cart');
+                choiseOk = true;
+            }
+        });
     });
 })(jQuery);
 
@@ -89,6 +103,8 @@ function addInputsInsurance(selectedAlmaInsurance) {
 
     handleInput('alma_insurance_price', selectedAlmaInsurance.option.price, formAddToCart);
     handleInput('alma_insurance_name', selectedAlmaInsurance.name, formAddToCart);
+    let addToCart = document.querySelector('.add-to-cart');
+    addToCart.click();
 }
 
 function handleInput(inputName, value, form) {

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -20,76 +20,61 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
+const settings = JSON.parse(document.querySelector('#alma-widget-insurance-product-page').dataset.almaInsuranceSettings);
+let insuranceSelected = false;
+let selectedAlmaInsurance = null;
+let addToCartFlow = false;
 
-// Insurance
-
-/**
- * 2018-2023 Alma SAS
- *
- * THE MIT LICENSE
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
- * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
- * Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
- * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
- * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- *
- * @author    Alma SAS <contact@getalma.eu>
- * @copyright 2018-2023 Alma SAS
- * @license   https://opensource.org/licenses/MIT The MIT License
- */
 (function ($) {
     $(function () {
         //Insurance
-        let choiseOk = false;
-
         onloadAddInsuranceInputOnProductAlma();
         if (typeof prestashop !== 'undefined') {
             prestashop.on(
                 'updateProduct',
                 function (event) {
+                    let addToCart = document.querySelector('.add-to-cart');
                     let modalIsClosed = false;
+
                     if (event.event !== undefined) {
                         modalIsClosed = event.event.namespace === 'bs.modal' && event.event.type === 'hidden';
                     }
                     if (modalIsClosed) {
                         removeInsurance();
                     }
-
-                    if(typeof event.selectedAlmaInsurance !== 'undefined' && event.selectedAlmaInsurance !== null) {
+                    if(typeof event.selectedAlmaInsurance !== 'undefined' && event.selectedAlmaInsurance !== null ) {
+                        insuranceSelected = true;
                         addInputsInsurance(event.selectedAlmaInsurance);
                     }
+                    if (addToCartFlow) {
+                        addToCart.click();
+                        resetInsurance();
+                        insuranceSelected = false;
+                        addToCartFlow = false;
+                    }
+
                 }
             );
         }
-        let addToCart = document.querySelector('.add-to-cart');
-        addToCart.addEventListener("click", function (event) {
-            console.log(choiseOk);
-            if (!choiseOk) {
-                event.preventDefault();
-                event.stopPropagation();
-                openModal('popupModal');
-                console.log(openModal('popupModal'));
-                console.log('add to cart');
-                choiseOk = true;
-            }
-        });
+        if (typeof prestashop !== 'undefined') {
+            prestashop.on(
+                'updatedProduct',
+                function () {
+                    openModalOnAddToCart();
+                }
+            );
+        }
+        openModalOnAddToCart();
     });
 })(jQuery);
 
 // ** Add input insurance in form to add to cart **
 function onloadAddInsuranceInputOnProductAlma() {
     let currentResolve;
-    let selectedAlmaInsurance = null;
+
     window.addEventListener('message', (e) => {
         if (e.data.type === 'getSelectedInsuranceData') {
+            insuranceSelected = true;
             selectedAlmaInsurance = e.data.selectedInsuranceData;
             prestashop.emit('updateProduct', {selectedAlmaInsurance: selectedAlmaInsurance});
         } else if (currentResolve) {
@@ -103,8 +88,6 @@ function addInputsInsurance(selectedAlmaInsurance) {
 
     handleInput('alma_insurance_price', selectedAlmaInsurance.option.price, formAddToCart);
     handleInput('alma_insurance_name', selectedAlmaInsurance.name, formAddToCart);
-    let addToCart = document.querySelector('.add-to-cart');
-    addToCart.click();
 }
 
 function handleInput(inputName, value, form) {
@@ -135,4 +118,20 @@ function removeInsurance() {
     inputsInsurance.forEach((input) => {
         input.remove();
     });
+}
+
+function openModalOnAddToCart() {
+    if (settings.is_add_to_cart_popup_insurance_activated === 'true') {
+        let addToCart = document.querySelector('.add-to-cart');
+        addToCart.addEventListener("click", function (event) {
+            if (!insuranceSelected) {
+                event.preventDefault();
+                event.stopPropagation();
+                openModal('popupModal');
+                insuranceSelected = true;
+                addToCartFlow = true;
+            }
+            insuranceSelected = false;
+        });
+    }
 }

--- a/alma/views/js/alma-product-insurance16.js
+++ b/alma/views/js/alma-product-insurance16.js
@@ -95,6 +95,7 @@ function updateProduct(event) {
 // Insurance
 // ** Add input insurance in form to add to cart **
 function onloadAddInsuranceInputOnProductAlma() {
+    // To hide insurance widget on a quick view product
     $(document).off('click', '.quick-view').on('click', '.quick-view', function(e){
         e.preventDefault();
 

--- a/alma/views/templates/hook/displayProductActions.tpl
+++ b/alma/views/templates/hook/displayProductActions.tpl
@@ -1,9 +1,9 @@
 {if isset($layout) || $oldPSVersion == 1}
 <div class="alma-widget-insurance"  id="alma-widget-insurance-product-page" {$addToCartLink}>
-    <iframe id="product-alma-iframe" src="https://protect.staging.almapay.com/almaProductInPageWidget.html"></iframe>
+    <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
     <div id="alma-insurance-modal"></div>
 </div>
 <!-- TODO : Need to load the asset in registerJavascript() with type module -->
-<script type="module" src="https://protect.staging.almapay.com/openInPageModal.js"></script>
+<script type="module" src="{$scriptModalUrl}"></script>
 {/if}
 <div onClick='openModal("popupModal")'>Coucou</div>

--- a/alma/views/templates/hook/displayProductActions.tpl
+++ b/alma/views/templates/hook/displayProductActions.tpl
@@ -1,9 +1,8 @@
 {if isset($layout) || $oldPSVersion == 1}
-<div class="alma-widget-insurance"  id="alma-widget-insurance-product-page" {$addToCartLink}>
-    <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
-    <div id="alma-insurance-modal"></div>
-</div>
-<!-- TODO : Need to load the asset in registerJavascript() with type module -->
-<script type="module" src="{$scriptModalUrl}"></script>
+    <div class="alma-widget-insurance"  id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" {$addToCartLink}>
+        <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
+        <div id="alma-insurance-modal"></div>
+    </div>
+    <!-- TODO : Need to load the asset in registerJavascript() with type module -->
+    <script type="module" src="{$scriptModalUrl}"></script>
 {/if}
-<div onClick='openModal("popupModal")'>Coucou</div>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/MPP-1045/add-the-modal-confirm-on-click-to-the-add-to-cart)

### Code changes

Open modal insurance when add to click to add to cart button in the product page

### How to test

Add product on the cart without select insurance

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->