### PR TITLE
[insurance] Fix when i select an insurance the quantity set at 1

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -25,6 +25,7 @@ let insuranceSelected = false;
 let selectedAlmaInsurance = null;
 let addToCartFlow = false;
 let productDetails = null;
+let quantity = 1;
 
 (function ($) {
     $(function () {
@@ -41,7 +42,11 @@ let productDetails = null;
                     if (event.event !== undefined) {
                         modalIsClosed = event.event.namespace === 'bs.modal' && event.event.type === 'hidden';
                     }
-                    if (modalIsClosed || event.eventType === 'updatedProductQuantity' || event.eventType === 'updatedProductCombination') {
+                    if (event.eventType === 'updatedProductQuantity') {
+                        quantity = event.event.target.value;
+                        removeInsurance();
+                    }
+                    if (modalIsClosed || event.eventType === 'updatedProductCombination') {
                         removeInsurance();
                     }
                     if(typeof event.selectedAlmaInsurance !== 'undefined' && event.selectedAlmaInsurance !== null ) {
@@ -58,6 +63,7 @@ let productDetails = null;
             prestashop.on(
                 'updatedProduct',
                 function () {
+                    document.getElementById('quantity_wanted').value = quantity;
                     productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
 
                     refreshWidget();

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -41,6 +41,7 @@ let quantity = 1;
 
                     if (event.event !== undefined) {
                         modalIsClosed = event.event.namespace === 'bs.modal' && event.event.type === 'hidden';
+                        quantity = 1;
                     }
                     if (event.eventType === 'updatedProductQuantity') {
                         quantity = event.event.target.value;


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/MPP-1147/fix-when-i-select-an-insurance-the-quantity-set-at-1)

### Code changes

Set quantity product if is changed when you select an insurance for set the same quantity in the product

### How to test

Change the quantity then select an insurance and see if the quantity is the same

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->