### PR TITLE
Feature/ecom 1377 ps add loader on add to cart button before full loading

### DIFF
--- a/alma/views/css/alma-insurance.css
+++ b/alma/views/css/alma-insurance.css
@@ -77,7 +77,27 @@
 .three {
     animation: change-color 1.34s normal 0.58s infinite, bounce 1.34s linear 0.48s infinite;
 }
+.spinner {
+    vertical-align: middle;
+    margin-right: 5px;
+    width: 20px;
+    height: 20px;
+    border: 2px solid #FFF;
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    display: inline-block;
+    box-sizing: border-box;
+    animation: rotation 1s linear infinite;
 
+}
+@keyframes rotation {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
 @keyframes bounce {
     0%,
     40%,

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -26,17 +26,17 @@ let selectedAlmaInsurance = null;
 let addToCartFlow = false;
 let productDetails = null;
 let quantity = 1;
-let isEligible = false;
 
 (function ($) {
     $(function () {
         //Insurance
+        $("#rbutton'+i+'").attr("disabled","disabled");
         onloadAddInsuranceInputOnProductAlma();
-        openModalOnAddToCart();
         if (typeof prestashop !== 'undefined') {
             prestashop.on(
                 'updateProduct',
                 function (event) {
+                    console.log('updateProduct');
                     let addToCart = document.querySelector('.add-to-cart');
                     let modalIsClosed = false;
 
@@ -70,9 +70,8 @@ let isEligible = false;
                 function () {
                     document.getElementById('quantity_wanted').value = quantity;
                     productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
-
                     refreshWidget();
-                    openModalOnAddToCart();
+                    addModalListenerToAddToCart();
                 }
             );
         }
@@ -86,11 +85,11 @@ function onloadAddInsuranceInputOnProductAlma() {
     window.addEventListener('message', (e) => {
         if (e.data.type === 'almaEligibilityAnswer') {
             if (e.data.eligibilityCallResponseStatus.response.eligibleProduct === true) {
-                isEligible = true;
-                prestashop.emit('updateProduct', {isEligible: isEligible});
+                addModalListenerToAddToCart();
+                let heightIframe = e.data.widgetSize.height;
+                document.getElementById('alma-widget-insurance-product-page').style.height = heightIframe + "px";
             }
-            let heightIframe = e.data.widgetSize.height + 25;
-            document.getElementById('product-alma-iframe').style.height = heightIframe + "px";
+            // remove spinner
         }
         if (e.data.type === 'getSelectedInsuranceData') {
             insuranceSelected = true;
@@ -151,8 +150,8 @@ function removeInputInsurance() {
     });
 }
 
-function openModalOnAddToCart() {
-    if (settings.is_add_to_cart_popup_insurance_activated === 'true' && isEligible) {
+function addModalListenerToAddToCart() {
+    if (settings.is_add_to_cart_popup_insurance_activated === 'true') {
         let addToCart = document.querySelector('.add-to-cart');
         addToCart.addEventListener("click", function (event) {
             if (!insuranceSelected) {

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -30,7 +30,7 @@ let quantity = 1;
 (function ($) {
     $(function () {
         //Insurance
-        $("#rbutton'+i+'").attr("disabled","disabled");
+        btnLoaders('start');
         onloadAddInsuranceInputOnProductAlma();
         if (typeof prestashop !== 'undefined') {
             prestashop.on(
@@ -51,7 +51,7 @@ let quantity = 1;
                     if (modalIsClosed || event.eventType === 'updatedProductCombination') {
                         removeInsurance();
                     }
-                    if(typeof event.selectedAlmaInsurance !== 'undefined' && event.selectedAlmaInsurance !== null ) {
+                    if (typeof event.selectedAlmaInsurance !== 'undefined' && event.selectedAlmaInsurance !== null) {
                         insuranceSelected = true;
                         addInputsInsurance(event.selectedAlmaInsurance);
                     }
@@ -78,6 +78,20 @@ let quantity = 1;
     });
 })(jQuery);
 
+
+function btnLoaders(action) {
+    const addBtn = $(".add-to-cart");
+    if (action === 'start') {
+        $('<div id="insuranceSpinner" class="spinner"></div>').insertBefore($(".add-to-cart i"));
+        addBtn.attr("disabled", "disabled");
+    }
+    if (action === 'stop') {
+        $(".spinner").remove();
+        addBtn.removeAttr("disabled");
+        addModalListenerToAddToCart();
+    }
+}
+
 // ** Add input insurance in form to add to cart **
 function onloadAddInsuranceInputOnProductAlma() {
     let currentResolve;
@@ -85,7 +99,7 @@ function onloadAddInsuranceInputOnProductAlma() {
     window.addEventListener('message', (e) => {
         if (e.data.type === 'almaEligibilityAnswer') {
             if (e.data.eligibilityCallResponseStatus.response.eligibleProduct === true) {
-                addModalListenerToAddToCart();
+                btnLoaders('stop');
                 let heightIframe = e.data.widgetSize.height;
                 document.getElementById('alma-widget-insurance-product-page').style.height = heightIframe + "px";
             }
@@ -94,7 +108,10 @@ function onloadAddInsuranceInputOnProductAlma() {
         if (e.data.type === 'getSelectedInsuranceData') {
             insuranceSelected = true;
             selectedAlmaInsurance = e.data.selectedInsuranceData;
-            prestashop.emit('updateProduct', {selectedAlmaInsurance: selectedAlmaInsurance, selectedInsuranceData: e.data.declinedInsurance});
+            prestashop.emit('updateProduct', {
+                selectedAlmaInsurance: selectedAlmaInsurance,
+                selectedInsuranceData: e.data.declinedInsurance
+            });
         } else if (currentResolve) {
             currentResolve(e.data);
         }
@@ -123,7 +140,7 @@ function addInputsInsurance(selectedAlmaInsurance) {
 
 function handleInput(inputName, value, form) {
     let elementInput = document.getElementById(inputName);
-    if(elementInput == null) {
+    if (elementInput == null) {
         let input = document.createElement('input');
         input.setAttribute('value', value);
         input.setAttribute('name', inputName);
@@ -132,7 +149,7 @@ function handleInput(inputName, value, form) {
         input.setAttribute('type', 'hidden');
 
         form.prepend(input);
-    }  else {
+    } else {
         elementInput.setAttribute('value', value);
     }
 }

--- a/alma/views/templates/hook/displayProductActions.tpl
+++ b/alma/views/templates/hook/displayProductActions.tpl
@@ -21,7 +21,7 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
 {if isset($layout)}
-    <div class="alma-widget-insurance" id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" >
+    <div class="alma-widget-insurance" id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" style="height: 0px" >
         <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
         <div id="alma-insurance-modal"></div>
     </div>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->
Change Iframe div visibility on null before elibility result
Change refresh cycle for widget ( flicking widget on load )  
Add a jquery spinner before icone in add to cart button - stop spinning add widget display
[Linear task](https://linear.app/almapay/issue/ECOM-1377/[🧩-ps]-add-loader-on-add-to-cart-button-before-full-loading-insurance)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->