### PR TITLE
fix: compatibility 1.7.0

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -27,6 +27,7 @@ let addToCartFlow = false;
 let productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
 let quantity = getQuantity();
 let almaEligibilityAnswer = false;
+let modalIsClosed = false;
 
 (function ($) {
     $(function () {
@@ -39,8 +40,8 @@ let almaEligibilityAnswer = false;
             prestashop.on(
                 'updateProduct',
                 function (event) {
+                    console.log('updateProduct', event);
                     let addToCart = document.querySelector('.add-to-cart');
-                    let modalIsClosed = false;
 
                     if (event.event !== undefined) {
                         modalIsClosed = event.event.namespace === 'bs.modal' && event.event.type === 'hidden';
@@ -72,7 +73,8 @@ let almaEligibilityAnswer = false;
             );
             prestashop.on(
                 'updatedProduct',
-                function () {
+                function (event) {
+                    console.log('updatedProduct', event);
                     document.querySelector('.qty [name="qty"]').value = quantity;
                     productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
                     refreshWidget();
@@ -128,7 +130,16 @@ function onloadAddInsuranceInputOnProductAlma() {
                 }
 
                 document.getElementById('alma-widget-insurance-product-page').style.height = stringHeightIframe;
-                prestashop.emit('updateProduct', {event});
+                $('#blockcart-modal').on('hidden.bs.modal', function (e) {
+                    console.log('close modal hidden');
+                    modalIsClosed = true;
+                });
+                prestashop.emit('updateProduct', {
+                    reason:{
+                        productUrl: window.location.href,
+                        modal: modalIsClosed
+                    }
+                });
             } else {
                 let addToCart = document.querySelector('.add-to-cart');
                 if (addToCart) {

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -72,7 +72,7 @@ let almaEligibilityAnswer = false;
             );
             prestashop.on(
                 'updatedProduct',
-                function (event) {
+                function () {
                     document.querySelector('.qty [name="qty"]').value = quantity;
                     productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
                     refreshWidget();

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -27,12 +27,13 @@ let addToCartFlow = false;
 let productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
 let quantity = getQuantity();
 let almaEligibilityAnswer = false;
-let modalIsClosed = false;
 
 (function ($) {
     $(function () {
         //Insurance
-
+        $("body").on("hidden.bs.modal", "#blockcart-modal", function (e) {
+            removeInsurance();
+        });
         handleInsuranceProductPage();
         btnLoaders('start');
         onloadAddInsuranceInputOnProductAlma();
@@ -40,11 +41,9 @@ let modalIsClosed = false;
             prestashop.on(
                 'updateProduct',
                 function (event) {
-                    console.log('updateProduct', event);
                     let addToCart = document.querySelector('.add-to-cart');
 
                     if (event.event !== undefined) {
-                        modalIsClosed = event.event.namespace === 'bs.modal' && event.event.type === 'hidden';
                         quantity = getQuantity();
                     }
                     if (event.eventType === 'updatedProductQuantity') {
@@ -54,7 +53,7 @@ let modalIsClosed = false;
                         }
                         removeInsurance();
                     }
-                    if (modalIsClosed || event.eventType === 'updatedProductCombination') {
+                    if (event.eventType === 'updatedProductCombination') {
                         removeInsurance();
                     }
                     if (typeof event.selectedAlmaInsurance !== 'undefined' && event.selectedAlmaInsurance !== null) {
@@ -74,7 +73,6 @@ let modalIsClosed = false;
             prestashop.on(
                 'updatedProduct',
                 function (event) {
-                    console.log('updatedProduct', event);
                     document.querySelector('.qty [name="qty"]').value = quantity;
                     productDetails = JSON.parse(document.getElementById('product-details').dataset.product);
                     refreshWidget();
@@ -130,14 +128,9 @@ function onloadAddInsuranceInputOnProductAlma() {
                 }
 
                 document.getElementById('alma-widget-insurance-product-page').style.height = stringHeightIframe;
-                $('#blockcart-modal').on('hidden.bs.modal', function (e) {
-                    console.log('close modal hidden');
-                    modalIsClosed = true;
-                });
                 prestashop.emit('updateProduct', {
                     reason:{
                         productUrl: window.location.href,
-                        modal: modalIsClosed
                     }
                 });
             } else {

--- a/alma/views/templates/hook/notificationConfiguration.tpl
+++ b/alma/views/templates/hook/notificationConfiguration.tpl
@@ -82,6 +82,11 @@
                 } else {
                     //Hide ps account notification
                     document.querySelector(".alma.ps-account.alert").remove()
+                    $('.alma.first-installation').each(function(i) {
+                        if (i > 0) {
+                            $(this).remove();
+                        }
+                    });
                 }
             }
         </script>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1974/fix-insurance-compatibility-170)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We change the event listener to identify the event when the modal add to cart is close for compatibility with PS 1.7
We add a loop to identify if there are a multiple notification block of first install and remove other in JS

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
In PS 1.7.0.6 :
- install our module and see after link with PS account if there are more that one notification block about first installation
- Add product with insurance and after add to cart close the modal about add to cart and see if the insurance widget is reset and there is no error in the console of the browser

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [x] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features
- [x] The changes include adequate logging and Datadog traces
- [x] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->