### PR TITLE
[insurance] Send cartId & customerSessionId to the iFrame

### DIFF
--- a/alma/controllers/hook/DisplayProductActionsHookController.php
+++ b/alma/controllers/hook/DisplayProductActionsHookController.php
@@ -114,12 +114,14 @@ class DisplayProductActionsHookController extends FrontendHookController
         $this->context->smarty->assign([
             'settingsInsurance' => $settings,
             'iframeUrl' => sprintf(
-                "%s%s?cms_reference=%s&product_price=%s&merchant_id=%s",
+                "%s%s?cms_reference=%s&product_price=%s&merchant_id=%s&customer_session_id=%s&cart_id=%s",
                 $this->adminInsuranceHelper->envUrl(),
                 ConstantsHelper::FO_IFRAME_WIDGET_INSURANCE_PATH,
                 $cmsReference,
                 $regularPriceInCents,
-                $merchantId
+                $merchantId,
+                $this->context->session->getId(),
+                $this->cartHelper->getCartIdFromContext()
             ),
             'scriptModalUrl' => sprintf(
                 "%s%s",


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1286/send-cartid-and-customersessionid-to-the-iframe)

### Code changes

We add the customer session id and the cart id in the url of the insurance widget iframe

### How to test

Display the insurance widget and see in the url if the cartId ans customerSessionId are displayed

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->