### PR TITLE
[insurance] add cancellation url to subscription

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -86,6 +86,7 @@ class Alma extends PaymentModule
 
         if (version_compare(_PS_VERSION_, '1.7', '>=')) {
             $controllers[] = 'insurance';
+            $controllers[] = 'subscription';
         }
 
         $this->controllers = $controllers;

--- a/alma/controllers/front/subscription.php
+++ b/alma/controllers/front/subscription.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+use Alma\PrestaShop\Logger;
+use Alma\PrestaShop\Traits\AjaxTrait;
+use Alma\PrestaShop\Exceptions\AlmaException;
+use Alma\PrestaShop\Repositories\AlmaInsuranceProductRepository;
+use Alma\PrestaShop\Services\InsuranceProductService;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+class AlmaSubscriptionModuleFrontController extends ModuleFrontController
+{
+    use AjaxTrait;
+
+    public $ssl = true;
+
+    /**
+     * IPN constructor
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->context = Context::getContext();
+    }
+
+    /**
+     * @return void
+     *
+     * @throws PrestaShopException
+     * @throws RefundException
+     * @throws MismatchException
+     */
+    public function postProcess()
+    {
+        parent::postProcess();
+
+        header('Content-Type: application/json');
+
+        $action = Tools::getValue('action');
+        $sid = Tools::getValue('sid');
+
+        if(!$sid) {
+            $this->ajaxRenderAndExit(json_encode(['error' => 'Missing SID']), 500);
+        }
+
+        switch ($action) {
+            case  'cancellation' :
+                $this->ajaxRenderAndExit(json_encode(['success' => true]));
+            default :
+                $this->ajaxRenderAndExit(json_encode(['error' => 'Wrong action']), 500);
+        }
+    }
+}

--- a/alma/controllers/front/subscription.php
+++ b/alma/controllers/front/subscription.php
@@ -22,11 +22,7 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
 
-use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Traits\AjaxTrait;
-use Alma\PrestaShop\Exceptions\AlmaException;
-use Alma\PrestaShop\Repositories\AlmaInsuranceProductRepository;
-use Alma\PrestaShop\Services\InsuranceProductService;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -48,10 +44,6 @@ class AlmaSubscriptionModuleFrontController extends ModuleFrontController
 
     /**
      * @return void
-     *
-     * @throws PrestaShopException
-     * @throws RefundException
-     * @throws MismatchException
      */
     public function postProcess()
     {
@@ -61,13 +53,18 @@ class AlmaSubscriptionModuleFrontController extends ModuleFrontController
 
         $action = Tools::getValue('action');
         $sid = Tools::getValue('sid');
+        $trace = Tools::getValue('trace');
 
         if(!$sid) {
-            $this->ajaxRenderAndExit(json_encode(['error' => 'Missing SID']), 500);
+            $this->ajaxRenderAndExit(json_encode(['error' => 'Missing Id']), 500);
+        }
+
+        if(!$trace) {
+            $this->ajaxRenderAndExit(json_encode(['error' => 'Missing secutiry token']), 500);
         }
 
         switch ($action) {
-            case  'cancellation' :
+            case  'update' :
                 $this->ajaxRenderAndExit(json_encode(['success' => true]));
             default :
                 $this->ajaxRenderAndExit(json_encode(['error' => 'Wrong action']), 500);

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -235,7 +235,7 @@ class InsuranceService
         $cancelUrl = urldecode($this->context->link->getModuleLink(
             $this->module->name,
             'subscription',
-            ['action' => 'cancellation', 'sid' => ' {subscription_external_id}']
+            ['action' => 'cancellation', 'sid' => '{subscription_external_id}']
         ));
 
         foreach ($insuranceContracts as $insuranceContract) {

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -232,10 +232,14 @@ class InsuranceService
         $subscriptionData = [];
         $customerService = new CustomerService($cart->id_customer, $cart->id_address_invoice, $cart->id_address_delivery);
 
-        $cancelUrl = urldecode($this->context->link->getModuleLink(
+        $callbackUrl = urldecode($this->context->link->getModuleLink(
             $this->module->name,
             'subscription',
-            ['action' => 'cancellation', 'sid' => '{subscription_external_id}']
+            [
+                'action' => 'update',
+                'sid' => '<subscription_external_id>',
+                'trace' => '<trace>',
+            ]
         ));
 
         foreach ($insuranceContracts as $insuranceContract) {
@@ -244,7 +248,7 @@ class InsuranceService
                 $insuranceContract['cms_reference'],
                 $insuranceContract['product_price'],
                 $customerService->getSubscriber(),
-                $cancelUrl
+                $callbackUrl
             );
         }
 

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -232,12 +232,19 @@ class InsuranceService
         $subscriptionData = [];
         $customerService = new CustomerService($cart->id_customer, $cart->id_address_invoice, $cart->id_address_delivery);
 
+        $cancelUrl = urldecode($this->context->link->getModuleLink(
+            $this->module->name,
+            'subscription',
+            ['action' => 'cancellation', 'sid' => ' {subscription_external_id}']
+        ));
+
         foreach ($insuranceContracts as $insuranceContract) {
             $subscriptionData[] = new Subscription(
                 $insuranceContract['insurance_contract_id'],
                 $insuranceContract['cms_reference'],
                 $insuranceContract['product_price'],
-                $customerService->getSubscriber()
+                $customerService->getSubscriber(),
+                $cancelUrl
             );
         }
 


### PR DESCRIPTION
### Reason for change
add cancellation url to subscription #292

[Linear task](https://linear.app/almapay/issue/ECOM-1220/prestashop-sends-the-key-cancel-url-with-the-subscription)

### How to test

Have a fresh prestashop installation or reset the module in order to install the new controller

http://prestashop-a-1-7-8-7.local.test/module/alma/subscription?action=update&sid=test&trace=test
response : {"success":true}

http://prestashop-a-1-7-8-7.local.test/module/alma/subscription?action=update&trace=test
response : {"error":"Missing id"}

http://prestashop-a-1-7-8-7.local.test/module/alma/subscription?action=update&sid=test
response : {"error":"Missing security token"}


http://prestashop-a-1-7-8-7.local.test/module/alma/subscription?sid=eeeeee&trace=eeee
response : {"error":"Wrong action"}

The new parameters  to send a te subscription `cms_callback_url`  need to be tested too