### PR TITLE
[compatibility] feat: Add column in orders list with Has insurance

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -422,7 +422,19 @@ class Alma extends PaymentModule
     }
 
     /**
-     * Hook to modify the order table
+     * Hook to modify the order table before Ps 1.7.5
+     *
+     * @param $params
+     *
+     * @return mixed|null
+     */
+    public function hookActionAdminOrdersListingFieldsModifier($params)
+    {
+        return $this->runHookController('actionAdminOrdersListingFieldsModifier', $params);
+    }
+
+    /**
+     * Hook to modify the order table after Ps 1.7.5
      *
      * @param $params
      *
@@ -434,7 +446,7 @@ class Alma extends PaymentModule
     }
 
     /**
-     * Hook to modify the order table
+     * Hook to modify the order table after Ps 1.7.5
      *
      * @param $params
      *

--- a/alma/controllers/hook/ActionAdminOrdersListingFieldsModifierHookController.php
+++ b/alma/controllers/hook/ActionAdminOrdersListingFieldsModifierHookController.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Controllers\Hook;
+
+use Alma\PrestaShop\Builders\Helpers\InsuranceHelperBuilder;
+use Alma\PrestaShop\Helpers\InsuranceHelper;
+use Alma\PrestaShop\Helpers\SettingsHelper;
+use Alma\PrestaShop\Hooks\AdminHookController;
+
+class ActionAdminOrdersListingFieldsModifierHookController extends AdminHookController
+{
+    /**
+     * @var InsuranceHelper
+     */
+    protected $insuranceHelper;
+
+    public function canRun()
+    {
+        // Front controllers can run if the module is properly configured ...
+        return SettingsHelper::isFullyConfigured()
+            // ... and the plugin is in LIVE mode, or the visitor is an admin
+            && $this->insuranceHelper->isInsuranceActivated();
+    }
+
+    /**
+     * @param $module
+     */
+    public function __construct($module)
+    {
+        parent::__construct($module);
+
+        $insuranceHelperBuilder = new InsuranceHelperBuilder();
+        $this->insuranceHelper = $insuranceHelperBuilder->getInstance();
+    }
+
+    /**
+     * Run Controller
+     *
+     * @param array $params
+     *
+     * @return void
+     */
+    public function run($params)
+    {
+        if (array_key_exists('select', $params)) {
+            $params['select'] .= ' ,IF(aip.`id_order` IS NOT NULL,1,0) as has_alma_insurance ';
+        }
+        if (array_key_exists('join', $params)) {
+            $params['join'] .= 'LEFT JOIN ' . _DB_PREFIX_ . 'alma_insurance_product aip ON (a.id_order = aip.id_order)';
+        }
+        if (array_key_exists('group_by', $params)) {
+            $params['group_by'] .= 'GROUP BY a.id_order';
+        }
+        $params['fields']['has_alma_insurance'] = [
+            'title' => 'Has Insurance',
+            'type' => 'bool',
+            'tmpTableFilter' => true,
+        ];
+    }
+}

--- a/alma/lib/Helpers/HookHelper.php
+++ b/alma/lib/Helpers/HookHelper.php
@@ -103,12 +103,16 @@ class HookHelper
         'actionValidateOrder' => 'all',
         'displayCartExtraProductActions' => 'all',
         'termsAndConditions' => 'all',
+        'actionAdminOrdersListingFieldsModifier' => [
+            'version' => '1.7.5',
+            'operand' => '<',
+        ],
         'actionOrderGridQueryBuilderModifier' => [
-            'version' => '1.7.7',
+            'version' => '1.7.5',
             'operand' => '>=',
         ],
         'actionOrderGridDefinitionModifier' => [
-            'version' => '1.7.7',
+            'version' => '1.7.5',
             'operand' => '>=',
         ],
         'displayAdminOrderTop' => [


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1886/[🧩-ps]-add-column-in-orders-list-with-has-insurance)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We added a new hook to add insurance in the listing order for compatibility from PS 1.7

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Make an order with insurance and see the listing orders of the backoffice and see the column has insurance with the value

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->