### PR TITLE
[insurance] Explo error log duplicate entry

### DIFF
--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -215,9 +215,7 @@ class AlmaInsuranceProductRepository
             PRIMARY KEY (`id_alma_insurance_product`),
             index `ps_alma_insurance_product_cart_shop` (`id_cart`, `id_shop`),
             index `ps_alma_insurance_product` (`id_product`, `id_shop`, `id_product_attribute`, `id_customization`, `id_cart`),
-            index `ps_broker_id` (`subscription_broker_id`),
-            constraint ps_alma_insurance_product_pk  unique (`subscription_id`),
-            constraint ps_alma_insurance_broker_pk  unique (`subscription_broker_id`)
+            index `ps_broker_id` (`subscription_broker_id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
 
         return \Db::getInstance()->execute($sql);


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1375/[🧩-ps]-explo-error-log-duplicate-entry)

### Code changes

Remove constraint unique subscription_id and subscription_broker_id db

### How to test

Buy two insurances and see if you have two subscription on pending and see the log if there is any error

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->