### PR TITLE
Prevent to recreate subscription on status order change

### DIFF
--- a/alma/lib/Helpers/InsuranceHelper.php
+++ b/alma/lib/Helpers/InsuranceHelper.php
@@ -89,7 +89,7 @@ class InsuranceHelper
     {
         $rowTriggered = $this->insuranceProductRepository->hasOrderBeenTriggered($order) ;
 
-        if($rowTriggered) {
+        if ($rowTriggered) {
             return false;
         }
 

--- a/alma/lib/Helpers/InsuranceHelper.php
+++ b/alma/lib/Helpers/InsuranceHelper.php
@@ -26,7 +26,7 @@ namespace Alma\PrestaShop\Helpers;
 
 use Alma\PrestaShop\Repositories\CartProductRepository;
 use Alma\PrestaShop\Repositories\ProductRepository;
-use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use Alma\PrestaShop\Repositories\AlmaInsuranceProductRepository;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -44,6 +44,12 @@ class InsuranceHelper
      */
     public $productRepository;
 
+
+    /**
+     * @var AlmaInsuranceProductRepository
+     */
+    public $insuranceProductRepository;
+
     /**
      *
      */
@@ -51,6 +57,7 @@ class InsuranceHelper
     {
         $this->cartProductRepository = new CartProductRepository();
         $this->productRepository = new ProductRepository();
+        $this->insuranceProductRepository = new AlmaInsuranceProductRepository();
     }
 
     /**
@@ -73,6 +80,22 @@ class InsuranceHelper
             && (bool) (int) SettingsHelper::get(ConstantsHelper::ALMA_ALLOW_INSURANCE, false)
             && (bool) (int) SettingsHelper::get(ConstantsHelper::ALMA_ACTIVATE_INSURANCE, false);
     }
+
+    /**
+     * @param \OrderCore $order
+     * @return boolean
+     */
+    public function canInsuranceSubscriptionBeTriggered($order)
+    {
+        $rowTriggered = $this->insuranceProductRepository->hasOrderBeenTriggered($order) ;
+
+        if($rowTriggered) {
+            return false;
+        }
+
+        return true;
+    }
+
 
     /**
      * @return bool

--- a/alma/lib/Model/InsuranceProduct.php
+++ b/alma/lib/Model/InsuranceProduct.php
@@ -130,11 +130,11 @@ class InsuranceProduct extends \ObjectModel
             'subscription_amount' => ['type' => self::TYPE_FLOAT, 'validate' => 'isPrice'],
             'subscription_broker_id' => ['type' => self::TYPE_STRING],
             'subscription_state' => ['type' => self::TYPE_STRING],
-            'date_of_cancelation' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
-            'date_of_cancelation_request' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
+            'date_of_cancelation' => ['type' => self::TYPE_DATE, 'validate'],
+            'date_of_cancelation_request' => ['type' => self::TYPE_DATE],
             'reason_of_cancelation' => ['type' => self::TYPE_STRING],
             'is_refunded' => ['type' => self::TYPE_BOOL],
-            'date_of_refund' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
+            'date_of_refund' => ['type' => self::TYPE_DATE],
             'mode' => ['type' => self::TYPE_STRING]
         ],
     ];

--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -279,4 +279,22 @@ class AlmaInsuranceProductRepository
 
         return \Db::getInstance()->getRow($sql);
     }
+
+
+    /**
+     * @param \OrderCore$order
+     * @return array|null
+     */
+    public function hasOrderBeenTriggered($order)
+    {
+        $sql = '
+            SELECT `id_alma_insurance_product` as id
+            FROM `' . _DB_PREFIX_ . 'alma_insurance_product` aip
+            WHERE aip.`id_cart` = ' . (int)$order->id_cart . '
+            AND aip.`subscription_state` IS NOT NULL 
+            AND aip.`id_order` = ' . (int)$order->id . ' 
+            AND aip.`id_shop` = ' . (int)$order->id_shop  ;
+
+        return \Db::getInstance()->getRow($sql);
+    }
 }

--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -291,8 +291,8 @@ class AlmaInsuranceProductRepository
             SELECT `id_alma_insurance_product` as id
             FROM `' . _DB_PREFIX_ . 'alma_insurance_product` aip
             WHERE aip.`id_cart` = ' . (int)$order->id_cart . '
-            AND aip.`subscription_state` IS NOT NULL 
-            AND aip.`id_order` = ' . (int)$order->id . ' 
+            AND aip.`subscription_state` IS NOT NULL
+            AND aip.`id_order` = ' . (int)$order->id . '
             AND aip.`id_shop` = ' . (int)$order->id_shop  ;
 
         return \Db::getInstance()->getRow($sql);

--- a/alma/lib/Services/InsuranceSubscriptionService.php
+++ b/alma/lib/Services/InsuranceSubscriptionService.php
@@ -127,14 +127,7 @@ class InsuranceSubscriptionService
 
         if(!$almaInsuranceProduct) {
             throw new InsuranceSubscriptionException(
-                sprintf(
-                    'Data not found in db for subscription "%s", order id "%s", shop id "%s", contract id "%s", cms_reference "%s"',
-                    $subscription['subscription_id'],
-                    $orderId,
-                    $shopId,
-                    $subscription['contract_id'],
-                    $subscription['cms_reference']
-                )
+                sprintf('Data not found in db for subscription "%s"', json_encode($subscription))
             );
 
         }


### PR DESCRIPTION
### Reason for change

Prevent to recreate a subscription on status order changed

[Linear task](https://linear.app/almapay/issue/ECOM-1319/prevent-ps-to-recreate-subscription-on-status-order-change)

### How to test

- create multiple orders with subscriptions
- change the status of order on for exemple backorder payed, then in Payment accepted and check that the subscription stored has not changed of subscription id or broker
- go to the db and set to null the subscription_state and subscription_broker of an order, change the status of order on for exemple backorder payed, then in Payment accepted and check that the subscription stored  has now a broker and a state