### PR TITLE
render always ps account form

### DIFF
--- a/alma/controllers/hook/GetContentHookController.php
+++ b/alma/controllers/hook/GetContentHookController.php
@@ -807,9 +807,12 @@ final class GetContentHookController extends AdminHookController
     {
         $this->context->smarty->assign([
             'hasPSAccount' => $params['hasPSAccount'],
+            'updated' => true,
         ]);
 
         $this->assignSmartyAlertClasses();
+
+        $messages = null;
 
         if (\Tools::isSubmit('alma_config_form')) {
             $messages = $this->processConfiguration();
@@ -822,8 +825,13 @@ final class GetContentHookController extends AdminHookController
             if ($messages) {
                 $messages = $messages['message'];
             }
-        } else {
-            $messages = '';
+        }
+
+        if (!$messages) {
+            $this->context->smarty->assign([
+                'updated' => false,
+            ]);
+            $messages = $this->module->display($this->module->file, 'getContent.tpl');
         }
 
         $htmlForm = $this->renderForm();

--- a/alma/views/templates/hook/getContent.tpl
+++ b/alma/views/templates/hook/getContent.tpl
@@ -128,13 +128,13 @@
             En cas de problème, contactez-nous par email à <a href="mailto:support@getalma.eu">support@getalma.eu</a>
         </p>
     </div>
-{else}
+{elseif $updated}
     <div class="{$success_classes|escape:'htmlall':'UTF-8'}">
         {l s='Settings successfully updated' mod='alma'}
     </div>
 {/if}
 
-{if $hasPSAccount}
+{if isset($hasPSAccount) &&  $hasPSAccount}
     <prestashop-accounts></prestashop-accounts>
 
     <script src="{$urlAccountsCdn|escape:'htmlall':'UTF-8'}" rel=preload></script>


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1672/[%F0%9F%A7%A9-ps]-display-the-ps-link-in-the-configuration-form)


### How to test
You see the prestashop account module on top of the alma conf form