### PR TITLE
[insurance] Bug to add to cart if iso code prestashop isnt send

### DIFF
--- a/alma/controllers/front/insurance.php
+++ b/alma/controllers/front/insurance.php
@@ -84,6 +84,7 @@ class AlmaInsuranceModuleFrontController extends ModuleFrontController
                             \Tools::getValue('alma_id_insurance_contract'),
                             \Tools::getValue('qty'),
                             0,
+                            null,
                             \Tools::getValue('id_product_attribute')
                         );
 

--- a/alma/controllers/hook/ActionCartSaveHookController.php
+++ b/alma/controllers/hook/ActionCartSaveHookController.php
@@ -84,28 +84,28 @@ class ActionCartSaveHookController extends FrontendHookController
      */
     public function run($params)
     {
-        $this->handleAddingProductInsurance();
+        $this->handleAddingProductInsurance($params['cart']);
         $this->handleRemoveInsuranceProduct();
     }
 
     /**
+     * @param \Cart $cart
      * @return void
-     * @throws InsuranceInstallException
      */
-    public function handleAddingProductInsurance()
+    public function handleAddingProductInsurance($cart)
     {
         if (
             version_compare(_PS_VERSION_, '1.7', '>=')
             && \Tools::getIsset('alma_id_insurance_contract')
             && 1 == \Tools::getValue('add')
             && 'update' == \Tools::getValue('action')
-            &&  in_array(\Tools::strtoupper(\Context::getContext()->currency->iso_code), $this->module->limited_currencies)
         ) {
             $this->insuranceProductService->handleAddingProductInsurance(
                 \Tools::getValue('id_product'),
                 \Tools::getValue('alma_id_insurance_contract'),
                 \Tools::getValue('qty'),
-                \Tools::getValue('id_customization')
+                \Tools::getValue('id_customization'),
+                $cart
             );
         }
     }

--- a/alma/lib/Services/CartService.php
+++ b/alma/lib/Services/CartService.php
@@ -50,10 +50,24 @@ class CartService
      * @param int $quantity Quantity to add (or substract)
      * @param int $idProduct Product ID
      * @param int $idProductAttribute Attribute ID if needed
+     * @param \Cart|null $cart Object Cart
+     * @param bool $idCustomization Customization ID if needed
      * @param string $operator Indicate if quantity must be increased or decreased
+     * @param int $idAddressDelivery Address Delivery ID if needed
+     * @param null $shop
+     * @return bool|int|void|null
+     * @throws AlmaException
      */
-    public function updateQty($quantity, $idProduct, $idProductAttribute = null, $idCustomization = false,
-                              $operator = 'up', $idAddressDelivery = 0, Shop $shop = null)
+    public function updateQty(
+        $quantity,
+        $idProduct,
+        $idProductAttribute = null,
+        $cart = null,
+        $idCustomization = false,
+        $operator = 'up',
+        $idAddressDelivery = 0,
+        $shop = null
+    )
     {
         /**
          * @var \ContextCore $context
@@ -64,14 +78,21 @@ class CartService
             $shop = $context->shop;
         }
 
-        $cart = $context->cart;
+        if (null !== $context->cart) {
+            $cart = $context->cart;
+        }
 
         if ($context->customer->id) {
-            if ($idAddressDelivery == 0 && (int)$cart->id_address_delivery) { // The $idAddressDelivery is null, use the cart delivery address
+            if (
+                $idAddressDelivery == 0
+                && (int)$cart->id_address_delivery
+            ) { // The $idAddressDelivery is null, use the cart delivery address
                 $idAddressDelivery = $cart->id_address_delivery;
             } elseif ($idAddressDelivery == 0) { // The $idAddressDelivery is null, get the default customer address
                 $idAddressDelivery = (int)\Address::getFirstCustomerAddressId((int)$context->customer->id);
             } elseif (!\Customer::customerHasAddress($context->customer->id, $idAddressDelivery)) { // The $idAddressDelivery must be linked with customer
+                $idAddressDelivery = 0;
+            } else {
                 $idAddressDelivery = 0;
             }
         }

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -203,6 +203,7 @@ class InsuranceService
                     1,
                     $insuranceLinked['id_product_insurance'],
                     $insuranceLinked['id_product_attribute_insurance'],
+                    null,
                     0,
                     'down'
                 );


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1173/bug-to-add-to-cart-the-context-doesnt-exists-when-there-is-no-default)

### Code changes

Set the cart on context if not for a fix on Prestashop 1.7.8.7
https://www.prestashop.com/forums/topic/1059652-this-context-cart-is-null-when-product-is-added-into-cart/

### How to test

Create a customer without default address and add to cart a product with insurance

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->