### PR TITLE
fix: display order details of insurance subscription

### DIFF
--- a/alma/views/js/admin/alma-insurance-subscriptions.js
+++ b/alma/views/js/admin/alma-insurance-subscriptions.js
@@ -25,9 +25,16 @@
     $(function () {
         const subscriptionData = dataSubscriptions
 
-        window.addEventListener('almaIframeScriptLoaded', () => {
-            getSubscriptionDatafromCms(subscriptionData);
-        });
+        function waitForScript()
+        {
+            if (typeof getSubscriptionDatafromCms !== 'undefined') {
+                setTimeout(getSubscriptionDatafromCms(subscriptionData), 650)
+            } else {
+                console.log('re set timeout')
+                setTimeout(waitForScript, 450)
+            }
+        }
+        waitForScript();
 
         window.addEventListener('message', (e) => {
             if (e.data.type === 'sendCancelSubscriptionToCms') {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1944/[🧩-ps]-fix-display-order-of-insurance-subscription)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We added a setTimeout to refresh the load script for iframe

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Display an order detail subscription and refresh many time the page and see if the iframe is always displayed

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->