### PR TITLE
[insurance] remove broker_id from subscription creation response

### DIFF
--- a/alma/controllers/hook/TermsAndConditionsHookController.php
+++ b/alma/controllers/hook/TermsAndConditionsHookController.php
@@ -24,7 +24,6 @@
 
 namespace Alma\PrestaShop\Controllers\Hook;
 
-use Alma\PrestaShop\Exceptions\InsuranceContractException;
 use Alma\PrestaShop\Exceptions\TermsAndConditionsException;
 use Alma\PrestaShop\Helpers\InsuranceHelper;
 use Alma\PrestaShop\Hooks\FrontendHookController;

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -26,7 +26,6 @@ namespace Alma\PrestaShop\Services;
 
 use Alma\API\Entities\Insurance\Subscription;
 use Alma\PrestaShop\Exceptions\AlmaException;
-use Alma\PrestaShop\Exceptions\InsuranceContractException;
 use Alma\PrestaShop\Exceptions\InsuranceInstallException;
 use Alma\PrestaShop\Exceptions\TermsAndConditionsException;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
@@ -266,6 +265,7 @@ class InsuranceService
      * @param array $insuranceContracts
      *
      * @return array
+     *
      * @throws TermsAndConditionsException
      */
     public function createTextTermsAndConditions($insuranceContracts)

--- a/alma/lib/Services/InsuranceSubscriptionService.php
+++ b/alma/lib/Services/InsuranceSubscriptionService.php
@@ -144,10 +144,6 @@ class InsuranceSubscriptionService
         $insuranceProduct = new InsuranceProduct($almaInsuranceProduct['id_alma_insurance_product']);
         $insuranceProduct->subscription_id = $subscription['id'];
 
-        if (!empty($subscription['broker_subscription_id'])) {
-            $insuranceProduct->subscription_broker_id = $subscription['broker_subscription_id'];
-        }
-
         $insuranceProduct->subscription_amount = $subscription['amount'];
         $insuranceProduct->subscription_state = $subscription['state'];
         $insuranceProduct->save();


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1355/[prestashop]-remove-broker-id-from-subscription-creation-response)

### Code changes

Remove broker_id from subscription creation response

### How to test

Subscribe an insurance and we don't update the broker_id in the subscription insurance table

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->