### PR TITLE
[DEVX] Check latest release if no release draft to be published

### DIFF
--- a/.github/workflows/hotfix-pull-request.yml
+++ b/.github/workflows/hotfix-pull-request.yml
@@ -59,6 +59,7 @@ jobs:
             ### Checklist of actions to be done before merging
             - [ ] Review and update the CHANGELOG.md if needed
             - [ ] Review and update the Github release draft if needed
+              ⚠️ Click on `Save draft` to update it, do not click on `Publish release`: it will be published automatically after the merge of this PR
             - [ ] Review the files updated with the new version number in the commit named "chore: update version"
           branch: hotfix/${{ steps.release-drafter.outputs.tag_name }}
           base: main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -41,20 +41,47 @@ jobs:
             jq 'map(select(.draft == true))' \
           )
 
-          # Fail if 0 or more than 1 draft release is found
-          if [[ $(echo $DRAFT_RELEASE | jq 'length') -ne 1 ]]
+          # We should find exactly 1 draft release to be published
+          if [[ $(echo $DRAFT_RELEASE | jq 'length') -eq 1 ]]
           then
-            echo "No draft release found or more than one draft release found"
-            exit 1
+              echo "Draft release found"
+              DRAFT_RELEASE=$(echo $DRAFT_RELEASE | jq first)
+          else
+              # Fail if more than 1 draft release is found
+              if [[ $(echo $DRAFT_RELEASE | jq 'length') -gt 1 ]]
+              then
+                  echo "Unable to publish the release: More than one draft is found"
+                  exit 1
+              fi
+              # If no draft release is found, maybe the draft has been manually published by error
+              # prior to the workflow execution
+              echo "No draft release found, checking for the latest release..."
+              LATEST_RELEASE=$(curl \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ github.token }}" \
+                https://api.github.com/repos/${{ github.repository }}/releases/latest
+              )
+              # Compare the latest release version with the version in the branch name of the PR
+              # (which should be release/<version> or hotfix/<version>)
+              # If they match, we consider the latest release as the draft release
+              VERSION_FROM_LATEST_RELEASE=$(echo $LATEST_RELEASE | jq -r '.name')
+              echo "Latest release version: $VERSION_FROM_LATEST_RELEASE"
+              VERSION_FROM_PR_BRANCH_NAME=$(echo ${{ github.event.pull_request.head.ref }} | sed -E 's/(release|hotfix)\///')
+              echo "Version found from PR branch name: $VERSION_FROM_PR_BRANCH_NAME"
+              if [[ "$VERSION_FROM_LATEST_RELEASE" == "$VERSION_FROM_PR_BRANCH_NAME" ]]
+              then
+                  echo "Version from the latest release matches with the version found in the release/hotfix PR branch name"
+                  DRAFT_RELEASE=$LATEST_RELEASE
+              else
+                  echo "Unable to publish the release: Latest release does not match with the version found in the PR branch name"
+                  exit 1
+              fi
           fi
 
-          DRAFT_RELEASE=$(echo $DRAFT_RELEASE | jq first)
-
           # Retrieve name, id and body of the draft release
-          # We need to remove the quotes from the JSON output
-          NAME=$(echo $DRAFT_RELEASE | jq '.name' | sed 's/"//g')
+          NAME=$(echo $DRAFT_RELEASE | jq -r '.name')
           ID=$(echo $DRAFT_RELEASE | jq '.id')
-          BODY=$(echo $DRAFT_RELEASE | jq '.body' | sed 's/"//g')
+          BODY=$(echo $DRAFT_RELEASE | jq -r '.body')
 
           # Add URLs to GitHub pull requests
           PULL_REQUEST_URL_START=${{ github.server_url }}/${{ github.repository }}/pull/

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -66,6 +66,7 @@ jobs:
             ### Checklist of actions to be done before merging
             - [ ] Review and update the CHANGELOG.md if needed
             - [ ] Review and update the Github release draft if needed
+              ⚠️ Click on `Save draft` to update it, do not click on `Publish release`: it will be published automatically after the merge of this PR
             - [ ] Review and update the translation files after crowdin update if needed
             - [ ] Review the files updated with the new version number in the commit named "chore: update version"
           branch: release/${{ steps.release-drafter.outputs.tag_name }}


### PR DESCRIPTION
### Reason for change

ECOM integrations team is likely to update the release draft body before publishing it as it is targeted to a public audience.
When updating it, it is easy to click on the big flashy button "Publish release" instead of the grey button "Save draft"
This cannot be undone from the UI, and this shouldn't make the release-publish workflow fail

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
* Update release-publish workflow : If no release draft is found, fetch the latest release and go on with it if the version matches
* Update release/hotfix PR checklist: Add a warning to avoid misclick (even if handled, it is best not to publish the release before it is ready)

