### PR TITLE
[devx] Add a release draft template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+template: |
+
+  $CHANGES
+
+change-template: '- $TITLE'
+change-title-escapes: '\<*_&#@`'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'type: feature'
+  patch:
+    labels:
+      - 'patch'
+  default: patch


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

We need a release draft template to implement the release workflow (See the part for the automated release PR creation : https://github.com/alma/alma-installments-prestashop/pull/405)
We cannot test this workflow if the template **is not merged in the default branch** (See https://github.com/release-drafter/release-drafter?tab=readme-ov-file#configuration)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
This adds a minimal release draft template

