### PR TITLE
fix: Issue quantity insurance if we change quantity in cart

### DIFF
--- a/alma/views/js/alma-cart-insurance.js
+++ b/alma/views/js/alma-cart-insurance.js
@@ -28,6 +28,9 @@
         if (window.prestashop != null && window.prestashop.on != null) {
             prestashop.on("updatedCart", onloadInsuranceItemCartAlma);
         }
+        window.addEventListener('message', (e) => {
+            handleAddInsuranceProductFromWidget(e);
+        });
     });
 })(jQuery);
 
@@ -181,10 +184,6 @@ function onloadInsuranceClickEvents() {
                 //location.reload();
             });
 
-    });
-
-    window.addEventListener('message', (e) => {
-        handleAddInsuranceProductFromWidget(e);
     });
 }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1866/[🧩-ps]-issue-if-we-change-the-quantity-in-the-cart-we-dont-update-it)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We moved the addEventListener in the root function and not in the prestashop event updatedCart

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Chaneg the quantity in the cart item and add insurance.
See if we have the right quantity of insurance added

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->