### PR TITLE
fix: order page is broken

### DIFF
--- a/alma/controllers/admin/AdminAlmaInsuranceOrders.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceOrders.php
@@ -136,6 +136,11 @@ class AdminAlmaInsuranceOrdersController extends ModuleAdminController
 
         foreach ($this->_list as $key => $details) {
             foreach ($details as $value) {
+                if(null === $details['id_order']) {
+                    unset($this->_list[$key]);
+                    continue;
+                }
+
                 /**
                  * @var OrderCore $order
                  */


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1437/[%F0%9F%A7%A9-ps]-fix-orders-page-insurance-back-office-before-we-finalise-the)

### How to test

Go to the page order in front with insurance in your cart, ensure that the BO alma insurance order page is not broken