### PR TITLE
[DEVX] Update Slack release message

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,11 +28,6 @@
       "groupName": "docker updates"
     },
     {
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["LoveToKnow/slackify-markdown-action"],
-      "enabled": false
-    },
-    {
       "description": "PHP, composer and Prestashop versions in Dockerfiles must be freezed",
       "matchManagers": ["dockerfile"],
       "matchDepNames": ["prestashop/prestashop", "php", "composer"],

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -102,8 +102,7 @@ jobs:
             });
 
       - name: Format release notes for Slack
-        # v1.0.2 cannot be used as it is not correctly handling the newlines
-        uses: LoveToKnow/slackify-markdown-action@v1.0.0
+        uses: LoveToKnow/slackify-markdown-action@v1.1.1
         id: slack-markdown-release-notes
         with:
           text: |
@@ -112,13 +111,12 @@ jobs:
             ${{ steps.fetch-release-draft.outputs.body }}
 
             :warning: This release will be available on PrestaShop marketplace in a few hours
+            cc <@france.berut> <@khadija.cherif>
 
       - name: Send changelog to Slack
         uses: slackapi/slack-github-action@v1.26.0
         with:
-          # TODO: Replace with channel #alma_changelog (id: CR9C57YM6) once full testing is done
-          # Channel `#devx-experiments`
-          channel-id: C04MQ9VEWRF
+          channel-id: CR9C57YM6
           slack-message: ${{ steps.slack-markdown-release-notes.outputs.text }}
           payload: |
             {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

* Ping EM and PM in the Slack release message
* v1.1.1 of `LoveToKnow/slackify-markdown-action` fixes the issue we had with v1.0.2 so it can be safely used
* Publish the release message to #alma_changelog