### PR TITLE
[insurance] Improve opt in wording files link

### DIFF
--- a/alma/controllers/hook/TermsAndConditionsHookController.php
+++ b/alma/controllers/hook/TermsAndConditionsHookController.php
@@ -24,8 +24,13 @@
 
 namespace Alma\PrestaShop\Controllers\Hook;
 
+use Alma\API\Client;
+use Alma\API\Exceptions\ParamsException;
+use Alma\API\RequestError;
+use Alma\PrestaShop\Helpers\ClientHelper;
 use Alma\PrestaShop\Helpers\InsuranceHelper;
 use Alma\PrestaShop\Hooks\FrontendHookController;
+use Alma\PrestaShop\Repositories\AlmaInsuranceProductRepository;
 use Alma\PrestaShop\Services\InsuranceService;
 use PrestaShop\PrestaShop\Core\Checkout\TermsAndConditions;
 
@@ -47,6 +52,14 @@ class TermsAndConditionsHookController extends FrontendHookController
      * @var InsuranceService
      */
     protected $insuranceService;
+    /**
+     * @var AlmaInsuranceProductRepository
+     */
+    protected $almaInsuranceProductRepository;
+    /**
+     * @var TermsAndConditions
+     */
+    protected $termsAndConditions;
 
     /**
      * @param $module
@@ -55,11 +68,14 @@ class TermsAndConditionsHookController extends FrontendHookController
     {
         $this->insuranceHelper = new InsuranceHelper();
         $this->insuranceService = new InsuranceService();
+        $this->almaInsuranceProductRepository = new AlmaInsuranceProductRepository();
+        $this->termsAndConditions = new TermsAndConditions();
         parent::__construct($module);
     }
 
     /**
      * @return bool
+     * @throws \PrestaShopDatabaseException
      */
     public function canRun()
     {
@@ -71,16 +87,23 @@ class TermsAndConditionsHookController extends FrontendHookController
     /**
      * @param $params
      * @return array
+     * @throws ParamsException
+     * @throws RequestError
+     * @throws \PrestaShopDatabaseException
      */
     public function run($params)
     {
-        $returnedTermsAndConditions = [];
-        $termsAndConditions = new TermsAndConditions();
+        /**
+         * @var \Cart $cart
+         */
+        $cart = $params['cart'];
+        $insuranceContracts = $this->almaInsuranceProductRepository->getContractsInfosByCartIdAndShopId($cart->id, $cart->id_shop);
+        $termsAndConditionsInsurance = $this->insuranceService->createTextTermsAndConditions($insuranceContracts);
 
-        $termsAndConditions
-            ->setText($this->module->l('By accepting to subscribe to Alma insurance, I confirm my thorough review, acceptance, and retention of the general terms outlined in the information booklet and the insurance product details. Additionally, I consent to receiving contractual information by e-mail for the purpose of securely storing it in a durable format.', 'TermsAndConditionsHookController'))
+        // @TODO : Find an alternative about the modal on the click to the link
+        $returnedTermsAndConditions[] = $this->termsAndConditions
+            ->setText($termsAndConditionsInsurance['text'], $termsAndConditionsInsurance['link'])
             ->setIdentifier('terms-and-conditions-alma-insurance');
-        $returnedTermsAndConditions[] = $termsAndConditions;
 
         return $returnedTermsAndConditions;
     }

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -24,13 +24,15 @@
 
 namespace Alma\PrestaShop\Services;
 
-use Alma\API\Entities\Insurance\Subscriber;
+use Alma\API\Client;
 use Alma\API\Entities\Insurance\Subscription;
+use Alma\API\Exceptions\ParamsException;
+use Alma\API\RequestError;
 use Alma\PrestaShop\Exceptions\AlmaException;
 use Alma\PrestaShop\Exceptions\InsuranceInstallException;
+use Alma\PrestaShop\Helpers\ClientHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
 use Alma\PrestaShop\Logger;
-use Alma\PrestaShop\Model\CustomerData;
 use Alma\PrestaShop\Repositories\AlmaInsuranceProductRepository;
 use Alma\PrestaShop\Repositories\AttributeGroupRepository;
 use Alma\PrestaShop\Repositories\ProductRepository;
@@ -65,9 +67,15 @@ class InsuranceService
      * @var CartService
      */
     protected $cartService;
+    /**
+     * @var Client|mixed|null
+     */
+    protected $alma;
 
     public function __construct()
     {
+        $this->module = \Module::getInstanceByName(ConstantsHelper::ALMA_MODULE_NAME);
+        $this->alma = ClientHelper::defaultInstance();
         $this->productRepository = new ProductRepository();
         $this->imageService = new ImageService();
         $this->cartService = new CartService();
@@ -79,7 +87,7 @@ class InsuranceService
     /**
      * Create the default Insurance product
      *
-     * @return \ProductCore|void
+     * @return \ProductCore
      * @throws InsuranceInstallException
      */
     public function createProductIfNotExists()
@@ -247,5 +255,34 @@ class InsuranceService
         }
 
         return $subscriptionData;
+    }
+
+    /**
+     * @param array $insuranceContracts
+     * @return array
+     * @throws ParamsException
+     * @throws RequestError
+     */
+    public function createTextTermsAndConditions($insuranceContracts)
+    {
+        // @TODO : Need to define the logic about the loop of the documents
+        // @TODO : Maybe get the files info in the table alma_insurance_product in the field insurance_contract_infos ?
+        $files = [];
+        foreach ($insuranceContracts as $insuranceContract) {
+            $insuranceContractInfos = json_decode($insuranceContract['insurance_contract_infos'], true);
+            $files[] = $this->alma->insurance->getInsuranceContract(
+                $insuranceContractInfos['insurance_contract_id'],
+                $insuranceContractInfos['cms_reference'],
+                $insuranceContractInfos['product_price']
+            )->getFileByType('ipid-document');
+        }
+
+        return [
+            'text' => sprintf(
+                $this->module->l('By accepting to subscribe to [%s], I confirm my thorough review, acceptance, and retention of the general terms outlined in the information booklet and the insurance product details. Additionally, I consent to receiving contractual information by e-mail for the purpose of securely storing it in a durable format.', 'TermsAndConditionsHookController'),
+                $files[0]->getName()
+            ),
+            'link' => $files[0]->getPublicUrl()
+        ];
     }
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/MPP-1119/prestashop-improve-opt-in-wording-files-link)

### Code changes

Add document in the opt-in text of insurance

### How to test

Buy an insurance and see the opt-in text before the payment

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->