### PR TITLE
fix quantity issue with insurance without updateProduct event

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -112,6 +112,9 @@ function onloadAddInsuranceInputOnProductAlma() {
             }
         }
         if (e.data.type === 'getSelectedInsuranceData') {
+            if (parseInt(document.querySelector('.qty [name="qty"]').value) !== quantity) {
+                quantity = document.querySelector('.qty [name="qty"]').value;
+            }
             insuranceSelected = true;
             selectedAlmaInsurance = e.data.selectedInsuranceData;
             prestashop.emit('updateProduct', {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1726/[🧩-ps]-issue-about-the-quantity-when-selecting-insurance-with-more-1)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We check if the quantity is different between input and ProductDetail
If yes we get the quantity of input to set the quantity

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
We need to test on ODP because they haven't event to updateProduct when the quantity change

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->