### PR TITLE
feat: add column has insurance in order view >= PS 1.7.7

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -364,6 +364,30 @@ class Alma extends PaymentModule
     }
 
     /**
+     * Hook to modify the order table
+     *
+     * @param $params
+     *
+     * @return mixed|null
+     */
+    public function hookActionOrderGridQueryBuilderModifier($params)
+    {
+        return $this->runHookController('actionOrderGridQueryBuilderModifier', $params);
+    }
+
+    /**
+     * Hook to modify the order table
+     *
+     * @param $params
+     *
+     * @return mixed|null
+     */
+    public function hookActionOrderGridDefinitionModifier($params)
+    {
+        return $this->runHookController('actionOrderGridDefinitionModifier', $params);
+    }
+
+    /**
      * Hook action after add cart
      *
      * @param $params

--- a/alma/controllers/hook/ActionOrderGridDefinitionModifierHookController.php
+++ b/alma/controllers/hook/ActionOrderGridDefinitionModifierHookController.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Controllers\Hook;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Alma\PrestaShop\Exceptions\InsuranceInstallException;
+use Alma\PrestaShop\Helpers\InsuranceHelper;
+use Alma\PrestaShop\Helpers\ProductHelper;
+use Alma\PrestaShop\Helpers\SettingsHelper;
+use Alma\PrestaShop\Hooks\FrontendHookController;
+use Alma\PrestaShop\Services\InsuranceProductService;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\BooleanColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
+use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
+
+class ActionOrderGridDefinitionModifierHookController extends FrontendHookController
+{
+
+    public function canRun()
+    {
+        // Front controllers can run if the module is properly configured ...
+        return SettingsHelper::isFullyConfigured()
+            // ... and the plugin is in LIVE mode, or the visitor is an admin
+            && $this->insuranceHelper->isInsuranceActivated();
+    }
+
+    /**
+     * @param $module
+     */
+    public function __construct($module)
+    {
+        parent::__construct($module);
+
+        $this->insuranceHelper = new InsuranceHelper();
+    }
+
+    /**
+     * Run Controller
+     *
+     * @param array $params
+     *
+     * @return void
+     *
+     * @throws InsuranceInstallException
+     */
+    public function run($params)
+    {
+        /** @var GridDefinitionInterface $definition */
+        $definition = $params['definition'];
+
+        $definition
+            ->getColumns()
+            ->addAfter(
+                'date_add',
+                (new BooleanColumn('has_alma_insurance'))
+                    ->setName($this->module->l('Has Insurance', 'actionordergriddefinitionmodifiercontroller'))
+                    ->setOptions([
+                        'field' => 'has_alma_insurance',
+                        'true_name' => $this->module->l('Yes', 'actionordergriddefinitionmodifiercontroller'),
+                        'false_name' =>$this->module->l('No', 'actionordergriddefinitionmodifiercontroller'),
+                    ])
+            )
+        ;
+
+        $definition->getFilters()->add(
+            (new Filter('has_alma_insurance', YesAndNoChoiceType::class))
+                ->setAssociatedColumn('has_alma_insurance')
+        );
+
+    }
+}

--- a/alma/controllers/hook/ActionOrderGridQueryBuilderModifierHookController.php
+++ b/alma/controllers/hook/ActionOrderGridQueryBuilderModifierHookController.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Controllers\Hook;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Alma\PrestaShop\Exceptions\InsuranceInstallException;
+use Alma\PrestaShop\Helpers\InsuranceHelper;
+use Alma\PrestaShop\Helpers\ProductHelper;
+use Alma\PrestaShop\Helpers\SettingsHelper;
+use Alma\PrestaShop\Hooks\FrontendHookController;
+use Alma\PrestaShop\Services\InsuranceProductService;
+use PrestaShop\PrestaShop\Core\Foundation\Database\EntityManager\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Search\Filters\OrderFilters;
+
+class ActionOrderGridQueryBuilderModifierHookController extends FrontendHookController
+{
+
+    public function canRun()
+    {
+        // Front controllers can run if the module is properly configured ...
+        return SettingsHelper::isFullyConfigured()
+            // ... and the plugin is in LIVE mode, or the visitor is an admin
+            && $this->insuranceHelper->isInsuranceActivated();
+    }
+
+    /**
+     * @param $module
+     */
+    public function __construct($module)
+    {
+        parent::__construct($module);
+
+        $this->insuranceHelper = new InsuranceHelper();
+    }
+
+    /**
+     * Run Controller
+     *
+     * @param array $params
+     *
+     * @return void
+     *
+     * @throws InsuranceInstallException
+     */
+    public function run($params)
+    {
+        /** @var QueryBuilder $searchQueryBuilder */
+        $searchQueryBuilder = $params['search_query_builder'];
+
+        /** @var OrderFilters $searchCriteria */
+        $searchCriteria = $params['search_criteria'];
+
+        $searchQueryBuilder->addSelect(
+            'IF(aip.`id_order` IS NOT NULL,1,0) AS `has_alma_insurance`'
+        );
+
+        $searchQueryBuilder->leftJoin(
+            'o',
+            '`'.   _DB_PREFIX_  .'alma_insurance_product`',
+            'aip',
+            'aip.`id_order` = o.`id_order`'
+        );
+
+        if ('has_alma_insurance' === $searchCriteria->getOrderBy()) {
+            $searchQueryBuilder->orderBy('aip.`id_order`', $searchCriteria->getOrderWay());
+        }
+
+        foreach ($searchCriteria->getFilters() as $filterName => $filterValue) {
+            if ('has_alma_insurance' === $filterName) {
+                $searchQueryBuilder->andWhere('aip.`id_order` IS ' . ($filterValue ? 'NOT' : '') . ' NULL');
+            }
+        }
+    }
+}

--- a/alma/lib/Helpers/HookHelper.php
+++ b/alma/lib/Helpers/HookHelper.php
@@ -107,6 +107,14 @@ class HookHelper
         'actionValidateOrder' => 'all',
         'displayCartExtraProductActions' => 'all',
         'termsAndConditions' => 'all',
+        'actionOrderGridQueryBuilderModifier' => [
+            'version' => '1.7.7',
+            'operand' => '>=',
+        ],
+        'actionOrderGridDefinitionModifier' => [
+            'version' => '1.7.7',
+            'operand' => '>=',
+        ],
     ];
 
     /**


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1307/[%F0%9F%A7%A9-ps]-add-column-in-order-list-view)

### How to test

- do orders with insurance + go to the BO order page and see the new column
(need to reset the module to install the hook or have a new infra)