### PR TITLE
[DEVX][RENOVATE] Disable auto update of Prestashop version in Dockerfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,13 +18,14 @@
       "groupName": "composer updates"
     },
     {
-      "matchDepNames": ["php"],
-      "matchFileNames": ["scripts/build/Dockerfile"],
-      "enabled": false
-    },
-    {
       "matchManagers": ["dockerfile", "docker-compose"],
       "groupName": "docker updates"
+    },
+    {
+      "description": "PHP, composer and Prestashop versions in Dockerfiles must be freezed",
+      "matchManagers": ["docker"],
+      "matchDepNames": ["prestashop/prestashop", "php", "composer"],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
     },
     {
       "description": "PHP, composer and Prestashop versions in Dockerfiles must be freezed",
-      "matchManagers": ["docker"],
+      "matchManagers": ["dockerfile"],
       "matchDepNames": ["prestashop/prestashop", "php", "composer"],
       "enabled": false
     }


### PR DESCRIPTION
### Reason for change

We want to avoid Renovate from opening pull requests suggesting to update the prestashop version in Dockerfile
See this for example : https://github.com/alma/alma-installments-prestashop/pull/485

> [!WARNING]  
> Note that https://github.com/alma/alma-installments-prestashop/pull/480 was opened to prevent the composer update but I should have merged it on `main` rather than `develop` to take effect, so I apply the same change here, but it will probably cause conflicts when develop will be merged on main and/or the other way around, I apologize
