### PR TITLE
Handle ps account & PS 1.6

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -81,6 +81,9 @@ class Alma extends PaymentModule
      */
     protected $toolsHelper;
 
+    /**
+     *
+     */
     public function __construct()
     {
         $this->name = \Alma\PrestaShop\Helpers\ConstantsHelper::ALMA_MODULE_NAME;

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -568,9 +568,16 @@ class Alma extends PaymentModule
      */
     public function getContent()
     {
-        $hasPSAccount = $this->renderPSAccount();
+        $suggestPSAccount = false;
 
-        return $this->runHookController('getContent', ['hasPSAccount' => $hasPSAccount]);
+        try {
+            $hasPSAccount = $this->renderPSAccount();
+        } catch (\PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException $e) {
+            $hasPSAccount = false;
+            $suggestPSAccount = true;
+        }
+
+        return $this->runHookController('getContent', ['hasPSAccount' => $hasPSAccount, 'suggestPSAccount' => $suggestPSAccount]);
     }
 
     /**

--- a/alma/composer.json
+++ b/alma/composer.json
@@ -49,11 +49,5 @@
         "installer-name": "alma"
     },
     "license": "MIT",
-    "minimum-stability": "dev",
-    "repositories": {
-        "alma/alma-php-client": {
-            "type": "path",
-            "url": "/app/alma/alma-php-client"
-        }
-    }
+    "minimum-stability": "dev"
 }

--- a/alma/composer.json
+++ b/alma/composer.json
@@ -49,5 +49,11 @@
         "installer-name": "alma"
     },
     "license": "MIT",
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "repositories": {
+        "alma/alma-php-client": {
+            "type": "path",
+            "url": "/app/alma/alma-php-client"
+        }
+    }
 }

--- a/alma/controllers/hook/GetContentHookController.php
+++ b/alma/controllers/hook/GetContentHookController.php
@@ -189,6 +189,9 @@ final class GetContentHookController extends AdminHookController
 
         if ((empty($liveKey) && ALMA_MODE_LIVE == $apiMode) || (empty($testKey) && ALMA_MODE_TEST == $apiMode)) {
             $this->context->smarty->assign('validation_error', "missing_key_for_{$apiMode}_mode");
+            $this->context->smarty->assign([
+                'suggestPSAccount' => false,
+            ]);
 
             return $this->module->display($this->module->file, 'getContent.tpl');
         }
@@ -519,6 +522,8 @@ final class GetContentHookController extends AdminHookController
 
             $this->assignSmartyAlertClasses();
             $this->context->smarty->assign('tip', 'fill_api_keys');
+            $this->context->smarty->assign('suggestPSAccount', false);
+            $this->context->smarty->assign('hasPSAccount', false);
 
             $extraMessage = $this->module->display($this->module->file, 'getContent.tpl');
         }
@@ -808,6 +813,7 @@ final class GetContentHookController extends AdminHookController
         $this->context->smarty->assign([
             'hasPSAccount' => $params['hasPSAccount'],
             'updated' => true,
+            'suggestPSAccount' => $params['suggestPSAccount'],
         ]);
 
         $this->assignSmartyAlertClasses();

--- a/alma/views/templates/hook/getContent.tpl
+++ b/alma/views/templates/hook/getContent.tpl
@@ -146,3 +146,18 @@
         window?.psaccountsVue?.init();
     </script>
 {/if}
+{if isset($suggestPSAccount) &&  $suggestPSAccount}
+
+    <div class="alert alert-dismissible alert-info">
+        <h4>
+            {l s='We offer to download the PrestaShop Account module ' mod='alma'}
+        </h4>
+        <p>
+            {l s='Link your store to your PrestaShop account to take full advantage of the modules offered by the PrestaShop Marketplace and optimize your experience.'}
+        </p>
+        {almaDisplayHtml}
+        {l s='You can find the module %1$shere%2$s' sprintf=['<a href="https://addons.prestashop.com/en/administrative-tools/49648-prestashop-account.html" target=\"_blank\">', '</a>'] mod='alma'}
+        {/almaDisplayHtml}
+    </div>
+
+{/if}


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1673/[%F0%9F%A7%A9-ps]-handle-the-display-of-the-ps-link-only-if-the-module-ps)

### Code changes
![image](https://github.com/alma/alma-installments-prestashop/assets/110386752/d928697a-2123-4370-bfe7-e1bb1b5014d7)

### How to test
On PS 1.6 you must have the suggest PS account module message, then when you install the module, you see the module