### PR TITLE
fix: Issue insurance for product not eligible created after import

### DIFF
--- a/alma/views/js/alma-cart-insurance.js
+++ b/alma/views/js/alma-cart-insurance.js
@@ -218,7 +218,7 @@ function handleAddInsuranceProductFromWidget(e) {
         }
     }
     if (e.data.type === 'almaEligibilityAnswer') {
-        if (e.data.eligibilityCallResult.length > 0) {
+        if (e.data.eligibilityCallResponseStatus.response.eligibleProduct && e.data.eligibilityCallResult.length > 0) {
             $('#' + e.data.iFrameIdForProductWidget).show();
         }
     }

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -26,6 +26,7 @@ let selectedAlmaInsurance = null;
 let addToCartFlow = false;
 let productDetails = null;
 let quantity = 1;
+let almaEligibilityAnswer = false;
 
 (function ($) {
     $(function () {
@@ -97,8 +98,9 @@ function onloadAddInsuranceInputOnProductAlma() {
 
     window.addEventListener('message', (e) => {
         if (e.data.type === 'almaEligibilityAnswer') {
+            almaEligibilityAnswer = e.data.eligibilityCallResponseStatus.response.eligibleProduct;
             btnLoaders('stop');
-            if (e.data.eligibilityCallResponseStatus.response.eligibleProduct === true) {
+            if (almaEligibilityAnswer) {
                 let heightIframe = e.data.widgetSize.height;
                 let stringHeightIframe = heightIframe + 'px';
                 if (heightIframe <= 45) {
@@ -108,7 +110,7 @@ function onloadAddInsuranceInputOnProductAlma() {
                 document.getElementById('alma-widget-insurance-product-page').style.height = stringHeightIframe;
             } else {
                 let addToCart = document.querySelector('.add-to-cart');
-                addToCart.removeEventListener("click",insuranceListener)
+                addToCart.removeEventListener("click", insuranceListener)
             }
         }
         if (e.data.type === 'getSelectedInsuranceData') {
@@ -204,8 +206,9 @@ function removeInputInsurance() {
 }
 
 function addModalListenerToAddToCart() {
-    if (settings.isAddToCartPopupActivated === true) {
+    if (settings.isAddToCartPopupActivated === true && almaEligibilityAnswer) {
         let addToCart = document.querySelector('.add-to-cart');
+        // If we change the quantity the DOM is reloaded then we need to remove and add the listener again
         addToCart.removeEventListener("click",insuranceListener)
         addToCart.addEventListener("click", insuranceListener);
     }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1861/[🧩-ps]-fix-error-js-on-the-length-in-cart-if-product-is-not-eligible)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Check Eligibility Insurance before execute event of add to cart

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Create a new product not eligible 
And add to cart this product, see if the product is right added in cart

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->