### PR TITLE
add alert on order page with insurance

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -376,6 +376,29 @@ class Alma extends PaymentModule
     }
 
     /**
+     * Hook to display notification on order page
+     *
+     * @param $params
+     *
+     * @return mixed|null
+     */
+    public function hookDisplayInvoice($params)
+    {
+        return $this->hookDisplayAdminOrderTop($params);
+    }
+
+    /**
+     * Hook to display notification on order page
+     *
+     * @param $params
+     *
+     * @return mixed|null
+     */
+    public function hookDisplayAdminOrderTop($params)
+    {
+        return $this->runHookController('displayAdminOrderTop', $params);
+    }
+    /**
      * Hook action after validate order
      *
      * @param $params

--- a/alma/controllers/admin/AdminAlmaInsuranceOrdersDetails.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceOrdersDetails.php
@@ -105,6 +105,7 @@ class AdminAlmaInsuranceOrdersDetailsController extends ModuleAdminController
         $data = $this->buildSubscriptions($subscriptions, $data);
 
         $result['dataSubscriptions'] = json_encode($data);
+        $result['scriptUrl'] = $this->module->_path . 'views/js/admin/alma-insurance-subscriptions.js';
 
         return $result;
     }

--- a/alma/controllers/hook/DisplayAdminOrderTopHookController.php
+++ b/alma/controllers/hook/DisplayAdminOrderTopHookController.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * 2018-2023 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2023 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Controllers\Hook;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use Alma\PrestaShop\Helpers\InsuranceHelper;
+use Alma\PrestaShop\Helpers\SettingsHelper;
+use Alma\PrestaShop\Hooks\FrontendHookController;
+use Alma\PrestaShop\Services\InsuranceService;
+
+class DisplayAdminOrderTopHookController extends FrontendHookController
+{
+    /**
+     * @var InsuranceHelper
+     */
+    protected $insuranceHelper;
+
+    /**
+     * @var InsuranceService
+     */
+    protected $insuranceService;
+
+    public function __construct($module)
+    {
+        parent::__construct($module);
+
+        $this->insuranceHelper = new InsuranceHelper();
+        $this->insuranceService = new InsuranceService();
+    }
+
+    public function canRun()
+    {
+        return parent::canRun() && $this->insuranceHelper->isInsuranceActivated();
+    }
+
+    /**
+     * Run Controller
+     *
+     * @param array $params
+     *
+     * @return void
+     */
+    public function run($params)
+    {
+        /**
+         * @var \OrderCore $order
+         */
+        $order = new \Order($params['id_order']);
+
+        if($this->insuranceHelper->canRefundOrder($order)) {
+            $link = $this->insuranceService->getLinkToOrderDetails($order);
+
+            $text =  sprintf(
+                    $this->module->l('This basket includes one or more insurance subscriptions. Make sure that the subscription(s) is canceled before proceeding with the refund. <a href="%s">Manage the cancellation directly here.</a>', 'displayadminordertophookcontroller'),
+                    $link
+            );
+
+            $this->context->smarty->assign(
+                [
+                    'text' => $text,
+                ]
+            );
+            return $this->module->display($this->module->file, 'displayAdminOrderTop.tpl');
+        }
+    }
+
+}

--- a/alma/lib/Helpers/Admin/InsuranceHelper.php
+++ b/alma/lib/Helpers/Admin/InsuranceHelper.php
@@ -28,6 +28,7 @@ use Alma\PrestaShop\Exceptions\WrongParamsException;
 use Alma\PrestaShop\Helpers\ConfigurationHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
+use Alma\PrestaShop\Repositories\AlmaInsuranceProductRepository;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -60,11 +61,17 @@ class InsuranceHelper
      */
     private $module;
 
+    /**
+     * @var AlmaInsuranceProductRepository
+     */
+    protected $almaInsuranceProductRepository;
+
     public function __construct($module)
     {
         $this->module = $module;
         $this->tabsHelper = new TabsHelper();
         $this->configurationHelper = new ConfigurationHelper();
+        $this->almaInsuranceProductRepository = new AlmaInsuranceProductRepository();
     }
 
     /**

--- a/alma/lib/Helpers/HookHelper.php
+++ b/alma/lib/Helpers/HookHelper.php
@@ -107,6 +107,14 @@ class HookHelper
         'actionValidateOrder' => 'all',
         'displayCartExtraProductActions' => 'all',
         'termsAndConditions' => 'all',
+        'displayInvoice' => [
+            'version' => '1.7.7',
+            'operand' => '<',
+        ],
+        'displayAdminOrderTop' => [
+            'version' => '1.7.7',
+            'operand' => '>=',
+        ],
     ];
 
     /**

--- a/alma/lib/Helpers/InsuranceHelper.php
+++ b/alma/lib/Helpers/InsuranceHelper.php
@@ -116,4 +116,19 @@ class InsuranceHelper
 
         return (bool) $idProduct;
     }
+
+    /**
+     * @param \OrderCore $order
+     * @return bool
+     */
+    public function canRefundOrder($order)
+    {
+        $result = $this->insuranceProductRepository->canRefundOrder($order->id, $order->id_shop);
+
+        if($result['nbNotCancelled'] > 0) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/alma/lib/Repositories/AlmaInsuranceProductRepository.php
+++ b/alma/lib/Repositories/AlmaInsuranceProductRepository.php
@@ -24,6 +24,7 @@
 
 namespace Alma\PrestaShop\Repositories;
 
+use Alma\API\Entities\Insurance\Subscription;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 
 if (!defined('_PS_VERSION_')) {
@@ -407,5 +408,41 @@ class AlmaInsuranceProductRepository
             WHERE aip.`subscription_id` = "' . $id . '"';
 
         return \Db::getInstance()->getRow($sql);
+    }
+
+    /**
+     * @param int $orderId
+     * @param int $shopId
+     * @return array
+     */
+    public function canRefundOrder($orderId, $shopId)
+    {
+        $sql = '
+            SELECT count(`id_alma_insurance_product`) as nbNotCancelled
+            FROM `' . _DB_PREFIX_ . 'alma_insurance_product`
+            WHERE `id_order` = ' . (int) $orderId . '
+            AND `subscription_state` != "'. Subscription::STATE_CANCELLED .'" 
+            AND `id_shop` = ' . (int) $shopId;
+
+        return \Db::getInstance()->getRow($sql);
+    }
+
+    /**
+     * @param int $orderId
+     * @param int $shopId
+     *
+     * @return mixed
+     *
+     * @throws \PrestaShopDatabaseException
+     */
+    public function getIdByOrderId($orderId, $shopId)
+    {
+        $sql = '
+            SELECT `id_alma_insurance_product` as id
+            FROM `' . _DB_PREFIX_ . 'alma_insurance_product` aip
+            WHERE aip.`id_order` = ' . (int) $orderId . '
+            AND aip.`id_shop` = ' . (int) $shopId;
+
+        return \Db::getInstance()->executeS($sql);
     }
 }

--- a/alma/lib/Services/InsuranceService.php
+++ b/alma/lib/Services/InsuranceService.php
@@ -299,4 +299,26 @@ class InsuranceService
     {
         return $this->module->l('I hereby acknowledge my acceptance to subscribe to the insurance offered by Alma. In doing so, I confirm that I have previously reviewed the [information notice, which constitutes the general conditions], the [insurance product information document], and the [pre-contractual information and advice sheet]. I ahead to it without reservation and agree to electronically sign the various documents forming my contract, if applicable. I expressly consent to the collection and use of my personal data for the purpose of subscribing to and managing my insurance contract(s).', 'InsuranceService');
     }
+
+    /**
+     * @param \OrderCore $order
+     * @return string
+     */
+    public function getLinkToOrderDetails($order)
+    {
+        $almaInsuranceId = $this->almaInsuranceProductRepository->getIdByOrderId($order->id, $order->id_shop);
+
+        $link = new \LinkCore();
+
+        $linkToController = $link->getAdminLink(
+            'AdminAlmaInsuranceOrdersDetails',
+            true,
+            [],
+            [
+                'identifier' => $almaInsuranceId,
+            ]
+        );
+
+        return $linkToController;
+    }
 }

--- a/alma/views/css/admin/almaPage.css
+++ b/alma/views/css/admin/almaPage.css
@@ -193,8 +193,21 @@ fieldset .form-alma.disabled::before{
     font-size: 16px;
 }
 
+.bootstrap .alma.alert.alert-warning,
+#main-div .alma.alert.alert-warning{
+    background-color: #fffbd3;
+    border: 1px solid #fab000;
+    color: #00425D;
+    font-size: 16px;
+}
+
+
 .bootstrap .alma.alert.alert-info:before,
 #main-div .alma.alert.alert-info:before{
+    content: '';
+}
+.bootstrap .alma.alert.alert-warning:before,
+#main-div .alma.alert.alert-warning:before{
     content: '';
 }
 

--- a/alma/views/templates/hook/displayAdminOrderTop.tpl
+++ b/alma/views/templates/hook/displayAdminOrderTop.tpl
@@ -20,24 +20,12 @@
  * @copyright 2018-2023 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
-<div id="alma-insurance-modal"></div>
-<script type="module" src="https://protect.staging.almapay.com/displayModal.js"></script>
-
-<script type="text/javascript">
-    var dataSubscriptions = {$dataSubscriptions};
-</script>
-
-<div class="panel" id="fieldset_0">
-    <div class="panel-heading">
-        <img src="/modules/alma/views/img/logos/alma_tiny.svg" alt="{l s='Order details' mod='alma'}">{l s='Orders details' mod='alma'}
+<div class="alert alert-warning">
+    <div class="row">
+        <h2>{l s='Remember to cancel insurance subscriptions before initiating a refund' mod='alma'}</h2>
+        <p>
+            {$text|unescape:'html'}
+        </p>
     </div>
-    <div class="form-wrapper">
-        <div class="form-group">
-            <div class="alma--insurance-bo-form">
-                <iframe id="subscription-alma-iframe" class="alma-insurance-iframe" src="https://protect.staging.almapay.com/almaBackOfficeSubscriptions.html"></iframe>
-            </div>
-        </div>
-    </div>
+
 </div>
-
-<script type="module" src="{$scriptUrl}"></script>


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1304/%5B%F0%9F%A7%A9-ps%5D-display-a-warning-in-order-page)

### How to test

- Do orders with and without insurance
- You need to not see the warning in the top of the page in orders with no insurance
- - You need to not see the warning in the top of the page in orders with all insurances cancelled