### PR TITLE
[RENOVATE] Disable automatic PHP version update in Dockerfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,11 @@
       "groupName": "composer updates"
     },
     {
+      "matchDepNames": ["php"],
+      "matchFileNames": ["scripts/build/Dockerfile"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["dockerfile", "docker-compose"],
       "groupName": "docker updates"
     }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

We want to avoid Renovate from pushing these updates : https://github.com/alma/alma-installments-prestashop/pull/429
