### PR TITLE
fix: display multiple notification dashboard on ps17

### DIFF
--- a/alma/views/templates/hook/notificationConfiguration.tpl
+++ b/alma/views/templates/hook/notificationConfiguration.tpl
@@ -76,7 +76,9 @@
                 psAccountIsCompleted = window.psaccountsVue.isOnboardingCompleted();
                 if (psAccountIsCompleted != true) {
                     document.getElementById("alma_config_form").remove()
-                    document.getElementById("alma_first_installation").remove()
+                    $('.alma.first-installation').each(function() {
+                        $(this).remove();
+                    });
                 } else {
                     //Hide ps account notification
                     document.querySelector(".alma.ps-account.alert").remove()


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1961/[-ps]-fix-display-multiple-notifications-dashboard-ps17)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We loop on all notification notification to hide is ps account isn't installed fir ps 1.7.0.6

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Install our module on PS 1.7.0.6 and see there are no notification block duplicated

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->