### PR TITLE
[DEX-866] Add infos in PR about E2E tests run status

### DIFF
--- a/.github/workflows/e2e-test-post-results.yml
+++ b/.github/workflows/e2e-test-post-results.yml
@@ -44,9 +44,20 @@ jobs:
                   body: commentBody
               })
 
+
+      - name: Generate Github token for PR checks
+        id: github-token-checks
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
+          private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+          repositories: alma-installments-prestashop
+
       - name: Update check in PR with E2E tests results
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.github-token-checks.outputs.token }}
           script: |
             let checkStatus = 'completed';
             let checkConclusion = 'success';

--- a/.github/workflows/e2e-test-post-results.yml
+++ b/.github/workflows/e2e-test-post-results.yml
@@ -1,0 +1,70 @@
+name: Post E2E results in pull request
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        type: string
+        description: The PR number in which to post the results
+        required: true
+      e2e-status:
+        type: string
+        description: The status of the E2E tests (failure or success)
+        required: true
+      e2e-run-url:
+        type: string
+        description: The URL of the E2E tests run
+        required: true
+      check-id:
+        type: string
+        description: Github check ID of the E2E tests in the pull request
+        required: true
+
+jobs:
+
+  e2e-post-results:
+    runs-on: ubuntu-22.04
+
+    steps:
+
+      - name: Add a comment with E2E tests results in the Pull Request
+        uses: actions/github-script@v7
+        with:
+            script: |
+              let commentBody = '❌ E2E tests have failed. \n';
+              if ('${{ github.event.inputs.e2e-status }}' === 'success') {
+                  commentBody = '✅ E2E tests have been successfully completed. \n';
+              }
+              commentBody += '➡️ You can find the results [here](${{ github.event.inputs.e2e-run-url }}).';
+              commentBody += '\n\n<!-- id:e2e-test-run-info -->';
+              github.rest.issues.createComment({
+                  issue_number: ${{ github.event.inputs.pr-number }},
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+              })
+
+      - name: Update check in PR with E2E tests results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let checkStatus = 'completed';
+            let checkConclusion = 'success';
+            let checkOutput = {
+              title: 'E2E tests',
+              summary: '✅ E2E tests have been successfully completed',
+              text: `➡️ You can find the results [here](${{ github.event.inputs.e2e-run-url }}).`
+            };
+            if ('${{ github.event.inputs.e2e-status }}' === 'failure') {
+              checkConclusion = 'failure';
+              checkOutput.summary = '❌ E2E tests have failed.';
+            }
+            github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: '${{ github.event.inputs.check-id }}',
+              status: checkStatus,
+              conclusion: checkConclusion,
+              output: checkOutput
+            })
+

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -57,7 +57,7 @@ jobs:
       id: e2e-tests-workflow-dispatch
       with:
           token: ${{ steps.github-token-infrastructure.outputs.token }}
-          ref: devx/dex-866-improve-e2e-status-update-on-pr
+          ref: main
           repo: integration-infrastructure
           owner: alma
           workflow: deploy-cms.yaml

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -18,26 +18,21 @@ jobs:
           #- 1.7.7.5
 
     steps:
-    - name: Get only last part of branch name in $SLUG_VERSION env var
-      run:  |
-        VERSION=${{ matrix.version }}
-        echo "SLUG_VERSION=${VERSION//./-}" >> $GITHUB_ENV
 
-    - name: Generate Github token for PR checks
-      id: github-token-checks
-      uses: actions/create-github-app-token@v1
-      continue-on-error: true
+    - name: Create a Github check for E2E tests run in the Pull Request
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      id: create-github-check
       with:
-        app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
-        private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
-        repositories: alma-installments-prestashop
-
-    - uses: LouisBrunner/checks-action@v2.0.0
-      id: e2e_status
-      with:
-        token: ${{ steps.github-token-checks.outputs.token }}
-        name: E2E Test / result (${{ matrix.version }})
-        status: "in_progress"
+          script: |
+              const check = await github.rest.checks.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'E2E tests results',
+                  head_sha: '${{ github.event.pull_request.head.sha }}',
+                  status: "in_progress",
+              })
+              core.setOutput('id', check.data.id)
 
     - name: Generate Github token for integration-infrastructure repo
       id: github-token-infrastructure
@@ -47,27 +42,64 @@ jobs:
         private-key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}
         repositories: integration-infrastructure
 
-    - name: Invoke e2e workflow with inputs
-      uses: benc-uk/workflow-dispatch@v1.2.3
+    - name: Trigger E2E tests in the integration-infrastructure repository
+      uses: codex-/return-dispatch@v1
+      id: e2e-tests-workflow-dispatch
       with:
-        workflow: Deploy CMS
-        token: ${{ steps.github-token-infrastructure.outputs.token }}
-        repo: alma/integration-infrastructure
-        ref: main
-        inputs: >
-          {
-            "name": "e2e-${{ github.run_id }}",
-            "alma_plugin_branch": "${{ github.head_ref || github.ref_name }}",
-            "alma_plugin_test_branch" : "main",
-            "cms": "prestashop-${{ matrix.version }}",
-            "e2e": "true",
-            "e2e_check_id": "${{ steps.e2e_status.outputs.check_id }}",
-            "e2e_check_origin" : "${{ github.repository }}"
-          }
+          token: ${{ steps.github-token-infrastructure.outputs.token }}
+          ref: devx/dex-866-improve-e2e-status-update-on-pr
+          repo: integration-infrastructure
+          owner: alma
+          workflow: deploy-cms.yaml
+          workflow_inputs: '{
+              "name": "e2e-${{ github.run_id }}",
+              "alma_plugin_branch": "${{ github.head_ref || github.ref_name }}",
+              "alma_plugin_test_branch" : "main",
+              "cms": "prestashop-${{ matrix.version }}",
+              "e2e": "true",
+              "e2e_check_info" : "{
+                  \"repository\": \"${{ github.event.repository.name }}\",
+                  \"pr_number\": \"${{ github.event.number }}\",
+                  \"check_id\": \"${{ steps.create-github-check.outputs.id  }}\"
+                  }"
+              }'
+          workflow_timeout_seconds: 120 # Default: 300
 
-    - uses: LouisBrunner/checks-action@v2.0.0
-      if: failure()
+    - name: Hide deprecated E2E test run info message
+      uses: int128/hide-comment-action@v1
       with:
-        token: ${{ steps.github-token-checks.outputs.token }}
-        check_id: ${{ steps.e2e_status.outputs.check_id }}
-        conclusion: failure
+        # This string should be kept in sync with the last words of the comment in.
+        # `Send a comment to the PR informing that the E2E tests are running` step (in this workflow).
+        # `Add a comment with E2E tests results in the Pull Request` step (in e2e-test-post-results workflow)
+        contains: <!-- id:e2e-test-run-info -->
+
+    - name: Send a comment to the PR informing that the E2E tests are running
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+          script: |
+              github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: '⏳E2E tests are currently running. \n' +
+                      '➡️ You can follow their progression [here](${{steps.e2e-tests-workflow-dispatch.outputs.run_url}}).' +
+                      '\n\n<!-- id:e2e-test-run-info -->'
+              })
+
+    - name: Update Github check with the E2E tests run URL
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+          script: |
+              const checkOutput = {
+                  title: 'E2E tests results',
+                  summary: '⏳E2E tests are currently running.',
+                  text: '➡️ You can follow their progression [here](${{steps.e2e-tests-workflow-dispatch.outputs.run_url}}).'
+              };
+              github.rest.checks.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  check_run_id: '${{ steps.create-github-check.outputs.id }}',
+                  output: checkOutput
+              })

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -19,11 +19,21 @@ jobs:
 
     steps:
 
+    - name: Generate Github token for PR checks
+      id: github-token-checks
+      uses: actions/create-github-app-token@v1
+      continue-on-error: true
+      with:
+        app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
+        private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+        repositories: alma-installments-prestashop
+
     - name: Create a Github check for E2E tests run in the Pull Request
       if: github.event_name == 'pull_request'
       uses: actions/github-script@v7
       id: create-github-check
       with:
+          github-token: ${{ steps.github-token-checks.outputs.token }}
           script: |
               const check = await github.rest.checks.create({
                   owner: context.repo.owner,
@@ -91,6 +101,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: actions/github-script@v7
       with:
+          github-token: ${{ steps.github-token-checks.outputs.token }}
           script: |
               const checkOutput = {
                   title: 'E2E tests results',


### PR DESCRIPTION
### Reason for change

This is the duplicate of https://github.com/alma/alma-installments-prestashop/pull/463 but this targets main
We need this branch to be merged on `develop` AND `main` to be functional (A branch from `develop` will call `integration-infrastructure` `deploy-cms` workflow, that will call back the `e2e-test-post-results` workflow of prestashop on `main` branch that must exist)