### PR TITLE
[insurance] Get the eligibility info if the product havent insurance and disabled

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -26,6 +26,7 @@ let selectedAlmaInsurance = null;
 let addToCartFlow = false;
 let productDetails = null;
 let quantity = 1;
+let isEligible = false;
 
 (function ($) {
     $(function () {
@@ -81,6 +82,10 @@ function onloadAddInsuranceInputOnProductAlma() {
 
     window.addEventListener('message', (e) => {
         if (e.data.type === 'almaEligibilityAnswer') {
+            if (e.data.eligibilityCallResponseStatus.response.eligibleProduct === true) {
+                isEligible = true;
+                prestashop.emit('updateProduct', {isEligible: isEligible});
+            }
             let heightIframe = e.data.widgetSize.height + 25;
             document.getElementById('product-alma-iframe').style.height = heightIframe + "px";
         }
@@ -138,7 +143,7 @@ function removeInsurance() {
 }
 
 function openModalOnAddToCart() {
-    if (settings.is_add_to_cart_popup_insurance_activated === 'true') {
+    if (settings.is_add_to_cart_popup_insurance_activated === 'true' && isEligible) {
         let addToCart = document.querySelector('.add-to-cart');
         addToCart.addEventListener("click", function (event) {
             if (!insuranceSelected) {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1158/get-the-eligibility-info-if-the-product-havent-insurance-and-disabled)

### Code changes

Get the eligibility of the api in the widget to enable or not the event to click of insurance

### How to test

- Add to cart a product with insurance Eligible
- Add to cart a product with insurance not Eligible and in the catalogue insurance
- Add to cart a product with insurance not in the catalogue insurance

### Checklist for authors and reviewers

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->