### PR TITLE
[insurance] change fields from insurance association table + add cancellation url to subscription

### DIFF
--- a/alma/composer.json
+++ b/alma/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1",
-        "alma/alma-php-client": "^1.11.1",
+        "alma/alma-php-client": "^2.0.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "prestashop/autoindex": "^1.0.0"

--- a/alma/controllers/admin/AdminAlmaInsuranceOrders.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceOrders.php
@@ -74,7 +74,7 @@ class AdminAlmaInsuranceOrdersController extends ModuleAdminController
                 'title' => $this->module->l('Insurance product'),
                 'type' => 'text',
             ],
-            'subscription_price' => [
+            'subscription_amount' => [
                 'title' => $this->module->l('Insurance Price'),
                 'type' => 'text',
             ],
@@ -82,7 +82,7 @@ class AdminAlmaInsuranceOrdersController extends ModuleAdminController
                 'title' => $this->module->l('Subscription Contract'),
                 'type' => 'text',
             ],
-            'state' => [
+            'subscription_state' => [
                 'title' => $this->module->l('State'),
                 'type' => 'text',
             ],
@@ -136,8 +136,8 @@ class AdminAlmaInsuranceOrdersController extends ModuleAdminController
             $this->_list[$key]['customer'] = $customer->lastname . ' ' .  $customer->firstname;
             $this->_list[$key]['date'] = $order->date_add;
             $this->_list[$key]['product_price'] = PriceHelper::formatPriceToCentsByCurrencyId($details['product_price']);
-            $this->_list[$key]['price'] = PriceHelper::formatPriceToCentsByCurrencyId(
-                PriceHelper::convertPriceToCents($details['price'])
+            $this->_list[$key]['subscription_amount'] = PriceHelper::formatPriceToCentsByCurrencyId(
+                PriceHelper::convertPriceToCents($details['subscription_amount'])
             );
 
 

--- a/alma/controllers/admin/AdminAlmaInsuranceOrders.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceOrders.php
@@ -78,7 +78,7 @@ class AdminAlmaInsuranceOrdersController extends ModuleAdminController
                 'title' => $this->module->l('Insurance Price'),
                 'type' => 'text',
             ],
-            'broker_subscription_id' => [
+            'subscription_broker_id' => [
                 'title' => $this->module->l('Subscription Contract'),
                 'type' => 'text',
             ],

--- a/alma/controllers/admin/AdminAlmaInsuranceOrders.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceOrders.php
@@ -74,16 +74,12 @@ class AdminAlmaInsuranceOrdersController extends ModuleAdminController
                 'title' => $this->module->l('Insurance product'),
                 'type' => 'text',
             ],
-            'price' => [
-                'title' => $this->module->l('Insurance product price'),
+            'subscription_price' => [
+                'title' => $this->module->l('Insurance Price'),
                 'type' => 'text',
             ],
-            'insurance_contract_id' => [
-                'title' => $this->module->l('Insurance contract id'),
-                'type' => 'text',
-            ],
-            'subscription_id' => [
-                'title' => $this->module->l('Subscription id'),
+            'broker_subscription_id' => [
+                'title' => $this->module->l('Subscription Contract'),
                 'type' => 'text',
             ],
             'state' => [

--- a/alma/controllers/admin/AdminAlmaInsuranceOrders.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceOrders.php
@@ -136,9 +136,7 @@ class AdminAlmaInsuranceOrdersController extends ModuleAdminController
             $this->_list[$key]['customer'] = $customer->lastname . ' ' .  $customer->firstname;
             $this->_list[$key]['date'] = $order->date_add;
             $this->_list[$key]['product_price'] = PriceHelper::formatPriceToCentsByCurrencyId($details['product_price']);
-            $this->_list[$key]['subscription_amount'] = PriceHelper::formatPriceToCentsByCurrencyId(
-                PriceHelper::convertPriceToCents($details['subscription_amount'])
-            );
+            $this->_list[$key]['subscription_amount'] = PriceHelper::formatPriceToCentsByCurrencyId($details['subscription_amount']);
 
 
             $this->_list[$key]['product'] = $this->getProductName(

--- a/alma/controllers/admin/AdminAlmaInsuranceOrders.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceOrders.php
@@ -136,7 +136,9 @@ class AdminAlmaInsuranceOrdersController extends ModuleAdminController
             $this->_list[$key]['customer'] = $customer->lastname . ' ' .  $customer->firstname;
             $this->_list[$key]['date'] = $order->date_add;
             $this->_list[$key]['product_price'] = PriceHelper::formatPriceToCentsByCurrencyId($details['product_price']);
-            $this->_list[$key]['subscription_amount'] = PriceHelper::formatPriceToCentsByCurrencyId($details['subscription_amount']);
+            $this->_list[$key]['subscription_amount'] = PriceHelper::formatPriceToCentsByCurrencyId(
+                PriceHelper::convertPriceToCents($details['price'])
+            );
 
 
             $this->_list[$key]['product'] = $this->getProductName(

--- a/alma/lib/Helpers/ApiHelper.php
+++ b/alma/lib/Helpers/ApiHelper.php
@@ -105,13 +105,6 @@ class ApiHelper
             throw new ActivationException($this->module);
         }
 
-        $this->saveFeatureFlag(
-            $merchant,
-            'cms_allow_inpage',
-            ConstantsHelper::ALMA_ALLOW_INPAGE,
-            InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE
-        );
-
         if (version_compare(_PS_VERSION_, '1.7', '>=')) {
             $this->handleInsuranceFlag($merchant);
         }

--- a/alma/lib/Model/InsuranceProduct.php
+++ b/alma/lib/Model/InsuranceProduct.php
@@ -32,8 +32,6 @@ if (!defined('_PS_VERSION_')) {
 
 class InsuranceProduct extends \ObjectModel
 {
-    const STATE_ACTIVE = 'active';
-
     /** @var int Id  */
     public $id_alma_insurance_product;
 
@@ -71,13 +69,13 @@ class InsuranceProduct extends \ObjectModel
     public $product_price;
 
     /** @var float Subscription price Neat */
-    public $subscription_price;
+    public $subscription_amount;
 
     /** @var string Object creation date */
     public $date_add;
 
     /** @var string Object validity */
-    public $state;
+    public $subscription_state;
 
     /** @var string Neat insurance id */
     public $subscription_id;
@@ -129,9 +127,9 @@ class InsuranceProduct extends \ObjectModel
             'product_price' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice'],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'subscription_id' => ['type' => self::TYPE_STRING],
-            'subscription_price' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice'],
+            'subscription_amount' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice'],
             'subscription_broker_id' => ['type' => self::TYPE_STRING],
-            'state' => ['type' => self::TYPE_STRING],
+            'subscription_state' => ['type' => self::TYPE_STRING],
             'date_of_cancelation' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'date_of_cancelation_request' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'reason_of_cancelation' => ['type' => self::TYPE_STRING],

--- a/alma/lib/Model/InsuranceProduct.php
+++ b/alma/lib/Model/InsuranceProduct.php
@@ -83,7 +83,7 @@ class InsuranceProduct extends \ObjectModel
     public $subscription_id;
 
     /** @var string Neat client insurance id */
-    public $broker_subscription_id;
+    public $subscription_broker_id;
 
 
     /** @var string Alma cms reference */
@@ -130,7 +130,7 @@ class InsuranceProduct extends \ObjectModel
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'subscription_id' => ['type' => self::TYPE_STRING],
             'subscription_price' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice'],
-            'broker_subscription_id' => ['type' => self::TYPE_STRING],
+            'subscription_broker_id' => ['type' => self::TYPE_STRING],
             'state' => ['type' => self::TYPE_STRING],
             'date_of_cancelation' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'date_of_cancelation_request' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],

--- a/alma/lib/Model/InsuranceProduct.php
+++ b/alma/lib/Model/InsuranceProduct.php
@@ -70,6 +70,9 @@ class InsuranceProduct extends \ObjectModel
     /** @var float Price of the product */
     public $product_price;
 
+    /** @var float Subscription price Neat */
+    public $subscription_price;
+
     /** @var string Object creation date */
     public $date_add;
 
@@ -79,14 +82,21 @@ class InsuranceProduct extends \ObjectModel
     /** @var string Neat insurance id */
     public $subscription_id;
 
+    /** @var string Neat client insurance id */
+    public $broker_subscription_id;
+
+
     /** @var string Alma cms reference */
     public $cms_reference;
 
     /** @var string Object cancellation date */
-    public $date_of_cancellation;
+    public $date_of_cancelation;
+
+    /** @var string Object request cancellation date */
+    public $date_of_cancelation_request;
 
     /** @var string reason of cancellation */
-    public $reason_of_cancellation;
+    public $reason_of_cancelation;
 
     /** @var bool Object refunded state */
     public $is_refunded;
@@ -119,9 +129,12 @@ class InsuranceProduct extends \ObjectModel
             'product_price' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice'],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'subscription_id' => ['type' => self::TYPE_STRING],
+            'subscription_price' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice'],
+            'broker_subscription_id' => ['type' => self::TYPE_STRING],
             'state' => ['type' => self::TYPE_STRING],
-            'date_of_cancellation' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
-            'reason_of_cancellation' => ['type' => self::TYPE_STRING],
+            'date_of_cancelation' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
+            'date_of_cancelation_request' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
+            'reason_of_cancelation' => ['type' => self::TYPE_STRING],
             'is_refunded' => ['type' => self::TYPE_BOOL],
             'date_of_refund' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'mode' => ['type' => self::TYPE_STRING]

--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -197,7 +197,7 @@ class AlmaInsuranceProductRepository
             `product_price` int(10) unsigned NULL,
             `date_add` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             `subscription_id` varchar(255) null,
-            `subscription_price` int(10) unsigned NULL,
+            `subscription_amount` int(10) unsigned NULL,
             `subscription_broker_id` varchar(255) null,
             `state` varchar(255) null,
             `date_of_cancelation` datetime null,

--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -198,7 +198,7 @@ class AlmaInsuranceProductRepository
             `date_add` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             `subscription_id` varchar(255) null,
             `subscription_price` int(10) unsigned NULL,
-            `broker_subscription_id` varchar(255) null,
+            `subscription_broker_id` varchar(255) null,
             `state` varchar(255) null,
             `date_of_cancelation` datetime null,
             `reason_of_cancelation` text null,   
@@ -209,9 +209,9 @@ class AlmaInsuranceProductRepository
             PRIMARY KEY (`id_alma_insurance_product`) ,
             index `ps_alma_insurance_product_cart_shop` (`id_cart`, `id_shop`),
             index `ps_alma_insurance_product`  (`id_product`, `id_shop`, `id_product_attribute`, `id_customization`, `id_cart`) ,
-            index `ps_broker_id`  (`broker_subscription_id`) ,
+            index `ps_broker_id`  (`subscription_broker_id`) ,
             constraint ps_alma_insurance_product_pk  unique (`subscription_id`) ,
-            constraint ps_alma_insurance_broker_pk  unique (`broker_subscription_id`)
+            constraint ps_alma_insurance_broker_pk  unique (`subscription_broker_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
 
         return \Db::getInstance()->execute($sql);

--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -199,7 +199,7 @@ class AlmaInsuranceProductRepository
             `subscription_id` varchar(255) null,
             `subscription_amount` int(10) unsigned NULL,
             `subscription_broker_id` varchar(255) null,
-            `state` varchar(255) null,
+            `subscription_state` varchar(255) null,
             `date_of_cancelation` datetime null,
             `reason_of_cancelation` text null,   
             `is_refunded` boolean default 0 null,
@@ -274,7 +274,7 @@ class AlmaInsuranceProductRepository
             WHERE `id_order` = ' . (int)$orderId. '
             AND `insurance_contract_id` = "' . $contractId. '" 
             AND `cms_reference` = "' . $cmsReference. '" 
-            AND `state` is NULL 
+            AND `subscription_state` is NULL 
             AND `id_shop` = ' . (int)$shopId;
 
         return \Db::getInstance()->getRow($sql);

--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -197,16 +197,21 @@ class AlmaInsuranceProductRepository
             `product_price` int(10) unsigned NULL,
             `date_add` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             `subscription_id` varchar(255) null,
+            `subscription_price` int(10) unsigned NULL,
+            `broker_subscription_id` varchar(255) null,
             `state` varchar(255) null,
-            `date_of_cancellation` datetime null,
-            `reason_of_cancellation` text null,   
+            `date_of_cancelation` datetime null,
+            `reason_of_cancelation` text null,   
             `is_refunded` boolean default 0 null,
             `date_of_refund` datetime null,
+            `date_of_cancelation_request` datetime null,
             `mode` varchar(255) not NULL,
             PRIMARY KEY (`id_alma_insurance_product`) ,
             index `ps_alma_insurance_product_cart_shop` (`id_cart`, `id_shop`),
             index `ps_alma_insurance_product`  (`id_product`, `id_shop`, `id_product_attribute`, `id_customization`, `id_cart`) ,
-            constraint ps_alma_insurance_product_pk  unique (`subscription_id`)
+            index `ps_broker_id`  (`broker_subscription_id`) ,
+            constraint ps_alma_insurance_product_pk  unique (`subscription_id`) ,
+            constraint ps_alma_insurance_broker_pk  unique (`broker_subscription_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
 
         return \Db::getInstance()->execute($sql);

--- a/alma/lib/Services/InsuranceSubscriptionService.php
+++ b/alma/lib/Services/InsuranceSubscriptionService.php
@@ -140,7 +140,7 @@ class InsuranceSubscriptionService
 
         $insuranceProduct = new InsuranceProduct($almaInsuranceProduct['id_alma_insurance_product']);
         $insuranceProduct->subscription_id = $subscription['subscription_id'];
-        $insuranceProduct->broker_subscription_id = $subscription['broker_subscription_id'];
+        $insuranceProduct->subscription_broker_id = $subscription['subscription_broker_id'];
         $insuranceProduct->subscription_price = $subscription['subscription_price'];
         $insuranceProduct->state = $subscription['state'];
         $insuranceProduct->save();

--- a/alma/lib/Services/InsuranceSubscriptionService.php
+++ b/alma/lib/Services/InsuranceSubscriptionService.php
@@ -140,7 +140,9 @@ class InsuranceSubscriptionService
 
         $insuranceProduct = new InsuranceProduct($almaInsuranceProduct['id_alma_insurance_product']);
         $insuranceProduct->subscription_id = $subscription['subscription_id'];
-        $insuranceProduct->state = InsuranceProduct::STATE_ACTIVE;
+        $insuranceProduct->broker_subscription_id = $subscription['broker_subscription_id'];
+        $insuranceProduct->subscription_price = $subscription['subscription_price'];
+        $insuranceProduct->state = $subscription['state'];
         $insuranceProduct->save();
     }
 

--- a/alma/lib/Services/InsuranceSubscriptionService.php
+++ b/alma/lib/Services/InsuranceSubscriptionService.php
@@ -89,6 +89,7 @@ class InsuranceSubscriptionService
                 $subscriptionData,
                 $orderPayment->transaction_id
             );
+
             $this->confirmSubscriptions($order->id_cart, $order->id_shop, $subscriptions);
         }
     }
@@ -139,14 +140,14 @@ class InsuranceSubscriptionService
         }
 
         $insuranceProduct = new InsuranceProduct($almaInsuranceProduct['id_alma_insurance_product']);
-        $insuranceProduct->subscription_id = $subscription['subscription_id'];
+        $insuranceProduct->subscription_id = $subscription['id'];
         
-        if(isset($subscription['subscription_broker_id'])) {
-            $insuranceProduct->subscription_broker_id = $subscription['subscription_broker_id'];
+        if(!empty($subscription['broker_subscription_id'])) {
+            $insuranceProduct->subscription_broker_id = $subscription['broker_subscription_id'];
         }
 
-        $insuranceProduct->subscription_amount = $subscription['subscription_amount'];
-        $insuranceProduct->subscription_state = $subscription['subscription_state'];
+        $insuranceProduct->subscription_amount = $subscription['amount'];
+        $insuranceProduct->subscription_state = $subscription['state'];
         $insuranceProduct->save();
     }
 

--- a/alma/lib/Services/InsuranceSubscriptionService.php
+++ b/alma/lib/Services/InsuranceSubscriptionService.php
@@ -140,9 +140,13 @@ class InsuranceSubscriptionService
 
         $insuranceProduct = new InsuranceProduct($almaInsuranceProduct['id_alma_insurance_product']);
         $insuranceProduct->subscription_id = $subscription['subscription_id'];
-        $insuranceProduct->subscription_broker_id = $subscription['subscription_broker_id'];
-        $insuranceProduct->subscription_price = $subscription['subscription_price'];
-        $insuranceProduct->state = $subscription['state'];
+        
+        if(isset($subscription['subscription_broker_id'])) {
+            $insuranceProduct->subscription_broker_id = $subscription['subscription_broker_id'];
+        }
+
+        $insuranceProduct->subscription_amount = $subscription['subscription_amount'];
+        $insuranceProduct->subscription_state = $subscription['subscription_state'];
         $insuranceProduct->save();
     }
 


### PR DESCRIPTION
### Reason for change

Change format data
[Linear task](https://linear.app/almapay/issue/ECOM-1278/prestashop)

add cancellation url to subscription #292

[Linear task](https://linear.app/almapay/issue/ECOM-1220/prestashop-sends-the-key-cancel-url-with-the-subscription)

### How to test

- [x]  play with insurance on a new clean infra

- [x] Do insurance subscription and ensure that it works and we have subscription_amount and subscription_state field DB

- [x] Try this urls 
http://prestashop-a-1-7-8-7.local.test/module/alma/subscription?action=update&sid=test&trace=test
response : {"success":true}

http://prestashop-a-1-7-8-7.local.test/module/alma/subscription?action=update&trace=test
response : {"error":"Missing id"}

http://prestashop-a-1-7-8-7.local.test/module/alma/subscription?action=update&sid=test
response : {"error":"Missing security token"}


http://prestashop-a-1-7-8-7.local.test/module/alma/subscription?sid=eeeeee&trace=eeee
response : {"error":"Wrong action"}

- [x] The new parameters  to send a te subscription `cms_callback_url`  need to be tested too
