### PR TITLE
Change DB structure for association page

### DIFF
--- a/alma/composer.json
+++ b/alma/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1",
-        "alma/alma-php-client": "dev-insurance",
+        "alma/alma-php-client": "^1.11.1",
         "ext-json": "*",
         "ext-openssl": "*",
         "prestashop/autoindex": "^1.0.0"

--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -45,7 +45,7 @@ class AlmaInsuranceProductRepository
      * @param int $idProductAttributeInsurance
      * @param float $assurancePrice
      * @param int $idAddressDelivery
-     * @param string $insuranceContractInfos
+     * @param array $insuranceContractInfos
      * @return bool
      * @throws \PrestaShopDatabaseException
      */
@@ -72,7 +72,9 @@ class AlmaInsuranceProductRepository
             'id_product_attribute_insurance' => $idProductAttributeInsurance,
             'price' => $assurancePrice,
             'id_address_delivery' => $idAddressDelivery,
-            'insurance_contract_infos' => $insuranceContractInfos
+            'insurance_contract_id' => $insuranceContractInfos['insurance_contract_id'],
+            'cms_reference' => $insuranceContractInfos['cms_reference'],
+            'product_price' => $insuranceContractInfos['product_price']
         ])) {
             return false;
         }
@@ -212,7 +214,9 @@ class AlmaInsuranceProductRepository
           `id_address_delivery` int(10) unsigned NOT NULL,
           `id_order` int(10) unsigned NULL,
           `price` decimal(20,6) NOT NULL DEFAULT 0.000000,
-          `insurance_contract_infos` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+          `insurance_contract_id` varchar(255) NULL,
+          `cms_reference` varchar(255) NULL,
+          `product_price` int(10) unsigned NULL,
           `date_add` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
            PRIMARY KEY (`id_alma_insurance_product`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
@@ -254,8 +258,7 @@ class AlmaInsuranceProductRepository
     public function getContractsInfosByIdCartAndIdShop($idCart, $idShop)
     {
         $sql = '
-            SELECT `id_alma_insurance_product`,
-                   `insurance_contract_infos`
+            SELECT `id_alma_insurance_product`, `insurance_contract_id`, `cms_reference`, `product_price` 
             FROM `' . _DB_PREFIX_ . 'alma_insurance_product` aip
             WHERE aip.`id_cart` = ' . (int)$idCart . '
             AND aip.`id_shop` = ' . (int)$idShop;

--- a/alma/lib/Services/InsuranceProductService.php
+++ b/alma/lib/Services/InsuranceProductService.php
@@ -122,7 +122,7 @@ class InsuranceProductService
      * @param int $idProductAttributeToAssocation
      * @param float $price
      * @param int $idAddressDelivery
-     * @param string $insuranceContractInfos
+     * @param array $insuranceContractInfos
      * @return void
      * @throws \PrestaShopDatabaseException
      */
@@ -162,7 +162,7 @@ class InsuranceProductService
      * @param string $insuranceName
      * @param int $quantity
      * @param int $idCustomization
-     * @param string $insuranceContractInfos
+     * @param array $insuranceContractInfos
      * @param null|\Cart $cart
      * @param int $idProductAttibutePS16
      * @param bool $destroyPost
@@ -276,11 +276,11 @@ class InsuranceProductService
                     $insuranceContract->getName(),
                     $quantity,
                     $idCustomization,
-                    json_encode([
+                    [
                         'insurance_contract_id' => $insuranceContractId,
                         'cms_reference' => $cmsReference,
                         'product_price' => $regularPriceInCents,
-                    ]),
+                    ],
                     $cart,
                     $idProductAttributePS16,
                     $destroyPost

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -244,11 +244,10 @@ class InsuranceService
         $customerService = new CustomerService($cart->id_customer, $cart->id_address_invoice, $cart->id_address_delivery);
 
         foreach ($insuranceContracts as $insuranceContract) {
-            $insuranceContractInfos = json_decode($insuranceContract['insurance_contract_infos'], true);
             $subscriptionData[] = new Subscription(
-                $insuranceContractInfos['insurance_contract_id'],
-                $insuranceContractInfos['cms_reference'],
-                $insuranceContractInfos['product_price'],
+                $insuranceContract['insurance_contract_id'],
+                $insuranceContract['cms_reference'],
+                $insuranceContract['product_price'],
                 $customerService->getSubscriber()
             );
         }
@@ -266,12 +265,10 @@ class InsuranceService
         $file = null;
 
         foreach ($insuranceContracts as $insuranceContract) {
-            $insuranceContractInfos = json_decode($insuranceContract['insurance_contract_infos'], true);
-
             $file = $this->insuranceApiService->getInsuranceContractFileByType(
-                $insuranceContractInfos['insurance_contract_id'],
-                $insuranceContractInfos['cms_reference'],
-                $insuranceContractInfos['product_price']
+                $insuranceContract['insurance_contract_id'],
+                $insuranceContract['cms_reference'],
+                $insuranceContract['product_price']
             );
 
             break;


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1208/change-contract-infos-storage-in-db)


### How to test
 - mount a new clean PS infra
 - do insurance subscriptions
 - in the admin alma/insurance/orders check if the fields insurance_contact_id and insurance_price are not empty or check in db that insurance_contract_id, cms_reference and product price are not empty for table ps_alma_insurance
