### PR TITLE
[DEVX][RENOVATE] Freeze composer version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,12 @@
       "groupName": "composer updates"
     },
     {
+      "matchManagers": ["docker"],
+      "matchPackageNames": ["composer"],
+      "matchFileNames": ["scripts/build/Dockerfile"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["dockerfile", "docker-compose"],
       "groupName": "docker updates"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
     },
     {
       "matchManagers": ["docker"],
-      "matchPackageNames": ["composer"],
+      "matchDepNames": ["composer"],
       "matchFileNames": ["scripts/build/Dockerfile"],
       "enabled": false
     },


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

@Benjamin-Freoua-Alma was not able to build the module anymore following this Renovate update: https://github.com/alma/alma-installments-prestashop/pull/425
@Benjamin-Freoua-Alma fixed the issue by reverting the composer version to 2.2 here: https://github.com/alma/alma-installments-prestashop/pull/479
We need to configure Renovate to stop updating this version

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We disable updates of composer for the file `scripts/build/Dockerfile`
@gdraynz I tried something but I'm not sure if it's OK, wdyt ?

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->