### PR TITLE
[ALF-135] Add a semgrep rule to ensure compatibility with Prestashop v1.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,3 +48,9 @@ jobs:
       run: task test
       env:
         XDEBUG_MODE: coverage
+
+    - name: Install semgrep
+      run: pip install semgrep
+
+    - name: Run semgrep
+      run: semgrep scan --config semgrep/rules

--- a/semgrep/rules/prestashop-compatibility-no-use-keyword.yaml
+++ b/semgrep/rules/prestashop-compatibility-no-use-keyword.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: no-use-keyword-in-alma-php-file
+    pattern: use $X;
+    message: Use keyword cannot be used in alma.php to ensure compatibility with Prestashop v1.6
+    languages:
+      - php
+    severity: ERROR
+    metadata:
+      category: compatibility
+    paths:
+      include:
+        - "alma/alma.php"


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->
https://linear.app/almapay/issue/ALF-135/add-verification-during-release-prestashop-cms

### Code changes

* Add a semgrep rule
   * There will only be an error if there is a `use something;` statement in file alma.php
   *  No error is triggered if the use statement is commented, or if there is the string "use" somewhere in the file
   * Other files than `alma.php` are not checked as this is the only one concerned by this constraint
* Run semgrep in CI (for people who did not set pre-commit)

### Screenshot
![image](https://github.com/user-attachments/assets/219d9742-b61c-4a31-9ec1-755b141d9a34)
