### PR TITLE
fix: ensure library is not invoked in CLI mode

### DIFF
--- a/alma/lib/smarty.php
+++ b/alma/lib/smarty.php
@@ -25,7 +25,7 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-if (class_exists('\Context')) {
+if (class_exists('\Context') && php_sapi_name() != 'cli') {
     $smarty = \Context::getContext()->smarty;
 
     /**


### PR DESCRIPTION
### Reason for change

Resolved an issue where the smarty library was incorrectly loaded during command-line executions. This fix prevents the library from being called in CLI context, aligning with the intended behavior of module operations in a non-web environment.