### PR TITLE
Add verification type number on field amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.5
+
+- fix: Add verification of number on type in amount field for refund
+
 ## v3.1.4
 
 - fix: Return for refunded payments

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -30,7 +30,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 
 class Alma extends PaymentModule
 {
-    const VERSION = '3.1.4';
+    const VERSION = '3.1.5';
 
     public $_path;
     public $local_path;
@@ -65,7 +65,7 @@ class Alma extends PaymentModule
     {
         $this->name = 'alma';
         $this->tab = 'payments_gateways';
-        $this->version = '3.1.4';
+        $this->version = '3.1.5';
         $this->author = 'Alma';
         $this->need_instance = false;
         $this->bootstrap = true;

--- a/alma/composer.json
+++ b/alma/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1",
-        "alma/alma-php-client": "^2.0.0",
+        "alma/alma-php-client": "^2.0.1",
         "ext-json": "*",
         "ext-openssl": "*",
         "prestashop/autoindex": "^1.0.0"

--- a/alma/composer.json
+++ b/alma/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1",
-        "alma/alma-php-client": "^1.11.1",
+        "alma/alma-php-client": "^2.0.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "prestashop/autoindex": "^1.0.0"

--- a/alma/views/templates/hook/order_refund_bs3.tpl
+++ b/alma/views/templates/hook/order_refund_bs3.tpl
@@ -87,7 +87,13 @@
                 <div class="col-lg-2">
                     <div class="input-group">
                         <span class="input-group-addon">{$order.currencySymbol|escape:'htmlall':'UTF-8'}</span>
-                        <input type="text" class="alma" value="" name="amount" id="amount" placeholder="{$wording.placeholderInputRefundPartial|escape:'htmlall':'UTF-8'}"/>
+                        <input type="number"
+                               step="0.01"
+                               class="alma"
+                               value=""
+                               name="amount"
+                               id="amount"
+                               placeholder="{$wording.placeholderInputRefundPartial|escape:'htmlall':'UTF-8'}"/>
                     </div>
                 </div>
             </div>

--- a/alma/views/templates/hook/order_refund_bs4.tpl
+++ b/alma/views/templates/hook/order_refund_bs4.tpl
@@ -92,7 +92,8 @@
                 <div class="col-sm">
                     <div class="input-group">
                         <input 
-                            type="text" 
+                            type="number"
+                            step="0.01"
                             class="alma" 
                             name="amount" 
                             autocomplete="off" 

--- a/alma/views/templates/hook/order_refund_ps15.tpl
+++ b/alma/views/templates/hook/order_refund_ps15.tpl
@@ -88,7 +88,14 @@
                 {$wording.labelAmoutRefundPartial|escape:'htmlall':'UTF-8'}
             </label>
             <div class="margin-form">
-                <input type="text" autocomplete="off" class="alma-input-number" id="amount" value="" name="amount" placeholder="{$wording.placeholderInputRefundPartial|escape:'htmlall':'UTF-8'}" />
+                <input type="number"
+                       step="0.01"
+                       autocomplete="off"
+                       class="alma-input-number"
+                       id="amount"
+                       value=""
+                       name="amount"
+                       placeholder="{$wording.placeholderInputRefundPartial|escape:'htmlall':'UTF-8'}" />
             </div>
         </div>  
         <div class="clear"></div>


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1262/%5Bmodule%5D-add-verification-type-number-on-field-amount)

### Code changes

Change inputs type to number and return an error if amount equals zero.

### How to test

Make a partial refund with string, with decimal number and with zero.

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->