### PR TITLE
Gather cart data from pnx and deferred payments

### DIFF
--- a/alma/lib/Model/PaymentData.php
+++ b/alma/lib/Model/PaymentData.php
@@ -319,7 +319,7 @@ class PaymentData
                     ],
                 ],
                 'locale' => $locale,
-				'cart' => $this->cartData->cartInfo($this->context->cart),
+                'cart' => $this->cartData->cartInfo($this->context->cart),
             ],
             'customer' => $customerData,
         ];
@@ -328,7 +328,7 @@ class PaymentData
             $dataPayment['payment']['deferred'] = 'trigger';
             $dataPayment['payment']['deferred_description'] = $this->customFieldsHelper->getDescriptionPaymentTriggerByLang($this->context->language->id);
         }
-		
+
         if ($this->isInPage($dataPayment)) {
             $dataPayment['payment']['origin'] = 'online_in_page';
         }

--- a/alma/lib/Model/PaymentData.php
+++ b/alma/lib/Model/PaymentData.php
@@ -319,6 +319,7 @@ class PaymentData
                     ],
                 ],
                 'locale' => $locale,
+				'cart' => $this->cartData->cartInfo($this->context->cart),
             ],
             'customer' => $customerData,
         ];
@@ -327,11 +328,7 @@ class PaymentData
             $dataPayment['payment']['deferred'] = 'trigger';
             $dataPayment['payment']['deferred_description'] = $this->customFieldsHelper->getDescriptionPaymentTriggerByLang($this->context->language->id);
         }
-
-        if ($feePlans['installmentsCount'] > 4) {
-            $dataPayment['payment']['cart'] = $this->cartData->cartInfo($this->context->cart);
-        }
-
+		
         if ($this->isInPage($dataPayment)) {
             $dataPayment['payment']['origin'] = 'online_in_page';
         }

--- a/alma/tests/Unit/Model/PaymentDataTest.php
+++ b/alma/tests/Unit/Model/PaymentDataTest.php
@@ -24,27 +24,183 @@
 
 namespace Alma\PrestaShop\Tests\Unit\Model;
 
+use Alma\PrestaShop\Builders\Models\PaymentDataBuilder;
+use Alma\PrestaShop\Factories\ContextFactory;
+use Alma\PrestaShop\Helpers\SettingsHelper;
 use PHPUnit\Framework\TestCase;
 
 class PaymentDataTest extends TestCase
 {
-    public function testDataFromCart()
+    /**
+     * @var mixed
+     */
+    protected $customer;
+    protected $shippingAddress;
+    protected $billingAddress;
+    protected $paymentData;
+    protected $cartMock;
+    protected $linkMock;
+    protected $settingsHelperMock;
+    protected $contextMock;
+
+    public function setUp()
     {
+        $paymentDataBuilderMock = \Mockery::mock(PaymentDataBuilder::class)->makePartial();
+        $contextFactoryMock = $this->createMock(ContextFactory::class);
+        $this->contextMock = $this->createMock(\Context::class);
+
+        $this->cartMock = $this->createMock(\Cart::class);
+        $this->cartMock->id = '42';
+        $this->cartMock->method('getSummaryDetails')->willReturn(['products' => [], 'gift_products' => []]);
+        $this->cartMock->method('getCartRules')->willReturn([]);
+        $this->contextMock->cart = $this->cartMock;
+
+        $this->linkMock = $this->createMock(\Link::class);
+        $this->linkMock->method('getPageLink')->willReturn('');
+        $this->linkMock->method('getModuleLink')->willReturn('');
+        $this->contextMock->link = $this->linkMock;
+
+        $this->settingsHelperMock = $this->createMock(SettingsHelper::class);
+
+        $contextFactoryMock->method('getContext')->willReturn($this->contextMock);
+        $paymentDataBuilderMock->shouldReceive('getContextFactory')->andReturn($contextFactoryMock);
+        $paymentDataBuilderMock->shouldReceive('getSettingsHelper')->andReturn($this->settingsHelperMock);
+        $this->paymentData = $paymentDataBuilderMock->getInstance();
+
+        $this->customer = $this->createMock(\Customer::class);
+        $this->shippingAddress = $this->createMock(\Address::class);
+        $this->billingAddress = $this->createMock(\Address::class);
     }
 
-    public function testGetDataForEligibilityV2()
+    public function tearDown()
     {
+        \Mockery::close();
     }
 
-    public function testBuildCustomerData()
+    private $dataPaymentExpected = [
+        'website_customer_details' => [
+            'new_customer' => true,
+            'is_guest' => false,
+            'created' => false,
+            'current_order' => [
+                'purchase_amount' => 10000,
+                'created' => false,
+                'payment_method' => 'alma',
+                'shipping_method' => 'Unknown',
+                'items' => [],
+            ],
+            'previous_orders' => [
+                0 => [],
+            ],
+        ],
+        'payment' => [
+            'installments_count' => 3,
+            'deferred_days' => 0,
+            'deferred_months' => 0,
+            'purchase_amount' => 10000,
+            'customer_cancel_url' => '',
+            'return_url' => '',
+            'ipn_callback_url' => '',
+            'shipping_address' => [
+                'line1' => null,
+                'postal_code' => null,
+                'city' => null,
+                'country' => 'FR',
+                'county_sublocality' => null,
+                'state_province' => '',
+            ],
+            'shipping_info' => null,
+            'billing_address' => [
+                'line1' => null,
+                'postal_code' => null,
+                'city' => null,
+                'country' => 'FR',
+                'county_sublocality' => null,
+                'state_province' => '',
+            ],
+            'custom_data' => [
+                'cart_id' => '42',
+                'purchase_amount_new_conversion_func' => 10000,
+                'cart_totals' => 100,
+                'cart_totals_high_precision' => '100.0000000000000000',
+                'poc' => [
+                    0 => 'data-for-risk',
+                ],
+            ],
+            'locale' => 'fr-FR',
+            'cart' => [
+                'items' => [],
+                'discounts' => [],
+            ],
+        ],
+        'customer' => [
+            'state_province' => 'test',
+        ],
+    ];
+
+    private $purchaseAmount = 100;
+    private $feePlans = [
+        'installmentsCount' => 3,
+        'deferredDays' => 0,
+        'deferredMonths' => 0,
+        'deferred_trigger_limit_days' => 0,
+    ];
+    private $countryShippingAddress = 'FR';
+    private $countryBillingAddress = 'FR';
+    private $locale = 'fr-FR';
+    private $customerData = [
+        'state_province' => 'test',
+    ];
+
+    public function testBuildDataPaymentForPnx()
     {
+        $this->assertEquals($this->dataPaymentExpected, $this->paymentData->buildDataPayment(
+            $this->customer,
+            $this->purchaseAmount,
+            $this->feePlans,
+            $this->shippingAddress,
+            $this->countryShippingAddress,
+            $this->locale,
+            $this->billingAddress,
+            $this->countryBillingAddress,
+            $this->customerData));
     }
 
-    public function testBuildWebsiteCustomerDetails()
+    public function testBuildDataPaymentWithDeferredTrigger()
     {
+        $this->settingsHelperMock->method('isDeferredTriggerLimitDays')->willReturn(true);
+        $this->contextMock->language = $this->createMock(\Language::class);
+        $this->contextMock->language->id = '38';
+
+        $this->dataPaymentExpected['payment']['deferred'] = 'trigger';
+        $this->dataPaymentExpected['payment']['deferred_description'] = 'At shipping';
+
+        $this->assertEquals($this->dataPaymentExpected, $this->paymentData->buildDataPayment(
+            $this->customer,
+            $this->purchaseAmount,
+            $this->feePlans,
+            $this->shippingAddress,
+            $this->countryShippingAddress,
+            $this->locale,
+            $this->billingAddress,
+            $this->countryBillingAddress,
+            $this->customerData));
     }
 
-    public function testCheckPurchaseAmount()
+    public function testBuildDataPaymentWithInPage()
     {
+        $this->settingsHelperMock->method('isInPageEnabled')->willReturn(true);
+        $this->dataPaymentExpected['payment']['origin'] = 'online_in_page';
+
+        $this->assertEquals($this->dataPaymentExpected, $this->paymentData->buildDataPayment(
+            $this->customer,
+            $this->purchaseAmount,
+            $this->feePlans,
+            $this->shippingAddress,
+            $this->countryShippingAddress,
+            $this->locale,
+            $this->billingAddress,
+            $this->countryBillingAddress,
+            $this->customerData));
     }
 }

--- a/alma/tests/Unit/Model/PaymentDataTest.php
+++ b/alma/tests/Unit/Model/PaymentDataTest.php
@@ -32,7 +32,7 @@ use PHPUnit\Framework\TestCase;
 class PaymentDataTest extends TestCase
 {
     /**
-     * @var mixed
+     * @var \Customer
      */
     protected $customer;
     protected $shippingAddress;
@@ -59,6 +59,8 @@ class PaymentDataTest extends TestCase
         $this->linkMock->method('getPageLink')->willReturn('');
         $this->linkMock->method('getModuleLink')->willReturn('');
         $this->contextMock->link = $this->linkMock;
+
+        $this->contextMock->language = $this->createMock(\Language::class);
 
         $this->settingsHelperMock = $this->createMock(SettingsHelper::class);
 
@@ -169,8 +171,6 @@ class PaymentDataTest extends TestCase
     public function testBuildDataPaymentWithDeferredTrigger()
     {
         $this->settingsHelperMock->method('isDeferredTriggerLimitDays')->willReturn(true);
-        $this->contextMock->language = $this->createMock(\Language::class);
-        $this->contextMock->language->id = '38';
 
         $this->dataPaymentExpected['payment']['deferred'] = 'trigger';
         $this->dataPaymentExpected['payment']['deferred_description'] = 'At shipping';


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1784/[🧩-ps]-gather-cart-data-from-pnx-and-deferred-payments)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Juste delete the "if" condition which used to verify if the payment methods is > 5 to add cart data in the payment object.
And add some unit tests.

### How to test

_As a reviewer, you are encouraged to test the PR locally._
You can run unit tests.


<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [x] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features


### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)