### PR TITLE
fix: eligible limit of feePlans

### DIFF
--- a/alma/lib/Helpers/FeePlanHelper.php
+++ b/alma/lib/Helpers/FeePlanHelper.php
@@ -99,8 +99,8 @@ class FeePlanHelper
             $getDataFromKey = $this->settingsHelper->getDataFromKey($key);
 
             if (
-                $purchaseAmount > $feePlan->min
-                && $purchaseAmount < $feePlan->max
+                $purchaseAmount >= $feePlan->min
+                && $purchaseAmount <= $feePlan->max
             ) {
                 $activePlans[] = $getDataFromKey;
             }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1743/absolution-minimum-payment)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
The equal limit of feePlans are now eligible

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Buy a product of equal limit of eligibility feePlan

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [x] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features
- [x] The changes include adequate logging and Datadog traces
- [x] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->