### PR TITLE
[devx] Fix local lint:fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         name: Check the PHP compatibility
         language: system
         pass_filenames: false
-        entry:  task php-compatibililty
+        entry:  task php-compatibility
         stages: [commit]
 
   - repo: https://github.com/returntocorp/semgrep

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -72,7 +72,7 @@ tasks:
       # Script commented as it is not coherent with the linter rules
       - #./scripts/remove-blank-line-index.sh
 
-  php-compatibililty:
+  php-compatibility:
     desc: Check compatibility code
     deps:
       - install-tools

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,7 +69,8 @@ tasks:
       # Execute autoindex to add index in all folders
       - php ./alma/vendor/bin/autoindex prestashop:add:index --exclude=vendor alma/
       # Remove blank line at the end of index.php file
-      #- ./scripts/remove-blank-line-index.sh alma/
+      # Script commented as it is not coherent with the linter rules
+      - #./scripts/remove-blank-line-index.sh
 
   php-compatibililty:
     desc: Check compatibility code

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,7 +67,7 @@ tasks:
     cmds:
       - php alma/vendor/bin/php-cs-fixer fix alma
       # Execute autoindex to add index in all folders
-      - php ./alma/vendor/bin/autoindex prestashop:add:index alma/
+      - php ./alma/vendor/bin/autoindex prestashop:add:index --exclude=vendor alma/
       # Remove blank line at the end of index.php file
       #- ./scripts/remove-blank-line-index.sh alma/
 

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -76,9 +76,6 @@ class Alma extends PaymentModule
      */
     protected $toolsHelper;
 
-    /**
-     *
-     */
     public function __construct()
     {
         $this->name = \Alma\PrestaShop\Helpers\ConstantsHelper::ALMA_MODULE_NAME;

--- a/alma/config/admin/index.php
+++ b/alma/config/admin/index.php
@@ -1,8 +1,9 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/config/index.php
+++ b/alma/config/index.php
@@ -1,8 +1,9 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/lib/Builders/Admin/index.php
+++ b/alma/lib/Builders/Admin/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/lib/Builders/Admin/index.php
+++ b/alma/lib/Builders/Admin/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/lib/Builders/index.php
+++ b/alma/lib/Builders/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/lib/Builders/index.php
+++ b/alma/lib/Builders/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/lib/Factories/index.php
+++ b/alma/lib/Factories/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/lib/Factories/index.php
+++ b/alma/lib/Factories/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/lib/Grid/Column/index.php
+++ b/alma/lib/Grid/Column/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/lib/Grid/Column/index.php
+++ b/alma/lib/Grid/Column/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/lib/Grid/index.php
+++ b/alma/lib/Grid/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/lib/Grid/index.php
+++ b/alma/lib/Grid/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/lib/Helpers/Admin/index.php
+++ b/alma/lib/Helpers/Admin/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/lib/Helpers/Admin/index.php
+++ b/alma/lib/Helpers/Admin/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/tests/Unit/Builders/Admin/index.php
+++ b/alma/tests/Unit/Builders/Admin/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/tests/Unit/Builders/Admin/index.php
+++ b/alma/tests/Unit/Builders/Admin/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/tests/Unit/Builders/index.php
+++ b/alma/tests/Unit/Builders/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/tests/Unit/Builders/index.php
+++ b/alma/tests/Unit/Builders/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/tests/Unit/Factories/index.php
+++ b/alma/tests/Unit/Factories/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/tests/Unit/Factories/index.php
+++ b/alma/tests/Unit/Factories/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/tests/Unit/Helper/Admin/index.php
+++ b/alma/tests/Unit/Helper/Admin/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/tests/Unit/Helper/Admin/index.php
+++ b/alma/tests/Unit/Helper/Admin/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/tests/Unit/Helper/index.php
+++ b/alma/tests/Unit/Helper/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/tests/Unit/Helper/index.php
+++ b/alma/tests/Unit/Helper/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/tests/Unit/Model/index.php
+++ b/alma/tests/Unit/Model/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/tests/Unit/Model/index.php
+++ b/alma/tests/Unit/Model/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/tests/Unit/Services/index.php
+++ b/alma/tests/Unit/Services/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/tests/Unit/Services/index.php
+++ b/alma/tests/Unit/Services/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/tests/Unit/index.php
+++ b/alma/tests/Unit/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/tests/Unit/index.php
+++ b/alma/tests/Unit/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/views/PrestaShop/Admin/Common/Grid/Columns/Content/index.php
+++ b/alma/views/PrestaShop/Admin/Common/Grid/Columns/Content/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/views/PrestaShop/Admin/Common/Grid/Columns/Content/index.php
+++ b/alma/views/PrestaShop/Admin/Common/Grid/Columns/Content/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/views/PrestaShop/Admin/Common/Grid/Columns/index.php
+++ b/alma/views/PrestaShop/Admin/Common/Grid/Columns/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/views/PrestaShop/Admin/Common/Grid/Columns/index.php
+++ b/alma/views/PrestaShop/Admin/Common/Grid/Columns/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/views/PrestaShop/Admin/Common/Grid/index.php
+++ b/alma/views/PrestaShop/Admin/Common/Grid/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/views/PrestaShop/Admin/Common/Grid/index.php
+++ b/alma/views/PrestaShop/Admin/Common/Grid/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/views/PrestaShop/Admin/Common/index.php
+++ b/alma/views/PrestaShop/Admin/Common/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/views/PrestaShop/Admin/Common/index.php
+++ b/alma/views/PrestaShop/Admin/Common/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/views/PrestaShop/Admin/index.php
+++ b/alma/views/PrestaShop/Admin/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/views/PrestaShop/Admin/index.php
+++ b/alma/views/PrestaShop/Admin/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/views/PrestaShop/index.php
+++ b/alma/views/PrestaShop/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/views/PrestaShop/index.php
+++ b/alma/views/PrestaShop/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/alma/views/js/admin/components/index.php
+++ b/alma/views/js/admin/components/index.php
@@ -1,4 +1,5 @@
 <?php
+
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 header('Cache-Control: no-store, no-cache, must-revalidate');

--- a/alma/views/js/admin/components/index.php
+++ b/alma/views/js/admin/components/index.php
@@ -1,8 +1,8 @@
 <?php
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
-header("Location: ../");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+header('Location: ../');
 exit;

--- a/scripts/remove-blank-line-index.sh
+++ b/scripts/remove-blank-line-index.sh
@@ -2,7 +2,11 @@
 
 find alma -name "index.php"|while read file; do
     echo "$file"
-    sed -i '' -e '/^\s*$/d' "$file"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' -e '/^\s*$/d' "$file"
+    else
+        sed -i -e '/^\s*$/d' "$file"
+    fi
 done
 
 # sed -i '' -e '/^\s*$/d' alma/includes/index.php


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

Fixes issues encountered locally with linter : 
* `autoindex` was updating vendor, so `php-cs-fixer` was failing silently if running after `autoindex` (It was always passing)
* `scripts/remove-blank-line-index.sh` was only working on MAC
*  AND `scripts/remove-blank-line-index.sh` removes lines that are added by the lint:fix, so we never ends in a situation where both are satisfied

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
* The vendor folder is now excluded from autoindex 
*  We check the local OS in `scripts/remove-blank-line-index.sh` and execute the right sed command 
* BUT I finally commented the script as it is not coherent with the linter
* Lots of linting change

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->