### PR TITLE
[Security] Enable vulnerability scanner on PR targeting develop

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
 
 jobs:
   aqua:


### PR DESCRIPTION
### Reason for change

To match repository's gitflow, we need to enable Aqua scans on PR targeting `develop`.

### Code changes

Modify `aqua.yml` workflow to trigger scan on PR targeting `develop`.

### How to test

No test needed.

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [x ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it


### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->

- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)