### PR TITLE
[DEX-815] Add backport Github workflow

### DIFF
--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -1,0 +1,34 @@
+# This workflow is triggered when a pull request is merged and the label 'release' is present.
+# It opens a pull request to backport the changes from main to develop.
+name: Create backport pull request
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+
+  create-backport-pull-request:
+    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release')) }}
+    runs-on: ubuntu-latest
+
+    steps:
+
+        - uses: actions/checkout@v4
+          with:
+            ref: develop
+
+        # See https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#keep-a-branch-up-to-date-with-another
+        - name: Fetch main branch
+          run: |
+            git fetch origin main:main
+            git reset --hard main
+
+        - name: Create Pull Request
+          uses: peter-evans/create-pull-request@v6
+          with:
+            commit-message: 'chore: backport main to develop'
+            title: Backport main to develop
+            branch: chore/backport-main-to-develop
+            base: develop

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
 
   create-backport-pull-request:
     if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release')) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
 

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -4,6 +4,8 @@ name: Create backport pull request
 
 on:
   pull_request:
+    branches:
+      - main
     types:
       - closed
 

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   create-release-pull-request:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

https://linear.app/almapay/issue/DEX-815/prestashop-create-develop-backport-github-workflow

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
This adds a new Github workflow that will be triggered when a pull request containing the label "release" is merged
This workflow will create a new pull request that updates the develop branch with the changes pushed on main for the release.

### How to test

> [!WARNING]
> This has been tested on https://github.com/alma/github-actions-experiments
> It will have to be tested on this repository during the next release