### PR TITLE
Improve insurance opt-in message

### DIFF
--- a/alma/controllers/hook/TermsAndConditionsHookController.php
+++ b/alma/controllers/hook/TermsAndConditionsHookController.php
@@ -99,7 +99,7 @@ class TermsAndConditionsHookController extends FrontendHookController
 
             // @TODO : Find an alternative about the modal on the click to the link
             $returnedTermsAndConditions[] = $this->termsAndConditions
-                ->setText($termsAndConditionsInsurance['text'], $termsAndConditionsInsurance['link'])
+                ->setText($termsAndConditionsInsurance['text'], $termsAndConditionsInsurance['link-notice'], $termsAndConditionsInsurance['link-ipid'], $termsAndConditionsInsurance['link-fic'])
                 ->setIdentifier('terms-and-conditions-alma-insurance');
 
             return $returnedTermsAndConditions;

--- a/alma/lib/Services/InsuranceApiService.php
+++ b/alma/lib/Services/InsuranceApiService.php
@@ -65,26 +65,32 @@ class InsuranceApiService
     }
 
     /**
-     * @param int $insuranceContractId
-     * @param string $cmsReference
-     * @param int $productPrice
-     * @param string $type
-     * @return File|null
+     * @param $insuranceContractId
+     * @param $cmsReference
+     * @param $productPrice
+     * @return array|null
      */
-    public function getInsuranceContractFileByType($insuranceContractId, $cmsReference, $productPrice, $type = 'ipid-document')
+    public function getInsuranceContractFiles($insuranceContractId, $cmsReference, $productPrice)
     {
         try {
-            return $this->almaApiClient->insurance->getInsuranceContract(
+            $filesByType = [];
+            $files = $this->almaApiClient->insurance->getInsuranceContract(
                 $insuranceContractId,
                 $cmsReference,
                 $productPrice,
                 $this->context->session->getId(),
                 $this->cartHelper->getCartIdFromContext()
-            )->getFileByType($type);
+            )->getFiles();
+
+            foreach ($files as $file) {
+                $filesByType[$file->getType()] = $file->getPublicUrl();
+            }
+
+            return $filesByType;
         } catch (\Exception  $e) {
             Logger::instance()->error(
                 sprintf(
-                    '[Alma] Impossible to retrieve insurance contract file, message "%s", trace "%s"',
+                    '[Alma] Impossible to retrieve insurance contract files, message "%s", trace "%s"',
                     $e->getMessage(),
                     $e->getTraceAsString()
                 )

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -251,25 +251,33 @@ class InsuranceService
      */
     public function createTextTermsAndConditions($insuranceContracts)
     {
-        $file = null;
+        $files = null;
+        $name = '';
 
         foreach ($insuranceContracts as $insuranceContract) {
-            $file = $this->insuranceApiService->getInsuranceContractFileByType(
+            $files = $this->insuranceApiService->getInsuranceContractFiles(
                 $insuranceContract['insurance_contract_id'],
                 $insuranceContract['cms_reference'],
                 $insuranceContract['product_price']
             );
+            $name = $this->insuranceApiService->getInsuranceContract(
+                $insuranceContract['insurance_contract_id'],
+                $insuranceContract['cms_reference'],
+                $insuranceContract['product_price']
+            )->getName();
 
             break;
         }
 
-        if ($file) {
+        if ($files) {
             return [
                 'text' => sprintf(
-                    $this->module->l('By accepting to subscribe to [%s], I confirm my thorough review, acceptance, and retention of the general terms outlined in the information booklet and the insurance product details. Additionally, I consent to receiving contractual information by e-mail for the purpose of securely storing it in a durable format.', 'TermsAndConditionsHookController'),
-                    $file->getName()
+                    $this->module->l('I agree to subscribe to %s coverage, and I confirm that I have read, accepted, and saved the [information notice, which constitutes the general conditions], the [insurance product information document], and the [pre-contractual information and advice sheet] before finalising my purchase and subscribing to the insurance.', 'TermsAndConditionsHookController'),
+                    $name
                 ),
-                'link' => $file->getPublicUrl()
+                'link-notice' => $files['notice-document'],
+                'link-ipid' => $files['ipid-document'],
+                'link-fic' => $files['fic-document']
             ];
         }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1253/improve-insurance-opt-in-message-on-prestashop)

### Code changes

We add each files in the opt-in message of insurance

### How to test

Add an insurance and see the opt-in message with the three files and the name

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->