### PR TITLE
fix: install module without ConfigCache about PS Account

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -150,6 +150,7 @@ class Alma extends PaymentModule
     {
         if (
             $this->toolsHelper->psVersionCompare('1.6', '<')
+            || !class_exists(\Symfony\Component\Config\ConfigCache::class)
             || !class_exists(\PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer::class)
             || _PS_MODE_DEV_ === true
         ) {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1948/[-ps]-fix-install-alma-module-on-old-ps-version-if-symfony-isnt)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Add verification of Symfony ConfigCache for install module without Ps account

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Identify from merchant

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->