### PR TITLE
Send session id and id cart 

### DIFF
--- a/alma/controllers/hook/DisplayProductActionsHookController.php
+++ b/alma/controllers/hook/DisplayProductActionsHookController.php
@@ -29,6 +29,7 @@ if (!defined('_PS_VERSION_')) {
 }
 
 use Alma\PrestaShop\Helpers\Admin\InsuranceHelper as AdminInsuranceHelper;
+use Alma\PrestaShop\Helpers\CartHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
 use Alma\PrestaShop\Helpers\InsuranceHelper;
 use Alma\PrestaShop\Helpers\PriceHelper;
@@ -55,6 +56,12 @@ class DisplayProductActionsHookController extends FrontendHookController
     protected $productHelper;
 
     /**
+     * @var CartHelper
+     */
+    protected $cartHelper;
+
+
+    /**
      * @param $module
      */
     public function __construct($module)
@@ -62,6 +69,8 @@ class DisplayProductActionsHookController extends FrontendHookController
         $this->insuranceHelper = new InsuranceHelper();
         $this->adminInsuranceHelper = new AdminInsuranceHelper($module);
         $this->productHelper = new ProductHelper();
+        $this->cartHelper = new CartHelper();
+
         parent::__construct($module);
     }
 
@@ -126,10 +135,12 @@ class DisplayProductActionsHookController extends FrontendHookController
      * @return false|string
      * @throws \PrestaShopException
      */
-    private function handleSettings($merchantId)
+    protected function handleSettings($merchantId)
     {
         $settings = $this->adminInsuranceHelper->mapDbFieldsWithIframeParams();
         $settings['merchant_id'] = $merchantId;
+        $settings['cart_id'] = $this->cartHelper->getCartIdFromContext();
+        $settings['session_id'] = $this->context->session->getId();
 
         return json_encode($settings);
     }

--- a/alma/lib/Helpers/CartHelper.php
+++ b/alma/lib/Helpers/CartHelper.php
@@ -39,19 +39,32 @@ if (!defined('_PS_VERSION_')) {
  */
 class CartHelper
 {
-    /** @var \Context */
+    /** @var \ContextCore */
     private $context;
     /**
      * @var OrderRepository
      */
     protected $orderRepository;
 
-    public function __construct($context)
+    public function __construct()
     {
-        $this->context = $context;
+        $this->context = \Context::getContext();
         $this->orderRepository = new OrderRepository();
     }
 
+    /**
+     * @return null/int
+     */
+    public function getCartIdFromContext()
+    {
+        $cartId = null;
+
+        if(isset($this->context->cart->id)) {
+            $cartId = $this->context->cart->id;
+        }
+
+        return $cartId;
+    }
     /**
      * Previous cart items of the customer
      *

--- a/alma/lib/Model/PaymentData.php
+++ b/alma/lib/Model/PaymentData.php
@@ -277,7 +277,7 @@ class PaymentData
     private static function buildWebsiteCustomerDetails($context, $customer, $cart, $purchaseAmount)
     {
         $carrierHelper = new CarrierHelper($context);
-        $cartHelper = new CartHelper($context);
+        $cartHelper = new CartHelper();
         $productHelper = new ProductHelper();
         $productRepository = new ProductRepository();
 

--- a/alma/lib/Services/InsuranceApiService.php
+++ b/alma/lib/Services/InsuranceApiService.php
@@ -32,6 +32,7 @@ use Alma\API\Exceptions\ParamsException;
 use Alma\API\Exceptions\RequestException;
 use Alma\API\RequestError;
 use Alma\PrestaShop\Exceptions\InsuranceSubscriptionException;
+use Alma\PrestaShop\Helpers\CartHelper;
 use Alma\PrestaShop\Helpers\ClientHelper;
 use Alma\API\Client;
 use Alma\PrestaShop\Logger;
@@ -44,12 +45,23 @@ class InsuranceApiService
     protected $almaApiClient;
 
     /**
+     * @var \ContextCore
+     */
+    protected $context;
+
+    /**
+     * @var CartHelper
+     */
+    protected $cartHelper;
+
+    /**
      *
      */
     public function __construct()
     {
         $this->almaApiClient = ClientHelper::defaultInstance();
-
+        $this->context = \Context::getContext();
+        $this->cartHelper = new CartHelper();
     }
 
     /**
@@ -65,7 +77,9 @@ class InsuranceApiService
             return $this->almaApiClient->insurance->getInsuranceContract(
                 $insuranceContractId,
                 $cmsReference,
-                $productPrice
+                $productPrice,
+                $this->context->session->getId(),
+                $this->cartHelper->getCartIdFromContext()
             )->getFileByType($type);
         } catch (\Exception  $e) {
             Logger::instance()->error(
@@ -92,7 +106,9 @@ class InsuranceApiService
             return $this->almaApiClient->insurance->getInsuranceContract(
                 $insuranceContractId,
                 $cmsReference,
-                $productPrice
+                $productPrice,
+                $this->context->session->getId(),
+                $this->cartHelper->getCartIdFromContext()
             );
         } catch (\Exception $e) {
             Logger::instance()->error(
@@ -117,7 +133,12 @@ class InsuranceApiService
     public function subscribeInsurance($subscriptionData, $idTransaction)
     {
         try {
-          $result = $this->almaApiClient->insurance->subscription($subscriptionData, $idTransaction);
+          $result = $this->almaApiClient->insurance->subscription(
+              $subscriptionData,
+              $idTransaction,
+              $this->context->session->getId(),
+              $this->cartHelper->getCartIdFromContext()
+          );
 
           if(isset($result['subscriptions'])) {
               return $result['subscriptions'];

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -110,7 +110,9 @@ function refreshWidget() {
         cmsReference,
         regularPriceToCents,
         settings.merchant_id,
-        productDetails.quantity_wanted
+        productDetails.quantity_wanted,
+        settings.cart_id,
+        settings.session_id
     );
 }
 


### PR DESCRIPTION
### Reason for change

Add headers in Insurance API call subscription & eligibility

Send session ID and cart id as header to : 

- eligibility call made from CMS
- subscription call made from CMS
- widget iframe

[Linear task](https://linear.app/almapay/issue/ECOM-1198/prestashop)
