### PR TITLE
Fix stock quantity on insurance product

### DIFF
--- a/alma/lib/Repositories/StockAvailableRepository.php
+++ b/alma/lib/Repositories/StockAvailableRepository.php
@@ -43,14 +43,32 @@ class StockAvailableRepository
      * @param int $idProductAttribute The product id attribute
      * @return int
      */
-    public function getQuantity($idProduct, $idProductAttribute)
+    public function getQuantity($idProduct, $idProductAttribute, $shopId)
     {
         $query = new \DbQuery();
         $query->select('quantity');
         $query->from('stock_available');
         $query->where('id_product = ' . (int) $idProduct);
         $query->where('id_product_attribute = ' . (int) $idProductAttribute);
+        $query->where('id_shop = ' . (int) $shopId);
 
         return (int) \Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
+    }
+
+    /**
+     * Return the stock available for a given product id and attribute
+     *
+     * @param int $idProduct The product id
+     * @param int $idProductAttribute The product id attribute
+     * @return int
+     */
+    public function setQuantity($idProduct, int $idProductAttribute, $quantity, $shopId)
+    {
+        return \Db::getInstance()->execute('
+						UPDATE `' . _DB_PREFIX_ . 'stock_available`
+						SET `quantity` = ' . $quantity . ' 
+						WHERE `id_product` = ' . (int)$idProduct . ' 
+						AND `id_product_attribute` = ' . $idProductAttribute . ' 
+						AND `id_shop` = ' . (int)$shopId );
     }
 }

--- a/alma/lib/Repositories/StockAvailableRepository.php
+++ b/alma/lib/Repositories/StockAvailableRepository.php
@@ -66,7 +66,7 @@ class StockAvailableRepository
     {
         return \Db::getInstance()->execute('
 						UPDATE `' . _DB_PREFIX_ . 'stock_available`
-						SET `quantity` = ' . $quantity . ' 
+						SET `quantity` = 999 
 						WHERE `id_product` = ' . (int)$idProduct . ' 
 						AND `id_product_attribute` = ' . $idProductAttribute . ' 
 						AND `id_shop` = ' . (int)$shopId );

--- a/alma/lib/Repositories/StockAvailableRepository.php
+++ b/alma/lib/Repositories/StockAvailableRepository.php
@@ -49,7 +49,7 @@ class StockAvailableRepository
         $query->select('quantity');
         $query->from('stock_available');
         $query->where('id_product = ' . (int) $idProduct);
-        $query->where('id_product_attribute = ' . (int) $idProductAttribute);
+        $query->where('id_product_attribute = ' .  $idProductAttribute);
         $query->where('id_shop = ' . (int) $shopId);
 
         return (int) \Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);

--- a/alma/lib/Repositories/StockAvailableRepository.php
+++ b/alma/lib/Repositories/StockAvailableRepository.php
@@ -29,34 +29,28 @@ if (!defined('_PS_VERSION_')) {
 }
 
 /**
- * Class CombinationRepository.
+ * Class StockAvailableRepository.
  *
  * Use for Product
  */
-class CombinationRepository
+class StockAvailableRepository
 {
 
     /**
-     * For a given product_attribute reference and price, returns the corresponding id.
+     * Return the stock available for a given product id and attribute
      *
-     * @param int $idProduct
-     * @param string $reference
-     * @param int $price
-     * @return int id
+     * @param int $idProduct The product id
+     * @param int $idProductAttribute The product id attribute
+     * @return int
      */
-    public function getIdByReferenceAndPrice($idProduct, $reference, $price)
+    public function getQuantity($idProduct, $idProductAttribute)
     {
-        if (empty($reference)) {
-            return 0;
-        }
-
         $query = new \DbQuery();
-        $query->select('pa.id_product_attribute');
-        $query->from('product_attribute', 'pa');
-        $query->where('pa.id_product = ' . (int)$idProduct);
-        $query->where('pa.reference = "' . (string) $reference . '"');
-        $query->where('pa.price = ' . (float)$price);
+        $query->select('quantity');
+        $query->from('stock_available');
+        $query->where('id_product = ' . (int) $idProduct);
+        $query->where('id_product_attribute = ' . (int) $idProductAttribute);
 
-        return \Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
+        return (int) \Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);
     }
 }

--- a/alma/lib/Services/InsuranceProductService.php
+++ b/alma/lib/Services/InsuranceProductService.php
@@ -204,6 +204,7 @@ class InsuranceProductService
             $insuranceAttributeId,
             $insuranceName,
             $insurancePrice,
+            $quantity,
             $this->context->shop->id
         );
 

--- a/alma/lib/Services/StockAvailableService.php
+++ b/alma/lib/Services/StockAvailableService.php
@@ -82,10 +82,6 @@ class StockAvailableService
      */
     public function updateStocks($idProduct, $quantity, $shopId, $idProductAttributeInsurance)
     {
-        $oldQuantity = $this->stockAvailableRepository->getQuantity($idProduct, $idProductAttributeInsurance, $shopId);
-
-        $quantity = $oldQuantity + $quantity;
-
        $this->stockAvailableRepository->setQuantity($idProduct, $idProductAttributeInsurance, $quantity, $shopId);
     }
 }

--- a/alma/lib/Services/StockAvailableService.php
+++ b/alma/lib/Services/StockAvailableService.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Services;
+
+
+use Alma\PrestaShop\Repositories\StockAvailableRepository;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ *
+ */
+class StockAvailableService
+{
+    /**
+     * @var StockAvailableRepository
+     */
+    protected $stockAvailableRepository;
+
+    public function __construct()
+    {
+        $this->stockAvailableRepository = new StockAvailableRepository();
+    }
+
+    /**
+     * @param int $idProduct
+     * @param bool $outOfStock
+     * @param int $shopId
+     * @param int $idProductAttributeInsurance
+     * @return void
+     */
+    public function createStocks($idProduct, $outOfStock, $shopId, $idProductAttributeInsurance)
+    {
+        \StockAvailable::setProductOutOfStock(
+            $idProduct,
+            $outOfStock,
+            $shopId,
+            $idProductAttributeInsurance
+        );
+
+        if (version_compare(_PS_VERSION_, '1.7.8', '<')) {
+            \StockAvailable::setProductDependsOnStock(
+                $idProduct,
+                $outOfStock == 1 ? false : true,
+                $shopId,
+                $idProductAttributeInsurance
+            );
+        }
+    }
+
+    /**
+     * @param int $idProduct
+     * @param int $quantity
+     * @param int $shopId
+     * @param int $idProductAttributeInsurance
+     * @return void
+     */
+    public function updateStocks($idProduct, $quantity, $shopId, $idProductAttributeInsurance)
+    {
+        $oldQuantity = $this->stockAvailableRepository->getQuantity($idProduct, $idProductAttributeInsurance);
+
+        $quantity = $oldQuantity + $quantity;
+
+        \StockAvailable::setQuantity($idProduct, $idProductAttributeInsurance, $quantity, $shopId);
+    }
+}

--- a/alma/lib/Services/StockAvailableService.php
+++ b/alma/lib/Services/StockAvailableService.php
@@ -70,6 +70,7 @@ class StockAvailableService
                 $idProductAttributeInsurance
             );
         }
+
     }
 
     /**
@@ -81,10 +82,10 @@ class StockAvailableService
      */
     public function updateStocks($idProduct, $quantity, $shopId, $idProductAttributeInsurance)
     {
-        $oldQuantity = $this->stockAvailableRepository->getQuantity($idProduct, $idProductAttributeInsurance);
+        $oldQuantity = $this->stockAvailableRepository->getQuantity($idProduct, $idProductAttributeInsurance, $shopId);
 
         $quantity = $oldQuantity + $quantity;
 
-        \StockAvailable::setQuantity($idProduct, $idProductAttributeInsurance, $quantity, $shopId);
+       $this->stockAvailableRepository->setQuantity($idProduct, $idProductAttributeInsurance, $quantity, $shopId);
     }
 }


### PR DESCRIPTION
### Reason for change

The insurance product stock is negative

[Linear task](https://linear.app/almapay/issue/ECOM-1162/make-sure-that-the-insurance-quantities-are-always-positive)

### How to test

- Mount a clean PS infra
- Order insurances
- See if the amount of stock is correct in the BO insurance product page, combinations tab
- See if in the bo in the order , the field available is good and you don't have this message 

![image](https://github.com/alma/alma-installments-prestashop/assets/110386752/fc25e05d-970b-4551-9b35-b650566ee45d)
