### PR TITLE
[insurance] Add amount insurance in the subscription endpoint

### DIFF
--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -246,6 +246,7 @@ class InsuranceService
         foreach ($insuranceContracts as $insuranceContract) {
             $subscriptionData[] = new Subscription(
                 $insuranceContract['insurance_contract_id'],
+                $insuranceContract['price'],
                 $insuranceContract['cms_reference'],
                 $insuranceContract['product_price'],
                 $customerService->getSubscriber(),

--- a/alma/lib/Services/InsuranceSubscriptionService.php
+++ b/alma/lib/Services/InsuranceSubscriptionService.php
@@ -70,6 +70,7 @@ class InsuranceSubscriptionService
      * @param \OrderCore $order
      * @return void
      * @throws InsuranceSubscriptionException
+     * @throws \PrestaShopDatabaseException
      */
     public function triggerInsuranceSubscription($order)
     {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1337/[prestashop]-add-amount-insurance-in-the-subscription-endpoint)

### Code changes

Add amount insurance in the subscription endpoint

### How to test

Buy an insurance and see if there is the good price of insurance in the table alma_insurance_product

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->