### PR TITLE
[DEX-814] Add Github release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,7 +10,9 @@ on:
 jobs:
 
   release:
-    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release')) }}
+    if: |
+      github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'hotfix'))
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,126 @@
+# This workflow is triggered when a pull request is merged and the label 'release' is present.
+# It fetches the last draft release, updates it to a non-draft release and sends a Slack message with the release notes.
+name: Publish Release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+
+  release:
+    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release')) }}
+    runs-on: ubuntu-22.04
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Install taskfile.dev
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ github.token }}
+
+      - name: Create release zip file
+        shell: bash
+        run: |
+          task dist
+
+      - name: Fetch last draft release
+        id: fetch-release-draft
+        shell: bash
+        run: |
+
+          # Call Github releases API and filter draft releases
+          DRAFT_RELEASE=$(curl \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            https://api.github.com/repos/${{ github.repository }}/releases | \
+            jq 'map(select(.draft == true))' \
+          )
+
+          # Fail if 0 or more than 1 draft release is found
+          if [[ $(echo $DRAFT_RELEASE | jq 'length') -ne 1 ]]
+          then
+            echo "No draft release found or more than one draft release found"
+            exit 1
+          fi
+
+          DRAFT_RELEASE=$(echo $DRAFT_RELEASE | jq first)
+
+          # Retrieve tag_name, id and body of the draft release
+          # We need to remove the quotes from the JSON output
+          TAG_NAME=$(echo $DRAFT_RELEASE | jq '.tag_name' | sed 's/"//g')
+          ID=$(echo $DRAFT_RELEASE | jq '.id')
+          BODY=$(echo $DRAFT_RELEASE | jq '.body' | sed 's/"//g')
+          HTML_URL=$(echo $DRAFT_RELEASE | jq '.html_url' | sed 's/"//g')
+
+          # Add URLs to GitHub pull requests
+          PULL_REQUEST_URL_START=${{ github.server_url }}/${{ github.repository }}/pull/
+          ESCAPED_PULL_REQUEST_URL_START=$(printf '%s\n' "$PULL_REQUEST_URL_START" | sed -e 's/[\/&]/\\&/g')
+          BODY=$(echo -e "$BODY" | sed -E "s/#([0-9]+)/[#\1](${ESCAPED_PULL_REQUEST_URL_START}\1)/g")
+
+          # Add URLs to GitHub profiles
+          PROFILE_URL_START=${{ github.server_url }}/
+          ESCAPED_PROFILE_URL_START=$(printf '%s\n' "$PROFILE_URL_START" | sed -e 's/[\/&]/\\&/g')
+          BODY=$(echo -e "$BODY" | sed -E "s/@([[:alnum:]-]+)/[@\1](${ESCAPED_PROFILE_URL_START}\1)/g")
+
+          # Write the output variables
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "id=$ID" >> $GITHUB_OUTPUT
+          echo "html_url=$HTML_URL" >> $GITHUB_OUTPUT
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Add zip file to the release assets
+        shell: bash
+        run: |
+         curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Content-Type: application/zip" \
+            -T "dist/alma.zip" \
+            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.fetch-release-draft.outputs.id }}/assets?name=alma.zip
+
+      - name: Publish Github release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: "${{ steps.fetch-release-draft.outputs.id }}",
+              draft: false,
+              make_latest: true
+            });
+
+      - name: Format release notes for Slack
+        # v1.0.2 cannot be used as it is not correctly handling the newlines
+        uses: LoveToKnow/slackify-markdown-action@v1.0.0
+        id: slack-markdown-release-notes
+        with:
+          text: |
+            New release of `${{ github.repository }}` published, **[${{ steps.fetch-release-draft.outputs.tag_name }}](${{
+              steps.fetch-release-draft.outputs.html_url }})**:
+
+            ${{ steps.fetch-release-draft.outputs.body }}
+
+      - name: Send changelog to Slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # TODO: Replace with channel #alma_changelog (id: CR9C57YM6) once full testing is done
+          # Channel `#devx-experiments`
+          channel-id: C04MQ9VEWRF
+          slack-message: ${{ steps.slack-markdown-release-notes.outputs.text }}
+          payload: |
+            {
+              "username": "${{ github.event.sender.login }}",
+              "icon_url": "${{ github.event.sender.avatar_url }}"
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_RELEASE_CHANGELOG_BOT_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -50,9 +50,9 @@ jobs:
 
           DRAFT_RELEASE=$(echo $DRAFT_RELEASE | jq first)
 
-          # Retrieve tag_name, id and body of the draft release
+          # Retrieve name, id and body of the draft release
           # We need to remove the quotes from the JSON output
-          TAG_NAME=$(echo $DRAFT_RELEASE | jq '.tag_name' | sed 's/"//g')
+          NAME=$(echo $DRAFT_RELEASE | jq '.name' | sed 's/"//g')
           ID=$(echo $DRAFT_RELEASE | jq '.id')
           BODY=$(echo $DRAFT_RELEASE | jq '.body' | sed 's/"//g')
           HTML_URL=$(echo $DRAFT_RELEASE | jq '.html_url' | sed 's/"//g')
@@ -68,7 +68,7 @@ jobs:
           BODY=$(echo -e "$BODY" | sed -E "s/@([[:alnum:]-]+)/[@\1](${ESCAPED_PROFILE_URL_START}\1)/g")
 
           # Write the output variables
-          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "id=$ID" >> $GITHUB_OUTPUT
           echo "html_url=$HTML_URL" >> $GITHUB_OUTPUT
           echo "body<<EOF" >> $GITHUB_OUTPUT
@@ -96,7 +96,8 @@ jobs:
               repo,
               release_id: "${{ steps.fetch-release-draft.outputs.id }}",
               draft: false,
-              make_latest: true
+              make_latest: true,
+              tag_name: "${{ steps.fetch-release-draft.outputs.name }}"
             });
 
       - name: Format release notes for Slack
@@ -105,7 +106,7 @@ jobs:
         id: slack-markdown-release-notes
         with:
           text: |
-            New release of `${{ github.repository }}` published, **[${{ steps.fetch-release-draft.outputs.tag_name }}](${{
+            New release of `${{ github.repository }}` published, **[${{ steps.fetch-release-draft.outputs.name }}](${{
               steps.fetch-release-draft.outputs.html_url }})**:
 
             ${{ steps.fetch-release-draft.outputs.body }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,9 +10,7 @@ on:
 jobs:
 
   release:
-    if: |
-      github.event.pull_request.merged == true &&
-      (contains(github.event.pull_request.labels.*.name, 'release') || contains(github.event.pull_request.labels.*.name, 'hotfix'))
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-22.04
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ tools/composer.lock
 .phpunit.result.cache
 /alma/.php-cs-fixer.cache
 /alma/.coverage
-./.task
+.task/
 .php-cs-fixer.cache


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

https://linear.app/almapay/issue/DEX-814/prestashop-create-release-github-workflow

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
This adds a new Github workflow that will be triggered when a pull request containing the label "release" is merged : 
* It will fetch the current draft release, add the zip file and publish it
* It will send a Slack message to #alma_changelog with the content of the release 

### How to test

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
> [!WARNING]
> This has only been tested on https://github.com/alma/github-actions-experiments
> It will have to be tested on this repository during the next release
