### PR TITLE
[develop] Bug : Pay Now not working PS 1.5 / 1.6 without inpage

### DIFF
--- a/alma/controllers/hook/DisplayPaymentHookController.php
+++ b/alma/controllers/hook/DisplayPaymentHookController.php
@@ -133,7 +133,6 @@ class DisplayPaymentHookController extends FrontendHookController
             if ($isPayNow) {
                 $paymentOption['text'] = SettingsCustomFieldsHelper::getPayNowButtonTitleByLang($idLang);
                 $paymentOption['desc'] = SettingsCustomFieldsHelper::getPayNowButtonDescriptionByLang($idLang);
-                $paymentOption['isInPageEnabled'] = true;
             }
             $paymentOptions[$key] = $paymentOption;
             $sortOptions[$key] = $feePlans->$key->order;


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1256/bug-pay-now-not-working-ps-15-16-without-inpage)

### Code changes

We forced `true` on InPage for Pay Now on PS < 1.7
We replaced with the variable which is set in configuration

### How to test

- Install the module
- disabled In Page
- Go to the payment page and pay with Pay now

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->