### PR TITLE
[main] Backoffice almaPage.css breaks switchs in Prestashop 8.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- fix: CSS of Prestashop Switch button on Back-office setting
+
 ## v3.1.2
 
 - hotfix: Select payment In-Page without open the modal and try to pay with other payment method

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -30,7 +30,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 
 class Alma extends PaymentModule
 {
-    const VERSION = '3.1.2';
+    const VERSION = '3.1.3';
 
     public $_path;
     public $local_path;
@@ -65,7 +65,7 @@ class Alma extends PaymentModule
     {
         $this->name = 'alma';
         $this->tab = 'payments_gateways';
-        $this->version = '3.1.2';
+        $this->version = '3.1.3';
         $this->author = 'Alma';
         $this->need_instance = false;
         $this->bootstrap = true;

--- a/alma/views/css/admin/almaPage.css
+++ b/alma/views/css/admin/almaPage.css
@@ -156,9 +156,6 @@ fieldset .form-alma.disabled::before{
 .alma_switch .switch .slider:active:after {
 	width: 35px;
 }
-.bootstrap .prestashop-switch .slide-button::after {
-    top: 49%;
-}
 
 .bootstrap .alma.alert,
 #main-div .alma.alert{


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1170/backoffice-almapagecss-breaks-switchs-in-prestashop-81)

### Code changes

Remove CSS to fix switch Prestashop 8

### How to test

Up Prestashop 8.1+
Connect to the back office
Go to Shop parameters > Search
And the switch button if it's right

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->