### PR TITLE
PS account first alma activation

### DIFF
--- a/alma/controllers/hook/GetContentHookController.php
+++ b/alma/controllers/hook/GetContentHookController.php
@@ -93,6 +93,11 @@ final class GetContentHookController extends AdminHookController
     protected $mediaHelper;
 
     /**
+     * @var boolean
+     */
+    protected $hasKey;
+
+    /**
      * @var array
      */
     const KEY_CONFIG = [
@@ -171,6 +176,8 @@ final class GetContentHookController extends AdminHookController
         $mediaHelperBuilder = new MediaHelperBuilder();
         $this->mediaHelper = $mediaHelperBuilder->getInstance();
 
+        $this->hasKey = false;
+
         parent::__construct($module);
     }
 
@@ -202,6 +209,7 @@ final class GetContentHookController extends AdminHookController
                 'suggestPSAccount' => false,
             ]);
 
+            $this->hasKey = false;
             return $this->module->display($this->module->file, 'getContent.tpl');
         }
 
@@ -839,8 +847,13 @@ final class GetContentHookController extends AdminHookController
 
             if ($messages) {
                 $messages = $messages['message'];
+            } else {
+                $this->hasKey = true;
             }
         }
+        $this->context->smarty->assign([
+            'hasKey' => $this->hasKey,
+        ]);
 
         if (!$messages) {
             $this->context->smarty->assign([

--- a/alma/lib/Helpers/ApiHelper.php
+++ b/alma/lib/Helpers/ApiHelper.php
@@ -110,7 +110,10 @@ class ApiHelper
             throw new ApiMerchantsException($this->moduleFactory->l('Alma encountered an error when fetching merchant status, please check your api keys or retry later.', 'GetContentHookController'), $e->getCode(), $e);
         }
 
-        if (!$merchant->can_create_payments) {
+        if (
+            !$merchant
+            || !$merchant->can_create_payments
+        ) {
             throw new ActivationException($this->moduleFactory);
         }
 

--- a/alma/views/templates/hook/getContent.tpl
+++ b/alma/views/templates/hook/getContent.tpl
@@ -151,6 +151,7 @@
             window.onload = function() {
                 if (window.psaccountsVue.isOnboardingCompleted() != true) {
                     document.getElementById("alma_config_form").style.opacity = "0.5";
+                    document.getElementById("alma_config_form").setAttribute('inert', 'inert')
                 }
             }
         </script>

--- a/alma/views/templates/hook/getContent.tpl
+++ b/alma/views/templates/hook/getContent.tpl
@@ -145,6 +145,17 @@
          * *******************/
         window?.psaccountsVue?.init();
     </script>
+
+    {if isset($hasKey) &&  !$hasKey}
+        <script>
+            window.onload = function() {
+                if (window.psaccountsVue.isOnboardingCompleted() != true) {
+                    document.getElementById("alma_config_form").style.opacity = "0.5";
+                }
+            }
+        </script>
+        }
+    {/if}
 {/if}
 {if isset($suggestPSAccount) &&  $suggestPSAccount}
 


### PR DESCRIPTION
### Reason for change

=
[Linear task](https://linear.app/almapay/issue/ECOM-1690/[%F0%9F%A7%A9-ps]-merchant-installing-the-module-for-the-first-time)

### How to test
When the alma module is already installed and configure, you see the connect PS link
If the alma module has no keys, you have not access to the alma form