### PR TITLE
fix: create payment with object category in product

### DIFF
--- a/alma/controllers/front/payment.php
+++ b/alma/controllers/front/payment.php
@@ -22,7 +22,6 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
 
-use Alma\API\ParamsError;
 use Alma\PrestaShop\Builders\Helpers\SettingsHelperBuilder;
 use Alma\PrestaShop\Builders\Models\PaymentDataBuilder;
 use Alma\PrestaShop\Helpers\ClientHelper;
@@ -106,9 +105,7 @@ class AlmaPaymentModuleFrontController extends ModuleFrontController
     /**
      * @return void
      *
-     * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
-     * @throws ParamsError
      */
     public function postProcess()
     {

--- a/alma/lib/Helpers/ProductHelper.php
+++ b/alma/lib/Helpers/ProductHelper.php
@@ -250,4 +250,30 @@ class ProductHelper
 
         return htmlspecialchars($productName, ENT_NOQUOTES);
     }
+
+    /**
+     * @param $product
+     *
+     * @return array
+     */
+    public function getCategoryName($product)
+    {
+        $category = [];
+
+        if ($product instanceof \Product) {
+            $category = [$product->category];
+        }
+
+        if (is_array($product) && isset($product['category'])) {
+            if ($product['category'] instanceof \Category) {
+                $category = array_values($product['category']->name);
+            }
+
+            if (is_string($product['category'])) {
+                $category = [$product['category']];
+            }
+        }
+
+        return $category;
+    }
 }

--- a/alma/lib/Helpers/ProductHelper.php
+++ b/alma/lib/Helpers/ProductHelper.php
@@ -256,7 +256,7 @@ class ProductHelper
      *
      * @return array
      */
-    public function getCategoryName($product)
+    public function getCategoriesName($product)
     {
         $category = [];
 

--- a/alma/lib/Model/CartData.php
+++ b/alma/lib/Model/CartData.php
@@ -166,7 +166,7 @@ class CartData
                 'unit_price' => $this->priceHelper->convertPriceToCents($unitPrice),
                 'line_price' => $this->priceHelper->convertPriceToCents($linePrice),
                 'is_gift' => $isGift,
-                'categories' => [$productRow['category']],
+                'categories' => $this->productHelper->getCategoryName($productRow),
                 'url' => $this->productHelper->getProductLink($product, $productRow, $cart),
                 'picture_url' => $pictureUrl,
                 'requires_shipping' => $requiresShipping,

--- a/alma/lib/Model/CartData.php
+++ b/alma/lib/Model/CartData.php
@@ -166,7 +166,7 @@ class CartData
                 'unit_price' => $this->priceHelper->convertPriceToCents($unitPrice),
                 'line_price' => $this->priceHelper->convertPriceToCents($linePrice),
                 'is_gift' => $isGift,
-                'categories' => $this->productHelper->getCategoryName($productRow),
+                'categories' => $this->productHelper->getCategoriesName($productRow),
                 'url' => $this->productHelper->getProductLink($product, $productRow, $cart),
                 'picture_url' => $pictureUrl,
                 'requires_shipping' => $requiresShipping,

--- a/alma/tests/Unit/Helper/ProductHelperTest.php
+++ b/alma/tests/Unit/Helper/ProductHelperTest.php
@@ -70,7 +70,7 @@ class ProductHelperTest extends TestCase
         ];
         $expected = ['category-name'];
 
-        $this->assertEquals($expected, $this->productHelper->getCategoryName($productArray));
+        $this->assertEquals($expected, $this->productHelper->getCategoriesName($productArray));
     }
 
     /**
@@ -93,7 +93,7 @@ class ProductHelperTest extends TestCase
             'Category Name 2',
         ];
 
-        $this->assertEquals($expected, $this->productHelper->getCategoryName($product));
+        $this->assertEquals($expected, $this->productHelper->getCategoriesName($product));
     }
 
     /**
@@ -104,7 +104,7 @@ class ProductHelperTest extends TestCase
         $this->productMock->id = 25;
         $this->productMock->category = 'category-name-object';
 
-        $this->assertEquals(['category-name-object'], $this->productHelper->getCategoryName($this->productMock));
+        $this->assertEquals(['category-name-object'], $this->productHelper->getCategoriesName($this->productMock));
     }
 
     /**
@@ -114,7 +114,7 @@ class ProductHelperTest extends TestCase
      */
     public function testGetCategoryNameWithWrongData($product)
     {
-        $this->assertEquals([], $this->productHelper->getCategoryName($product));
+        $this->assertEquals([], $this->productHelper->getCategoriesName($product));
     }
 
     /**

--- a/alma/tests/Unit/Helper/ProductHelperTest.php
+++ b/alma/tests/Unit/Helper/ProductHelperTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Helper;
+
+use Alma\PrestaShop\Helpers\ProductHelper;
+use PHPUnit\Framework\TestCase;
+
+class ProductHelperTest extends TestCase
+{
+    /**
+     * @var ProductHelper
+     */
+    protected $productHelper;
+    /**
+     * @var \Category
+     */
+    protected $categoryMock;
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Product|(\Product&\PHPUnit_Framework_MockObject_MockObject)
+     */
+    protected $productMock;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->productHelper = new ProductHelper();
+        $this->categoryMock = $this->createMock(\Category::class);
+        $this->productMock = $this->createMock(\Product::class);
+    }
+
+    public function tearDown()
+    {
+        $this->productHelper = null;
+        $this->categoryMock = null;
+        $this->productMock = null;
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetCategoryNameWithArray()
+    {
+        $productArray = [
+            'id_product' => 1,
+            'category' => 'category-name',
+        ];
+        $expected = ['category-name'];
+
+        $this->assertEquals($expected, $this->productHelper->getCategoryName($productArray));
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetCategoryNameWithCategoryObject()
+    {
+        $this->categoryMock->id = 23;
+        $this->categoryMock->id_category = '23';
+        $this->categoryMock->name = [
+            'Category Name',
+            'Category Name 2',
+        ];
+        $product = [
+            'category' => $this->categoryMock,
+        ];
+
+        $expected = [
+            'Category Name',
+            'Category Name 2',
+        ];
+
+        $this->assertEquals($expected, $this->productHelper->getCategoryName($product));
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetCategoryNameWithObjectProduct()
+    {
+        $this->productMock->id = 25;
+        $this->productMock->category = 'category-name-object';
+
+        $this->assertEquals(['category-name-object'], $this->productHelper->getCategoryName($this->productMock));
+    }
+
+    /**
+     * @dataProvider wrongDataProvider
+     *
+     * @return void
+     */
+    public function testGetCategoryNameWithWrongData($product)
+    {
+        $this->assertEquals([], $this->productHelper->getCategoryName($product));
+    }
+
+    /**
+     * @return array
+     */
+    public function wrongDataProvider()
+    {
+        $object = new \stdClass();
+        $object->id = 24;
+        $object->name = 'category-name';
+        $product = [
+            'category' => $object,
+        ];
+
+        return [
+            'object not Category' => [
+                $product,
+            ],
+            'product is string' => [
+                'product',
+            ],
+            'product is int' => [1],
+            'product is null' => [null],
+            'product is false' => [false],
+            'product is true' => [true],
+        ];
+    }
+}

--- a/alma/tests/Unit/Model/CartDataTest.php
+++ b/alma/tests/Unit/Model/CartDataTest.php
@@ -60,6 +60,7 @@ class CartDataTest extends TestCase
         $productHelper = $this->createMock(ProductHelper::class);
         $productHelper->method('getImageLink')->willReturn('https://prestashop-a-1-7-8-7.local.test/1-large_default/product_test.jpg');
         $productHelper->method('getProductLink')->willReturn('https://prestashop-a-1-7-8-7.local.test/1-1-product_test.html#/1-size-s/8-color-white');
+        $productHelper->method('getCategoryName')->willReturn(['category_test']);
         $productHelper->method('createProduct')->with()->willReturn(new \Product(null, false, 1));
 
         $summaryDetailsMock = ['products' => $items, 'gift_products' => []];
@@ -226,6 +227,9 @@ class CartDataTest extends TestCase
         ];
     }
 
+    /**
+     * @return void
+     */
     public function testGetCartExclusion()
     {
         $cart = \Mockery::mock(\Cart::class);
@@ -251,17 +255,5 @@ class CartDataTest extends TestCase
         $result = $cartData->getCartExclusion($cart);
 
         $this->assertEquals(['2' => 'cateexclue'], $result);
-    }
-
-    public function testIncludeTaxes()
-    {
-    }
-
-    public function testCartInfo()
-    {
-    }
-
-    public function testGetCartDiscounts()
-    {
     }
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1882/hexamed-materiel-medical-error-when-making-a-payment)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We add helper to get category name of array or objet for create payment

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Issue identify by a merchant, tested in the merchant store

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->