### PR TITLE
[insurance] Fix change order state in the orders page bo

### DIFF
--- a/alma/views/js/admin/alma-insurance-orders.js
+++ b/alma/views/js/admin/alma-insurance-orders.js
@@ -44,11 +44,11 @@
             const updateConfirmModal = new window.ConfirmModal(
                 {
                     id: 'confirm-refund-order-insurance-modal',
-                    confirmTitle: window.confirmTitleText,
-                    closeButtonLabel: window.closeButtonLabelText,
-                    confirmButtonLabel: window.confirmButtonLabelText,
+                    confirmTitle: window.InsuranceModalConfirm.confirmTitleText,
+                    closeButtonLabel: window.InsuranceModalConfirm.closeButtonLabelText,
+                    confirmButtonLabel: window.InsuranceModalConfirm.confirmButtonLabelText,
                     confirmButtonClass: 'btn-primary',
-                    confirmMessage: window.confirmMessageLine1Text + '<br>' + window.confirmMessageLine2Text,
+                    confirmMessage: window.InsuranceModalConfirm.confirmMessageLine1Text + '<br>' + window.InsuranceModalConfirm.confirmMessageLine2Text,
                     closable: true,
                     customButtons: [],
                 },

--- a/alma/views/templates/hook/DisplayBackOfficeHeader.tpl
+++ b/alma/views/templates/hook/DisplayBackOfficeHeader.tpl
@@ -1,9 +1,9 @@
 <script type="text/javascript">
     window.InsuranceModalConfirm = {
-        confirmTitleText: '{l s="Confirm Insurance cancellation before refunding the order" mod="alma"}',
-        closeButtonLabelText: '{l s="Cancel" mod="alma"}',
-        confirmButtonLabelText: '{l s="Refund the order" mod="alma"}',
-        confirmMessageLine1Text: '{l s="Before proceeding with the order refund, ensure the associated insurance contracts have been successfully canceled." mod="alma"}',
-        confirmMessageLine2Text: '{l s="Are you sure you want to confirm the refund?" mod="alma"}'
+        confirmTitleText: "{l s='Confirm Insurance cancellation before refunding the order' mod='alma'}",
+        closeButtonLabelText: "{l s='Cancel' mod='alma'}",
+        confirmButtonLabelText: "{l s='Refund the order' mod='alma'}",
+        confirmMessageLine1Text: "{l s='Before proceeding with the order refund, ensure the associated insurance contracts have been successfully canceled.' mod='alma'}",
+        confirmMessageLine2Text: "{l s='Are you sure you want to confirm the refund?' mod='alma'}"
     };
 </script>

--- a/alma/views/templates/hook/DisplayBackOfficeHeader.tpl
+++ b/alma/views/templates/hook/DisplayBackOfficeHeader.tpl
@@ -1,7 +1,9 @@
 <script type="text/javascript">
-    let confirmTitleText = '{l s='Confirm Insurance cancellation before refunding the order' mod='alma'}';
-    let closeButtonLabelText = '{l s='Cancel' mod='alma'}';
-    let confirmButtonLabelText = '{l s='Refund the order' mod='alma'}';
-    let confirmMessageLine1Text = '{l s='Before proceeding with the order refund, ensure the associated insurance contracts have been successfully canceled.' mod='alma'}';
-    let confirmMessageLine2Text = '{l s='Are you sure you want to confirm the refund?' mod='alma'}';
+    window.InsuranceModalConfirm = {
+        confirmTitleText: '{l s="Confirm Insurance cancellation before refunding the order" mod="alma"}',
+        closeButtonLabelText: '{l s="Cancel" mod="alma"}',
+        confirmButtonLabelText: '{l s="Refund the order" mod="alma"}',
+        confirmMessageLine1Text: '{l s="Before proceeding with the order refund, ensure the associated insurance contracts have been successfully canceled." mod="alma"}',
+        confirmMessageLine2Text: '{l s="Are you sure you want to confirm the refund?" mod="alma"}'
+    };
 </script>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1624/[ps]-fix-change-order-state-in-the-orders-page-bo)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Change simple quote to double quote to handle translation FR on the wording for the modalConfirm on ordre page for insurance feature

### How to test

_As a reviewer, you are encouraged to test the PR locally._
Add your store in french
Order an insurance
Change the state of the order on a refund state

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->