### PR TITLE
Fix order warning UI

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -100,7 +100,12 @@ function onloadAddInsuranceInputOnProductAlma() {
             btnLoaders('stop');
             if (e.data.eligibilityCallResponseStatus.response.eligibleProduct === true) {
                 let heightIframe = e.data.widgetSize.height;
-                document.getElementById('alma-widget-insurance-product-page').style.height = heightIframe + "px";
+                let stringHeightIframe = heightIframe + 'px';
+                if (heightIframe <= 45) {
+                    stringHeightIframe = '100%';
+                }
+
+                document.getElementById('alma-widget-insurance-product-page').style.height = stringHeightIframe;
             } else {
                 let addToCart = document.querySelector('.add-to-cart');
                 addToCart.removeEventListener("click",insuranceListener)

--- a/alma/views/templates/hook/displayAdminOrderTop.tpl
+++ b/alma/views/templates/hook/displayAdminOrderTop.tpl
@@ -22,10 +22,11 @@
  *}
 <div class="alma-insurance alert alert-warning">
     <div class="row">
-        <h2>{l s='Remember to cancel insurance subscriptions before initiating a refund' mod='alma'}</h2>
-        <p>
-            {$text|unescape:'html'}
-        </p>
+        <div class="col-xs-12">
+            <h2>{l s='Remember to cancel insurance subscriptions before initiating a refund' mod='alma'}</h2>
+            <p>
+                {$text|unescape:'html'}
+            </p>
+        </div>
     </div>
-
 </div>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1612/[🧩-ps]-fix-order-warning-ui)

### Code changes

Fix block row warning UI order page
Fix height insurance widget when iframe we return 45 (min size of widget)
<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Display de warning message in order page with insurance on fullscreen
Tested on ODP, display the widget on ODP website

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->