### PR TITLE
Remove input insurance in DOM when click on remove insurance in the widget

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -56,7 +56,6 @@ let isEligible = false;
                         addInputsInsurance(event.selectedAlmaInsurance);
                     }
                     if (typeof event.selectedInsuranceData !== 'undefined' && event.selectedInsuranceData) {
-                        console.log('removeInputInsurance');
                         removeInputInsurance();
                     }
                     if (addToCartFlow) {

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -55,6 +55,10 @@ let isEligible = false;
                         insuranceSelected = true;
                         addInputsInsurance(event.selectedAlmaInsurance);
                     }
+                    if (typeof event.selectedInsuranceData !== 'undefined' && event.selectedInsuranceData) {
+                        console.log('removeInputInsurance');
+                        removeInputInsurance();
+                    }
                     if (addToCartFlow) {
                         addToCart.click();
                         insuranceSelected = false;
@@ -92,7 +96,7 @@ function onloadAddInsuranceInputOnProductAlma() {
         if (e.data.type === 'getSelectedInsuranceData') {
             insuranceSelected = true;
             selectedAlmaInsurance = e.data.selectedInsuranceData;
-            prestashop.emit('updateProduct', {selectedAlmaInsurance: selectedAlmaInsurance});
+            prestashop.emit('updateProduct', {selectedAlmaInsurance: selectedAlmaInsurance, selectedInsuranceData: e.data.declinedInsurance});
         } else if (currentResolve) {
             currentResolve(e.data);
         }
@@ -136,6 +140,10 @@ function handleInput(inputName, value, form) {
 function removeInsurance() {
     resetInsurance();
     insuranceSelected = false;
+    removeInputInsurance();
+}
+
+function removeInputInsurance() {
     let inputsInsurance = document.getElementById('add-to-cart-or-refresh').querySelectorAll('.alma_insurance_input');
     inputsInsurance.forEach((input) => {
         input.remove();


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1189/remove-input-insurance-in-dom-when-click-on-remove-insurance-in-the)

### Code changes

Identify if we remove the insurance via the widget and remove in the DOM the input insurance

### How to test

Add an insurance with the widget 
then remove it with the button in the widget
and add to cart to see if the insurance isn't in the cart

### Checklist for authors and reviewers

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->