### PR TITLE
Fix handle quantity if input id isn't quantity_wanted

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -67,7 +67,7 @@ let quantity = 1;
             prestashop.on(
                 'updatedProduct',
                 function () {
-                    document.getElementById('quantity_wanted').value = quantity;
+                    document.querySelector('.qty [name="qty"]').value = quantity;
                     productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
                     refreshWidget();
                     addModalListenerToAddToCart();


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1594/[🧩-ps]-handle-quantity-with-insurance-for-ipnl-and-odp)

### Code changes

Selector quantity by input name and not the id
<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Add a insurance with a quantity if you change the id of input quantity_wanted
_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->