### PR TITLE
[DEX-870] Add hotfix GitHub workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
       run: task lint:ci
 
     - name: Run unit Tests and Coverage
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'hotfix') }}
       run: task test:coverage
       env:
         XDEBUG_MODE: coverage

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   launch:
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'hotfix')
 
     strategy:
       matrix:

--- a/.github/workflows/hotfix-pull-request.yml
+++ b/.github/workflows/hotfix-pull-request.yml
@@ -62,5 +62,5 @@ jobs:
             - [ ] Review the files updated with the new version number in the commit named "chore: update version"
           branch: hotfix/${{ steps.release-drafter.outputs.tag_name }}
           base: main
-          labels: hotfix
+          labels: hotfix, release
 

--- a/.github/workflows/hotfix-pull-request.yml
+++ b/.github/workflows/hotfix-pull-request.yml
@@ -1,27 +1,23 @@
-name: Create release pull request
+name: Create hotfix pull request
 
 on:
   workflow_dispatch:
+    inputs:
+      changelog-message:
+        type: string
+        description: The message to add to the changelog
+        required: true
 
 jobs:
 
-  create-release-pull-request:
-    runs-on: ubuntu-latest
+  create-hotfix-pull-request:
+    runs-on: ubuntu-22.04
 
     steps:
 
       - uses: actions/checkout@v4
         with:
           ref: main
-          persist-credentials: false
-
-      # This is needed to get all changes from develop in the PR
-      # It won't work if we checkout from develop, see https://github.com/peter-evans/create-pull-request/issues/2841
-      # See https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#keep-a-branch-up-to-date-with-another
-      - name: Fetch develop branch
-        run: |
-          git fetch origin develop:develop
-          git reset --hard develop
 
       - name: Release drafter
         uses: release-drafter/release-drafter@v5
@@ -29,11 +25,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update CHANGELOG.md
+      - name: Update release draft
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: "${{ steps.release-drafter.outputs.id }}",
+              draft: true,
+              body: "### 🐛 Bug Fixes\n ${{ inputs.changelog-message }}\n"
+            });
+
+      - name: Update CHANGELOG.md file
         uses: stefanzweifel/changelog-updater-action@v1
         with:
           latest-version: ${{ steps.release-drafter.outputs.tag_name }}
-          release-notes: ${{ steps.release-drafter.outputs.body }}
+          release-notes: "### 🐛 Bug Fixes\n ${{ inputs.changelog-message }}\n"
 
       - name: Update other files
         run: |
@@ -46,11 +55,12 @@ jobs:
           title: Release ${{ steps.release-drafter.outputs.tag_name }}
           body: |
             Update version to ${{ steps.release-drafter.outputs.tag_name }}
-
+    
             ### Checklist of actions to be done before merging
             - [ ] Review and update the CHANGELOG.md if needed
             - [ ] Review and update the Github release draft if needed
             - [ ] Review the files updated with the new version number in the commit named "chore: update version"
-          branch: release/${{ steps.release-drafter.outputs.tag_name }}
+          branch: hotfix/${{ steps.release-drafter.outputs.tag_name }}
           base: main
-          labels: release
+          labels: hotfix
+


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

https://linear.app/almapay/issue/DEX-870/prestashop-add-hotfix-github-workflow

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
* This adds a new Github Workflow `hotfix-pull-request` that can be triggered manually 
This workflow requires a changelog message as an input
This workflow does following actions : 
   * Creates a release draft (with a computed version number)
   * Updates the release draft body with the changelog message provided as input
   * Updates the CHANGELOG.md file with the same content
   * Updates the files containing the version number using `./scripts/update-files-with-release-version.sh`
   * Creates a branch hotfix/<release_tag_name> from `main` branch containing previous changes
   * Opens a pull request base on main and labeled `hotfix`
* This updates `ci` and `e2e-test` workflows in order not to trigger unit tests and E2E tests on pull request labeled `hotfix`
### How to test

> [!WARNING]
> This has been tested on https://github.com/alma/github-actions-experiments
> It will need to be tested on this repository after merging
