### PR TITLE
add paymentoptiontemplatehelepr tests

### DIFF
--- a/alma/tests/Unit/Helper/PaymentOptionTemplateHelperTest.php
+++ b/alma/tests/Unit/Helper/PaymentOptionTemplateHelperTest.php
@@ -24,15 +24,265 @@
 
 namespace Alma\PrestaShop\Tests\Unit\Helper;
 
+use Alma\API\Entities\FeePlan;
+use Alma\PrestaShop\Builders\PaymentOptionTemplateHelperBuilder;
+use Alma\PrestaShop\Factories\ContextFactory;
+use Alma\PrestaShop\Factories\ModuleFactory;
+use Alma\PrestaShop\Helpers\ConfigurationHelper;
+use Alma\PrestaShop\Helpers\DateHelper;
+use Alma\PrestaShop\Helpers\PaymentOptionTemplateHelper;
+use Alma\PrestaShop\Helpers\PriceHelper;
+use Alma\PrestaShop\Helpers\SettingsHelper;
+use Alma\PrestaShop\Helpers\TranslationHelper;
 use PHPUnit\Framework\TestCase;
 
 class PaymentOptionTemplateHelperTest extends TestCase
 {
-    public function testGetTemplateAndBnpl()
+    /**
+     * @var \Alma\PrestaShop\Helpers\PaymentOptionTemplateHelper
+     */
+    protected $paymentOptionTemplateHelper;
+
+    public function setUp()
     {
+        $paymentOptionTemplateHelperBuilder = new PaymentOptionTemplateHelperBuilder();
+        $this->paymentOptionTemplateHelper = $paymentOptionTemplateHelperBuilder->getInstance();
+
+        $this->settingsHelperMock = \Mockery::mock(SettingsHelper::class);
+        $this->configurationHelperMock = \Mockery::mock(ConfigurationHelper::class);
+        $this->translationHelperMock = \Mockery::mock(TranslationHelper::class);
+        $this->priceHelperMock = \Mockery::mock(PriceHelper::class);
+        $this->dateHelperMock = \Mockery::mock(DateHelper::class);
+        $this->contextFactoryMock = \Mockery::mock(ContextFactory::class);
+        $this->moduleFactoryMock = \Mockery::mock(ModuleFactory::class);
     }
 
-    public function testBuildTemplateVar()
+    public function testGetTemplateAndBNPL()
     {
+        $this->assertEquals(
+            ['payment_button_deferred.tpl', 10],
+            $this->paymentOptionTemplateHelper->getTemplateAndBNPL(0, 10, 2)
+        );
+
+        $this->assertEquals(
+            ['payment_button_pnx.tpl', 4],
+            $this->paymentOptionTemplateHelper->getTemplateAndBNPL(4, 0, 0)
+        );
+    }
+
+    public function testBuildTemplateVarNoDeferredPlan()
+    {
+        $plan = \Mockery::mock(FeePlan::class);
+        $plan->customerTotalCostAmount = 100;
+        $plan->annualInterestRate = 1;
+        $plan->installmentsCount = 1;
+        $plan->deferredDays = 5;
+        $plan->deferredMonths = 1;
+
+        $plans = [
+            [
+                'purchase_amount' => 100,
+                'customer_fee' => 10,
+                'due_date' => '2024-05-22',
+            ],
+        ];
+
+        $this->settingsHelperMock->shouldReceive('getModeActive')->andReturn('test');
+        $this->settingsHelperMock->shouldReceive('getIdMerchant')->andReturn('merchantId');
+        $this->configurationHelperMock->shouldReceive('isInPageEnabled')->andReturn(true);
+        $this->translationHelperMock->shouldReceive('getTranslation')->andReturn('My translation');
+        $this->priceHelperMock->shouldReceive('formatPriceToCentsByCurrencyId')->andReturn('110.00');
+        $this->dateHelperMock->shouldReceive('getDateFormat')->andReturn('22/05/2024');
+
+        $paymentOptionTemplateHelper = new PaymentOptionTemplateHelper(
+            new ContextFactory(),
+            new ModuleFactory(),
+            $this->settingsHelperMock,
+            $this->configurationHelperMock,
+            $this->translationHelperMock,
+            $this->priceHelperMock,
+            $this->dateHelperMock
+        );
+
+        $result = $paymentOptionTemplateHelper->buildTemplateVar(
+            'general_1_0_0',
+            'update',
+            'description',
+            $plans,
+            0,
+            $plan,
+            1,
+            'en',
+            100,
+            false
+        );
+
+        $expectedResult = [
+            'keyPlan' => 'general_1_0_0',
+            'action' => 'update',
+            'desc' => 'description',
+            'plans' => $plans,
+            'deferred_trigger_limit_days' => 0,
+            'apiMode' => 'TEST',
+            'merchantId' => 'merchantId',
+            'isInPageEnabled' => true,
+            'first' => 1,
+            'creditInfo' => [
+                'totalCart' => 100,
+                'costCredit' => 100,
+                'totalCredit' => 200,
+                'taeg' => 1,
+            ],
+            'installment' => 1,
+            'deferredDays' => 5,
+            'deferredMonths' => 1,
+            'locale' => 'en',
+        ];
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testBuildTemplateVarDeferredPlan()
+    {
+        $plan = \Mockery::mock(FeePlan::class);
+        $plan->customerTotalCostAmount = 100;
+        $plan->annualInterestRate = 1;
+        $plan->installmentsCount = 1;
+        $plan->deferredDays = 5;
+        $plan->deferredMonths = 1;
+
+        $plans = [
+            [
+                'purchase_amount' => 100,
+                'customer_fee' => 10,
+                'due_date' => '2024-05-22',
+            ],
+        ];
+
+        $this->settingsHelperMock->shouldReceive('getModeActive')->andReturn('test');
+        $this->settingsHelperMock->shouldReceive('getIdMerchant')->andReturn('merchantId');
+        $this->configurationHelperMock->shouldReceive('isInPageEnabled')->andReturn(true);
+        $this->translationHelperMock->shouldReceive('getTranslation')->andReturn('My translation');
+        $this->priceHelperMock->shouldReceive('formatPriceToCentsByCurrencyId')->andReturn('110.00');
+        $this->dateHelperMock->shouldReceive('getDateFormat')->andReturn('22/05/2024');
+
+        $paymentOptionTemplateHelper = new PaymentOptionTemplateHelper(
+            new ContextFactory(),
+            new ModuleFactory(),
+            $this->settingsHelperMock,
+            $this->configurationHelperMock,
+            $this->translationHelperMock,
+            $this->priceHelperMock,
+            $this->dateHelperMock
+        );
+
+        $result = $paymentOptionTemplateHelper->buildTemplateVar(
+            'general_1_0_0',
+            'update',
+            'description',
+            $plans,
+            5,
+            $plan,
+            1,
+            'en',
+            100,
+            true
+        );
+
+        $expectedResult = [
+            'keyPlan' => 'general_1_0_0',
+            'action' => 'update',
+            'desc' => 'description',
+            'plans' => $plans,
+            'deferred_trigger_limit_days' => 5,
+            'apiMode' => 'TEST',
+            'merchantId' => 'merchantId',
+            'isInPageEnabled' => true,
+            'first' => 1,
+            'creditInfo' => [
+                'totalCart' => 100,
+                'costCredit' => 100,
+                'totalCredit' => 200,
+                'taeg' => 1,
+            ],
+            'installment' => 1,
+            'deferredDays' => 5,
+            'deferredMonths' => 1,
+            'locale' => 'en',
+            'installmentText' => 'My translation',
+        ];
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testGetTemplateInPage()
+    {
+        $smartyMock = \Mockery::mock(\Smarty::class);
+        $smartyMock->shouldReceive('fetch')->andReturn('module:alma/views/templates/front/payment_form_inpage.tpl');
+
+        $contextMock = \Mockery::mock(\Context::class);
+        $contextMock->smarty = $smartyMock;
+
+        $this->contextFactoryMock->shouldReceive('getContext')->andReturn($contextMock);
+
+        $moduleMock = \Mockery::mock(\Module::class);
+        $moduleMock->name = 'alma';
+        $this->moduleFactoryMock->shouldReceive('getModule')->andReturn($moduleMock);
+
+        $paymentOptionTemplateHelper = new PaymentOptionTemplateHelper(
+            $this->contextFactoryMock,
+            $this->moduleFactoryMock,
+            $this->settingsHelperMock,
+            $this->configurationHelperMock,
+            $this->translationHelperMock,
+            $this->priceHelperMock,
+            $this->dateHelperMock
+        );
+
+        $this->assertEquals(
+            'module:alma/views/templates/front/payment_form_inpage.tpl',
+            $paymentOptionTemplateHelper->getTemplateInPage()
+        );
+    }
+
+    public function testBuildSmartyTemplate()
+    {
+        $smartyMock = \Mockery::mock(\Smarty::class);
+        $smartyMock->shouldReceive('fetch')->andReturn('module:alma/views/templates/front/payment_form_inpage.tpl');
+        $smartyMock->shouldReceive('assign')->andReturn();
+
+        $contextMock = \Mockery::mock(\Context::class);
+        $contextMock->smarty = $smartyMock;
+
+        $this->contextFactoryMock->shouldReceive('getContext')->andReturn($contextMock);
+
+        $moduleMock = \Mockery::mock(\Module::class);
+        $moduleMock->name = 'alma';
+        $this->moduleFactoryMock->shouldReceive('getModule')->andReturn($moduleMock);
+
+        $paymentOptionTemplateHelper = new PaymentOptionTemplateHelper(
+            $this->contextFactoryMock,
+            $this->moduleFactoryMock,
+            $this->settingsHelperMock,
+            $this->configurationHelperMock,
+            $this->translationHelperMock,
+            $this->priceHelperMock,
+            $this->dateHelperMock
+        );
+
+        $this->assertEquals(
+            'module:alma/views/templates/front/payment_form_inpage.tpl',
+            $paymentOptionTemplateHelper->buildSmartyTemplate([], 'payment_form_inpage.tpl')
+        );
+    }
+
+    public function tearDown()
+    {
+        $this->paymentOptionTemplateHelper = null;
+        $this->settingsHelperMock = null;
+        $this->configurationHelperMock = null;
+        $this->translationHelperMock = null;
+        $this->priceHelperMock = null;
+        $this->dateHelperMock = null;
     }
 }


### PR DESCRIPTION
### Reason for change


[Linear task](https://linear.app/almapay/issue/ECOM-1583/[%F0%9F%A7%A9-ps]-unit-paymentoptiontemplatehelpertest)

### Code changes

![image](https://github.com/alma/alma-installments-prestashop/assets/110386752/05063758-176f-448b-9bb6-0c171dd1aaea)
### How to test
- Run the unit tests