### PR TITLE
Add dynamic url on the iframe insurance order detail for the sandbox/prod env

### DIFF
--- a/alma/controllers/admin/AdminAlmaInsuranceOrdersDetails.php
+++ b/alma/controllers/admin/AdminAlmaInsuranceOrdersDetails.php
@@ -25,6 +25,7 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use Alma\PrestaShop\Helpers\Admin\InsuranceHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
 use Alma\PrestaShop\Helpers\PriceHelper;
 use Alma\PrestaShop\Helpers\ProductHelper;
@@ -49,12 +50,17 @@ class AdminAlmaInsuranceOrdersDetailsController extends ModuleAdminController
      * @var Alma
      */
     public $module;
+    /**
+     * @var InsuranceHelper
+     */
+    protected $adminInsuranceHelper;
 
     public function __construct()
     {
         $this->bootstrap = true;
         $this->insuranceRepository = new AlmaInsuranceProductRepository();
         $this->productHelper = new ProductHelper();
+        $this->adminInsuranceHelper = new InsuranceHelper($this->module);
 
         parent::__construct();
     }
@@ -111,6 +117,8 @@ class AdminAlmaInsuranceOrdersDetailsController extends ModuleAdminController
 
         $result['dataSubscriptions'] = json_encode($data);
         $result['scriptUrl'] = $this->module->_path . 'views/js/admin/alma-insurance-subscriptions.js';
+        $result['modalScriptUrl'] = $this->adminInsuranceHelper->envUrl() . ConstantsHelper::SCRIPT_MODAL_WIDGET_INSURANCE_PATH;
+        $result['iframeUrl'] = $this->adminInsuranceHelper->envUrl() . ConstantsHelper::BO_IFRAME_SUBSCRIPTION_INSURANCE_PATH;
 
         return $result;
     }

--- a/alma/lib/Helpers/ConstantsHelper.php
+++ b/alma/lib/Helpers/ConstantsHelper.php
@@ -81,6 +81,7 @@ class ConstantsHelper
     const DOMAIN_URL_INSURANCE_TEST = 'https://protect.sandbox.almapay.com';
     const DOMAIN_URL_INSURANCE_LIVE = 'https://protect.almapay.com';
     const BO_IFRAME_CONFIGURATION_INSURANCE_PATH = '/almaBackOfficeConfiguration.html';
+    const BO_IFRAME_SUBSCRIPTION_INSURANCE_PATH = '/almaBackOfficeSubscriptions.html';
     const FO_IFRAME_WIDGET_INSURANCE_PATH = '/almaProductInPageWidget.html';
     const SCRIPT_MODAL_WIDGET_INSURANCE_PATH = '/displayModal.js';
 

--- a/alma/views/templates/admin/insurance_order_details.tpl
+++ b/alma/views/templates/admin/insurance_order_details.tpl
@@ -21,7 +21,7 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
 <div id="alma-insurance-modal"></div>
-<script type="module" src="https://protect.staging.almapay.com/displayModal.js"></script>
+<script type="module" src="{$modalScriptUrl}"></script>
 
 <script type="text/javascript">
     var dataSubscriptions = {$dataSubscriptions};
@@ -34,7 +34,7 @@
     <div class="form-wrapper">
         <div class="form-group">
             <div class="alma--insurance-bo-form">
-                <iframe id="subscription-alma-iframe" class="alma-insurance-iframe" src="https://protect.staging.almapay.com/almaBackOfficeSubscriptions.html"></iframe>
+                <iframe id="subscription-alma-iframe" class="alma-insurance-iframe" src="{$iframeUrl}"></iframe>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1500/[🧩-ps]-add-dynamic-url-on-the-iframe-insurance-order-detail-for-the)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We replace static url of element insurance order detail in dynamic url for sandbox/prod env

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Install module with insurance
Order an insurance with the basic process
See if the url of the iframe and modal js are link to the sandbox env

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->