### PR TITLE
[insurance] Fix creation combination insurance with the same name

### DIFF
--- a/alma/lib/Repositories/CombinationRepository.php
+++ b/alma/lib/Repositories/CombinationRepository.php
@@ -44,7 +44,7 @@ class CombinationRepository
      *
      * @return int id
      */
-    public function getIdByReference($idProduct, $reference)
+    public function getIdByReference($idProduct, $reference, $price)
     {
         if (empty($reference)) {
             return 0;
@@ -53,8 +53,9 @@ class CombinationRepository
         $query = new \DbQuery();
         $query->select('pa.id_product_attribute');
         $query->from('product_attribute', 'pa');
-        $query->where('pa.reference = "' . (string) $reference . '"');
         $query->where('pa.id_product = ' . (int)$idProduct);
+        $query->where('pa.reference = "' . (string) $reference . '"');
+        $query->where('pa.price = ' . (float)$price);
 
         return \Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
     }

--- a/alma/lib/Services/CombinationProductAttributeService.php
+++ b/alma/lib/Services/CombinationProductAttributeService.php
@@ -51,7 +51,7 @@ class CombinationProductAttributeService
         /**
          * @var \CombinationCore $combinaison
          */
-        $idProductAttributeInsurance = $this->combinationRepository->getIdByReference($product->id, $reference);
+        $idProductAttributeInsurance = $this->combinationRepository->getIdByReference($product->id, $reference, $price);
 
         if (!$idProductAttributeInsurance) {
             $idProductAttributeInsurance = $product->addCombinationEntity(

--- a/alma/lib/Services/InsuranceProductService.php
+++ b/alma/lib/Services/InsuranceProductService.php
@@ -154,7 +154,16 @@ class InsuranceProductService
      * @throws \PrestaShopDatabaseException
      * @throws \PrestaShopException
      */
-    public function addInsuranceProduct($idProduct, $insuranceProduct, $insurancePrice, $insuranceName, $quantity, $idCustomization, $idProductAttibutePS16 = 0, $destroyPost = true)
+    public function addInsuranceProduct(
+        $idProduct,
+        $insuranceProduct,
+        $insurancePrice,
+        $insuranceName,
+        $quantity,
+        $idCustomization,
+        $idProductAttibutePS16 = 0,
+        $destroyPost = true
+    )
     {
         if (version_compare(_PS_VERSION_, '1.7', '>=')) {
             $idProductAttribute = $this->attributeProductService->getIdProductAttributeFromPost($idProduct);


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/MPP-1142/fix-creation-combination-insurance-with-the-same-name)

### Code changes

Add price on verification if combination of insurance product existe if there are the same name but the different price

### How to test

Add insurance product with the same name but different price

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->