### PR TITLE
[DEVX] Fix release PR not triggering workflows 

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -44,9 +44,20 @@ jobs:
         run: |
           ./scripts/update-files-with-release-version.sh ${{ steps.release-drafter.outputs.tag_name }}
 
+      # If using default Github token, the created pull request won't trigger workflows with pull_request event
+      # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+      - name: Generate Github token to create PR
+        uses: actions/create-github-app-token@v1
+        id: github-token
+        with:
+          app-id: ${{ secrets.ALMA_CREATE_TEAM_PRS_APP_ID }}
+          private-key: ${{ secrets.ALMA_CREATE_TEAM_PRS_APP_PEM }}
+          repositories: alma-installments-prestashop
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ steps.github-token.outputs.token }}
           commit-message: 'chore: update version'
           title: Release ${{ steps.release-drafter.outputs.tag_name }}
           body: |


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

When release PRs are created by Github Action, the ci workflow is not triggered.
Until then it was triggered only because someone was adding a new commit to the Pull Request, but if no one commits to the release branch, CI is not triggered.
See the documentation explaining this here : https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
I copied what we did in other repositories : We now use a Github App token 

Tested here: https://github.com/alma/alma-installments-prestashop/pull/524