### PR TITLE
[DEX-863][DEX-809] Add a task command to trigger release/hotfix workflow

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -23,7 +23,7 @@ jobs:
           git fetch origin develop:develop
           git reset --hard develop
 
-      - name: Release drafter
+      - name: Create release draft
         uses: release-drafter/release-drafter@v5
         id: release-drafter
         env:
@@ -35,7 +35,7 @@ jobs:
           latest-version: ${{ steps.release-drafter.outputs.tag_name }}
           release-notes: ${{ steps.release-drafter.outputs.body }}
 
-      - name: Update other files
+      - name: Update files with release version
         run: |
           ./scripts/update-files-with-release-version.sh ${{ steps.release-drafter.outputs.tag_name }}
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,8 @@
 version: 3
 
+env:
+  REPOSITORY: alma-installments-prestashop
+
 tasks:
 
   default:
@@ -98,3 +101,45 @@ tasks:
       - crowdin
     cmds:
       - crowdin upload sources
+
+  release:
+    desc: Create a release pull request
+    cmds:
+    - task: trigger-release-pull-request-workflow
+      vars: { WORKFLOW_FILE: 'release-pull-request.yml', RELEASE_TYPE: 'release'
+        }
+
+  hotfix:
+    desc: Create a hotfix pull request
+    cmds:
+    - task: trigger-release-pull-request-workflow
+      vars: { WORKFLOW_FILE: 'hotfix-pull-request.yml', RELEASE_TYPE: 'hotfix'}
+
+  trigger-release-pull-request-workflow:
+    internal: true
+    vars:
+      WORKFLOW_FILE: '{{default "create-release-pr.yml" .WORKFLOW_FILE}}'
+      RELEASE_TYPE: '{{default "release" .RELEASE_TYPE}}'
+    silent: true
+    preconditions:
+    - sh: gh --version
+      msg: |
+        ⚠️ This task requires `gh` (Github CLI).
+        Please check out: https://github.com/cli/cli#installation
+        You'll need a personal access token to authenticate with `gh`.
+        Please check out: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic
+        Then, run `gh auth login` or set the GITHUB_TOKEN environment variable with your personal access token.
+    cmds:
+      - |
+        # If RELEASE_TYPE is hotfix, ask for a changelog message
+        INPUTS_FLAG=""
+        if [ "{{.RELEASE_TYPE}}" == "hotfix" ]; then
+          read -p "Please, provide a changelog message for this hotfix: "
+          INPUTS_FLAG="-f changelog-message='$REPLY'"
+        fi
+        echo "Creating {{.RELEASE_TYPE}} pull request..."
+        eval gh workflow run {{.WORKFLOW_FILE}} $INPUTS_FLAG
+        echo "{{.RELEASE_TYPE}} pull request created, check out https://github.com/alma/$REPOSITORY/pulls?q=is%3Aopen+is%3Apr+label%3A{{.RELEASE_TYPE}}"
+        echo "If no pull request is created, check out https://github.com/alma/$REPOSITORY/actions/workflows/{{.WORKFLOW_FILE}}."
+        echo "Please, review and merge the pull request."
+        echo "After merging, the release will be automatically created."

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -102,47 +102,50 @@ tasks:
     cmds:
       - crowdin upload sources
 
+  gh-cli:
+    internal: true
+    preconditions:
+      - sh: gh --version
+        msg: |
+          ⚠️ This task requires `gh` (Github CLI).
+          Please check out: https://github.com/cli/cli#installation
+          You'll need a personal access token to authenticate with `gh`.
+          Please check out: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic
+          Then, run `gh auth login` or set the GITHUB_TOKEN environment variable with your personal access token.
+
   release:
+    deps:
+      - gh-cli
     desc: Create a release pull request
-    cmds:
-    - task: trigger-release-pull-request-workflow
-      vars: 
-        WORKFLOW_FILE: 'release-pull-request.yml'
-        RELEASE_TYPE: 'release'
+    cmds: 
+      - gh workflow run release-pull-request.yml
+      - sleep 2
+      - cmd: echo "Release pull request created, check out https://github.com/alma/{{.REPOSITORY}}/pulls?q=is%3Aopen+is%3Apr+label%3Arelease"
+        silent: true
+      - cmd: echo "If no pull request is created, check out https://github.com/alma/{{.REPOSITORY}}/actions/workflows/release-pull-request.yml."
+        silent: true
+      - cmd: echo "Please, review and merge the pull request."
+        silent: true
+      - cmd: echo "After merging, the release will be automatically created."
+        silent: true
 
   hotfix:
+    deps:
+      - gh-cli
     desc: Create a hotfix pull request
-    cmds:
-    - task: trigger-release-pull-request-workflow
-      vars: 
-        WORKFLOW_FILE: 'hotfix-pull-request.yml'
-        RELEASE_TYPE: 'hotfix'
-
-  trigger-release-pull-request-workflow:
-    internal: true
-    vars:
-      WORKFLOW_FILE: '{{default "create-release-pr.yml" .WORKFLOW_FILE}}'
-      RELEASE_TYPE: '{{default "release" .RELEASE_TYPE}}'
-    silent: true
     preconditions:
-    - sh: gh --version
-      msg: |
-        ⚠️ This task requires `gh` (Github CLI).
-        Please check out: https://github.com/cli/cli#installation
-        You'll need a personal access token to authenticate with `gh`.
-        Please check out: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic
-        Then, run `gh auth login` or set the GITHUB_TOKEN environment variable with your personal access token.
-    cmds:
-      - |
-        # If RELEASE_TYPE is hotfix, ask for a changelog message
-        INPUTS_FLAG=""
-        if [ "{{.RELEASE_TYPE}}" == "hotfix" ]; then
-          read -p "Please, provide a changelog message for this hotfix: "
-          INPUTS_FLAG="-f changelog-message='$REPLY'"
-        fi
-        echo "Creating {{.RELEASE_TYPE}} pull request..."
-        eval gh workflow run {{.WORKFLOW_FILE}} $INPUTS_FLAG
-        echo "{{.RELEASE_TYPE}} pull request created, check out https://github.com/alma/$REPOSITORY/pulls?q=is%3Aopen+is%3Apr+label%3A{{.RELEASE_TYPE}}"
-        echo "If no pull request is created, check out https://github.com/alma/$REPOSITORY/actions/workflows/{{.WORKFLOW_FILE}}."
-        echo "Please, review and merge the pull request."
-        echo "After merging, the release will be automatically created."
+      - sh: test -n "{{.CHANGELOG_MESSAGE}}"
+        msg: |
+          ⚠️ This task requires a changelog message.
+          Please provide a changelog message. Example: `task hotfix CHANGELOG_MESSAGE='This is a message'`.
+    cmds: 
+      - gh workflow run hotfix-pull-request.yml -F changelog-message='{{.CHANGELOG_MESSAGE}}'
+      - sleep 2
+      - cmd: echo "Hotfix pull request created, check out https://github.com/alma/{{.REPOSITORY}}/pulls?q=is%3Aopen+is%3Apr+label%3Ahotfix"
+        silent: true
+      - cmd: echo "If no pull request is created, check out https://github.com/alma/{{.REPOSITORY}}/actions/workflows/hotfix-pull-request.yml."
+        silent: true
+      - cmd: echo "Please, review and merge the pull request."
+        silent: true
+      - cmd: echo "After merging, the release will be automatically created."
+        silent: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -114,7 +114,9 @@ tasks:
     desc: Create a hotfix pull request
     cmds:
     - task: trigger-release-pull-request-workflow
-      vars: { WORKFLOW_FILE: 'hotfix-pull-request.yml', RELEASE_TYPE: 'hotfix'}
+      vars: 
+        WORKFLOW_FILE: 'hotfix-pull-request.yml'
+        RELEASE_TYPE: 'hotfix'
 
   trigger-release-pull-request-workflow:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -106,8 +106,9 @@ tasks:
     desc: Create a release pull request
     cmds:
     - task: trigger-release-pull-request-workflow
-      vars: { WORKFLOW_FILE: 'release-pull-request.yml', RELEASE_TYPE: 'release'
-        }
+      vars: 
+        WORKFLOW_FILE: 'release-pull-request.yml'
+        RELEASE_TYPE: 'release'
 
   hotfix:
     desc: Create a hotfix pull request


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

https://linear.app/almapay/issue/DEX-809/prestashop-add-task-hotfix-command
https://linear.app/almapay/issue/DEX-863/prestashop-add-a-task-release-command-to-trigger-workflow-release-pull

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
This adds two task commands : 
* task release
* task hotfix
These 2 commands trigger the `release-pull-request` and `hotfix-pull-request` workflows respectively, that open a pull request for release/hotfix changes

These task commands require `gh` cli to be installed, and a Github personal token

Note that `hotfix-pull-request` workflow is not yet available, but will be with https://github.com/alma/alma-installments-prestashop/pull/445
