### PR TITLE
Check why cart id is not sent with subscription in prod

### DIFF
--- a/alma/lib/Helpers/CartHelper.php
+++ b/alma/lib/Helpers/CartHelper.php
@@ -93,13 +93,13 @@ class CartHelper
         $this->toolsHelper = $toolsHelper;
         $this->priceHelper = $priceHelper;
         $this->cartData = $cartData;
+        $this->orderRepository = $orderRepository;
         $this->orderStateHelper = $orderStateHelper;
         $this->carrierHelper = $carrierHelper;
-        $this->orderRepository = $orderRepository;
     }
 
     /**
-     * @return null/int
+     * @return int|null
      */
     public function getCartIdFromContext()
     {

--- a/alma/lib/Services/InsuranceApiService.php
+++ b/alma/lib/Services/InsuranceApiService.php
@@ -208,7 +208,7 @@ class InsuranceApiService
                 $order->id,
                 $idTransaction,
                 $this->context->session->getId(),
-                $this->cartHelper->getCartIdFromContext()
+                $order->id_cart
             );
 
             if (isset($result['subscriptions'])) {

--- a/alma/tests/Unit/Helper/CartHelperTest.php
+++ b/alma/tests/Unit/Helper/CartHelperTest.php
@@ -24,10 +24,67 @@
 
 namespace Alma\PrestaShop\Tests\Unit\Helper;
 
+use Alma\PrestaShop\Helpers\CarrierHelper;
+use Alma\PrestaShop\Helpers\CartHelper;
+use Alma\PrestaShop\Helpers\OrderStateHelper;
+use Alma\PrestaShop\Helpers\PriceHelper;
+use Alma\PrestaShop\Helpers\ToolsHelper;
+use Alma\PrestaShop\Model\CartData;
+use Alma\PrestaShop\Repositories\OrderRepository;
 use PHPUnit\Framework\TestCase;
 
 class CartHelperTest extends TestCase
 {
+    /**
+     * @var \ContextCore|(\ContextCore&\PHPUnit_Framework_MockObject_MockObject)|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $context;
+    /**
+     * @var ToolsHelper|(ToolsHelper&\PHPUnit_Framework_MockObject_MockObject)|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $toolHelper;
+    /**
+     * @var PriceHelper|(PriceHelper&\PHPUnit_Framework_MockObject_MockObject)|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $priceHelper;
+    /**
+     * @var CartData|(CartData&\PHPUnit_Framework_MockObject_MockObject)|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $cartData;
+    /**
+     * @var OrderRepository|(OrderRepository&\PHPUnit_Framework_MockObject_MockObject)|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $orderRepository;
+    /**
+     * @var OrderStateHelper|(OrderStateHelper&\PHPUnit_Framework_MockObject_MockObject)|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $orderStateHelper;
+    /**
+     * @var CarrierHelper|(CarrierHelper&\PHPUnit_Framework_MockObject_MockObject)|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $carrierHelper;
+
+    public function setUp()
+    {
+        $this->context = $this->createMock(\Context::class);
+        $this->toolHelper = $this->createMock(ToolsHelper::class);
+        $this->priceHelper = $this->createMock(PriceHelper::class);
+        $this->cartData = $this->createMock(CartData::class);
+        $this->orderRepository = $this->createMock(OrderRepository::class);
+        $this->orderStateHelper = $this->createMock(OrderStateHelper::class);
+        $this->carrierHelper = $this->createMock(CarrierHelper::class);
+        $this->cartHelper = new CartHelper(
+            $this->context,
+            $this->toolHelper,
+            $this->priceHelper,
+            $this->cartData,
+            $this->orderRepository,
+            $this->orderStateHelper,
+            $this->carrierHelper
+        );
+        $this->cart = $this->createMock(\Cart::class);
+    }
+
     public function testPreviousCartOrdered()
     {
     }
@@ -38,5 +95,16 @@ class CartHelperTest extends TestCase
 
     public function testGetCartTotal()
     {
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetCartIdFromContext()
+    {
+        $this->cart->id = 1;
+        $this->context->cart = $this->cart;
+
+        $this->assertEquals(1, $this->cartHelper->getCartIdFromContext());
     }
 }

--- a/alma/tests/Unit/Helper/ConfigurationHelperTest.php
+++ b/alma/tests/Unit/Helper/ConfigurationHelperTest.php
@@ -26,7 +26,6 @@ namespace Alma\PrestaShop\Tests\Unit\Helper;
 
 use Alma\PrestaShop\Helpers\ConfigurationHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
-use Alma\PrestaShop\Helpers\ShopHelper;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationHelperTest extends TestCase
@@ -35,6 +34,7 @@ class ConfigurationHelperTest extends TestCase
     {
         $this->configurationHelper = new ConfigurationHelper();
     }
+
     public function testIsPayNow()
     {
         $this->assertFalse($this->configurationHelper->isPayNow('test'));
@@ -43,6 +43,7 @@ class ConfigurationHelperTest extends TestCase
 
     /**
      * @dataProvider provideIsInPageEnabled
+     *
      * @return void
      */
     public function testIsInPageEnabled($expected, $isInPageEnabled, $installments)
@@ -58,32 +59,32 @@ class ConfigurationHelperTest extends TestCase
             'test no inpage enable, installment 1' => [
                 'expected' => false,
                 'isInpageEnabled' => false,
-                'installments' => 1
+                'installments' => 1,
             ],
             'test no inpage enable, installment 4' => [
                 'expected' => false,
                 'isInpageEnabled' => false,
-                'installments' => 4
+                'installments' => 4,
             ],
             'test no inpage enable, installment 6' => [
                 'expected' => false,
                 'isInpageEnabled' => false,
-                'installments' => 6
+                'installments' => 6,
             ],
             'test inpage enable, installment 1' => [
                 'expected' => true,
                 'isInpageEnabled' => true,
-                'installments' => 1
+                'installments' => 1,
             ],
             'test inpage enable, installment 4' => [
                 'expected' => true,
                 'isInpageEnabled' => true,
-                'installments' => 4
+                'installments' => 4,
             ],
             'test inpage enable, installment 6' => [
                 'expected' => false,
                 'isInpageEnabled' => true,
-                'installments' => 6
+                'installments' => 6,
             ],
         ];
     }

--- a/alma/tests/Unit/Helper/PlanHelperTest.php
+++ b/alma/tests/Unit/Helper/PlanHelperTest.php
@@ -27,7 +27,6 @@ namespace Alma\PrestaShop\Tests\Unit\Helper;
 use Alma\API\Entities\FeePlan;
 use Alma\PrestaShop\Helpers\CustomFieldsHelper;
 use Alma\PrestaShop\Helpers\DateHelper;
-use Alma\PrestaShop\Helpers\OrderHelper;
 use Alma\PrestaShop\Helpers\PlanHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use PHPUnit\Framework\TestCase;
@@ -55,6 +54,7 @@ class PlanHelperTest extends TestCase
 
     /**
      * @dataProvider provideIsPnxPlus4
+     *
      * @return void
      */
     public function testIsPnxPlus4($expected, $installmentsCount)
@@ -66,7 +66,6 @@ class PlanHelperTest extends TestCase
         );
 
         $this->assertEquals($expected, $this->planHelper->isPnxPlus4($plan));
-
     }
 
     public function provideIsPnxPlus4()
@@ -86,6 +85,7 @@ class PlanHelperTest extends TestCase
             ],
         ];
     }
+
     /**
      * @dataProvider provideIsDeferred
      *
@@ -101,7 +101,6 @@ class PlanHelperTest extends TestCase
         );
 
         $this->assertEquals($expected, $this->planHelper->isDeferred($plan));
-
     }
 
     public function provideIsDeferred()

--- a/alma/tests/Unit/Helper/ToolsHelperTest.php
+++ b/alma/tests/Unit/Helper/ToolsHelperTest.php
@@ -34,7 +34,8 @@ class ToolsHelperTest extends TestCase
      */
     protected $toolsHelper;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->toolsHelper = new ToolsHelper();
     }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1653/[🧩-ps]-check-why-cart-id-is-not-sent-with-subscription-in-prod)

### Code changes

On the subscription we have the order. We send directly the cart_id from the order
<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Subscribe an insurance and check the attach rate data
_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->