### PR TITLE
feat: HMAC verification on IPN callback for security

### DIFF
--- a/alma/composer.json
+++ b/alma/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1",
-        "alma/alma-php-client": "^2.1.0",
+        "alma/alma-php-client": "^2.2.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "prestashop/prestashop-accounts-installer": "^v1.0.4",

--- a/alma/controllers/front/ipn.php
+++ b/alma/controllers/front/ipn.php
@@ -68,6 +68,7 @@ class AlmaIpnModuleFrontController extends ModuleFrontController
 
         $paymentId = Tools::getValue('pid');
         // Test to log Header IPN callback
+        Logger::instance()->info('ipn paymentId - ' . $paymentId);
         Logger::instance()->info(json_encode(get_headers($this->context->link->getModuleLink('alma', 'ipn') . '?pid=' . $paymentId, true)));
 
         $validator = new PaymentValidation($this->context, $this->module);

--- a/alma/controllers/front/ipn.php
+++ b/alma/controllers/front/ipn.php
@@ -67,6 +67,9 @@ class AlmaIpnModuleFrontController extends ModuleFrontController
         header('Content-Type: application/json');
 
         $paymentId = Tools::getValue('pid');
+        // Test to log Header IPN callback
+        Logger::instance()->info(json_encode(get_headers($this->context->link->getModuleLink('alma', 'ipn') . '?pid=' . $paymentId, true)));
+
         $validator = new PaymentValidation($this->context, $this->module);
 
         try {

--- a/alma/controllers/front/ipn.php
+++ b/alma/controllers/front/ipn.php
@@ -41,7 +41,15 @@ class AlmaIpnModuleFrontController extends ModuleFrontController
 {
     use AjaxTrait;
 
+    /**
+     * @var bool
+     */
     public $ssl = true;
+
+    /**
+     * @var Context
+     */
+    public $context;
 
     /**
      * @var PaymentValidation
@@ -77,15 +85,15 @@ class AlmaIpnModuleFrontController extends ModuleFrontController
         try {
             $this->paymentValidation->checkSignature($paymentId, Configuration::get('ALMA_API_KEY'), $_SERVER['HTTP_X_ALMA_SIGNATURE']);
             $this->paymentValidation->validatePayment($paymentId);
+        } catch (PaymentValidationException $e) {
+            Logger::instance()->error('[Alma] IPN Payment Validation Error - Message : ' . $e->getMessage());
+            $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 500);
         } catch (PaymentValidationError $e) {
             Logger::instance()->error('ipn payment_validation_error - Message : ' . $e->getMessage());
             $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 500);
         } catch (MismatchException $e) {
             Logger::instance()->error('ipn payment_validation_mismatch_error - Message : ' . $e->getMessage());
             $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 200);
-        } catch (PaymentValidationException $e) {
-            Logger::instance()->error('[Alma] IPN Payment Validation Error - Message : ' . $e->getMessage());
-            $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 500);
         }
 
         $this->ajaxRenderAndExit(json_encode(['success' => true]));

--- a/alma/controllers/front/ipn.php
+++ b/alma/controllers/front/ipn.php
@@ -85,6 +85,7 @@ class AlmaIpnModuleFrontController extends ModuleFrontController
         try {
             $this->paymentValidation->checkSignature($paymentId, Configuration::get('ALMA_API_KEY'), $_SERVER['HTTP_X_ALMA_SIGNATURE']);
             $this->paymentValidation->validatePayment($paymentId);
+            $this->ajaxRenderAndExit(json_encode(['success' => true]));
         } catch (PaymentValidationException $e) {
             Logger::instance()->error('[Alma] IPN Payment Validation Error - Message : ' . $e->getMessage());
             $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 500);
@@ -95,7 +96,5 @@ class AlmaIpnModuleFrontController extends ModuleFrontController
             Logger::instance()->error('ipn payment_validation_mismatch_error - Message : ' . $e->getMessage());
             $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 200);
         }
-
-        $this->ajaxRenderAndExit(json_encode(['success' => true]));
     }
 }

--- a/alma/controllers/front/ipn.php
+++ b/alma/controllers/front/ipn.php
@@ -68,8 +68,8 @@ class AlmaIpnModuleFrontController extends ModuleFrontController
 
         $paymentId = Tools::getValue('pid');
         // Test to log Header IPN callback
-        Logger::instance()->info('ipn paymentId - ' . $paymentId);
-        Logger::instance()->info(json_encode(get_headers($this->context->link->getModuleLink('alma', 'ipn') . '?pid=' . $paymentId, true)));
+
+        var_dump($_SERVER['HTTP_X_ALMA_SIGNATURE']);
 
         $validator = new PaymentValidation($this->context, $this->module);
 

--- a/alma/controllers/front/validation.php
+++ b/alma/controllers/front/validation.php
@@ -22,6 +22,8 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
 
+use Alma\PrestaShop\API\MismatchException;
+use Alma\PrestaShop\Exceptions\PaymentValidationException;
 use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Validators\PaymentValidation;
 use Alma\PrestaShop\Validators\PaymentValidationError;
@@ -72,7 +74,10 @@ class AlmaValidationModuleFrontController extends ModuleFrontController
         } catch (PaymentValidationError $e) {
             Logger::instance()->error('payment_validation_error - Message : ' . $e->getMessage());
             $redirect_to = $this->fail($e->cart, $e->getMessage());
-        } catch (Exception $e) {
+        } catch (PaymentValidationException $e) {
+            Logger::instance()->error('payment_validation_error - Message : ' . $e->getMessage());
+            $redirect_to = $this->fail($e->cartId, $e->getMessage());
+        } catch (MismatchException $e) {
             Logger::instance()->error('payment_error - Message : ' . $e->getMessage());
             $redirect_to = $this->fail(null, $e->getMessage());
         }

--- a/alma/exceptions/PaymentValidationException.php
+++ b/alma/exceptions/PaymentValidationException.php
@@ -31,13 +31,13 @@ if (!defined('_PS_VERSION_')) {
 class PaymentValidationException extends AlmaException
 {
     /**
-     * @var \Cart
+     * @var int
      */
-    public $cart;
+    public $cartId;
 
-    public function __construct($cart = null, $message = '', $code = 0, $previous = null)
+    public function __construct($message = '', $cartId = -1, $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
-        $this->cart = $cart;
+        $this->cartId = $cartId;
     }
 }

--- a/alma/exceptions/PaymentValidationException.php
+++ b/alma/exceptions/PaymentValidationException.php
@@ -30,6 +30,9 @@ if (!defined('_PS_VERSION_')) {
 
 class PaymentValidationException extends AlmaException
 {
+    /**
+     * @var \Cart
+     */
     public $cart;
 
     public function __construct($cart = null, $message = '', $code = 0, $previous = null)

--- a/alma/exceptions/PaymentValidationException.php
+++ b/alma/exceptions/PaymentValidationException.php
@@ -22,31 +22,19 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
 
-namespace Alma\PrestaShop\Tests\Unit\Controllers\Front;
+namespace Alma\PrestaShop\Exceptions;
 
-use Alma\PrestaShop\API\MismatchException;
-use Alma\PrestaShop\Exceptions\RefundException;
-use PHPUnit\Framework\TestCase;
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
-class IpnTest extends TestCase
+class PaymentValidationException extends AlmaException
 {
-    /**
-     * @var \AlmaIpnModuleFrontController
-     */
-    protected $controller;
+    public $cart;
 
-    public function setUp()
+    public function __construct($cart = null, $message = '', $code = 0, $previous = null)
     {
-        $this->controller = new \AlmaIpnModuleFrontController();
-    }
-
-    /**
-     * @throws \PrestaShopException
-     * @throws MismatchException
-     * @throws RefundException
-     */
-    public function testIpn()
-    {
-        $this->controller->postProcess();
+        parent::__construct($message, $code, $previous);
+        $this->cart = $cart;
     }
 }

--- a/alma/lib/Builders/Validators/PaymentValidationBuilder.php
+++ b/alma/lib/Builders/Validators/PaymentValidationBuilder.php
@@ -22,24 +22,31 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
 
-namespace Alma\PrestaShop\Validators;
+namespace Alma\PrestaShop\Builders\Validators;
+
+use Alma\PrestaShop\Traits\BuilderTrait;
+use Alma\PrestaShop\Validators\PaymentValidation;
 
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 
 /**
- * Class PaymentValidationError.
- *
- * @deprecated Use PaymentValidationException instead
+ * PaymentValidationBuilder.
  */
-class PaymentValidationError extends \Exception
+class PaymentValidationBuilder
 {
-    public $cart;
+    use BuilderTrait;
 
-    public function __construct($cart = null, $message = '', $code = 0, $previous = null)
+    /**
+     * @return PaymentValidation
+     */
+    public function getInstance()
     {
-        parent::__construct($message, $code, $previous);
-        $this->cart = $cart;
+        return new PaymentValidation(
+            $this->getContextFactory(),
+            $this->getModuleFactory(),
+            $this->getClientPaymentValidator()
+        );
     }
 }

--- a/alma/lib/Helpers/ShareOfCheckoutHelper.php
+++ b/alma/lib/Helpers/ShareOfCheckoutHelper.php
@@ -185,8 +185,6 @@ class ShareOfCheckoutHelper
             || empty($shareOfCheckoutEnabledDate)
             || !$this->dateHelper->isValidTimeStamp($shareOfCheckoutEnabledDate)
         ) {
-            Logger::instance()->info('Share Of Checkout is disabled or invalide date');
-
             return false;
         }
 

--- a/alma/lib/Traits/BuilderTrait.php
+++ b/alma/lib/Traits/BuilderTrait.php
@@ -1205,16 +1205,10 @@ trait BuilderTrait
     }
 
     /**
-     * @param PaymentValidator $clientPaymentValidator
-     *
      * @return PaymentValidator
      */
-    public function getClientPaymentValidator($clientPaymentValidator = null)
+    public function getClientPaymentValidator()
     {
-        if ($clientPaymentValidator) {
-            return $clientPaymentValidator;
-        }
-
         return new PaymentValidator();
     }
 }

--- a/alma/lib/Traits/BuilderTrait.php
+++ b/alma/lib/Traits/BuilderTrait.php
@@ -24,6 +24,7 @@
 
 namespace Alma\PrestaShop\Traits;
 
+use Alma\API\Lib\PaymentValidator;
 use Alma\PrestaShop\Factories\AddressFactory;
 use Alma\PrestaShop\Factories\CarrierFactory;
 use Alma\PrestaShop\Factories\CartFactory;
@@ -1201,5 +1202,19 @@ trait BuilderTrait
         }
 
         return new InsuranceApiService();
+    }
+
+    /**
+     * @param PaymentValidator $clientPaymentValidator
+     *
+     * @return PaymentValidator
+     */
+    public function getClientPaymentValidator($clientPaymentValidator = null)
+    {
+        if ($clientPaymentValidator) {
+            return $clientPaymentValidator;
+        }
+
+        return new PaymentValidator();
     }
 }

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -342,8 +342,8 @@ class PaymentValidation
      * in context to prevent amount_mismatch error
      * When calculating cart amount from an IPN call.
      *
-     * @param \Customer $cart
-     * @param $customer
+     * @param \Cart $cart
+     * @param \Customer $customer
      *
      * @return float
      */
@@ -362,11 +362,9 @@ class PaymentValidation
     }
 
     /**
-     * @param $paymentId
-     * @param $apiKey
-     * @param $signature
-     *
-     * @return true
+     * @param string $paymentId
+     * @param string $apiKey
+     * @param string $signature
      *
      * @throws PaymentValidationException
      */
@@ -375,13 +373,14 @@ class PaymentValidation
         if (!$paymentId) {
             throw new PaymentValidationException(null, '[Alma] Payment ID is missing');
         }
+        if (!$apiKey) {
+            throw new PaymentValidationException(null, '[Alma] Api key is missing');
+        }
         if (!$signature) {
             throw new PaymentValidationException(null, '[Alma] Signature is missing');
         }
         if (!$this->paymentValidator->isHmacValidated($paymentId, $apiKey, $signature)) {
             throw new PaymentValidationException(null, '[Alma] Signature is invalid');
         }
-
-        return true;
     }
 }

--- a/alma/tests/Unit/Controllers/Front/IpnTest.php
+++ b/alma/tests/Unit/Controllers/Front/IpnTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Controllers\Front;
+
+use Alma\PrestaShop\API\MismatchException;
+use Alma\PrestaShop\Exceptions\RefundException;
+use PHPUnit\Framework\TestCase;
+
+class IpnTest extends TestCase
+{
+    /**
+     * @var \AlmaIpnModuleFrontController
+     */
+    protected $controller;
+
+    public function setUp()
+    {
+        $this->controller = new \AlmaIpnModuleFrontController();
+    }
+
+    /**
+     * @throws \PrestaShopException
+     * @throws MismatchException
+     * @throws RefundException
+     */
+    public function testIpn()
+    {
+        $this->controller->postProcess();
+    }
+}

--- a/alma/tests/Unit/Validators/PaymentValidationTest.php
+++ b/alma/tests/Unit/Validators/PaymentValidationTest.php
@@ -87,7 +87,7 @@ class PaymentValidationTest extends TestCase
     /**
      * @throws PaymentValidationException
      */
-    public function testCheckSignatureWithGoodSignatureReturnTrue()
+    public function testCheckSignatureWithGoodSignature()
     {
         $this->clientPaymentValidator->expects($this->once())
             ->method('isHmacValidated')
@@ -105,6 +105,9 @@ class PaymentValidationTest extends TestCase
             'Without api key' => [self::PAYMENT_ID, '', self::GOOD_SIGNATURE],
             'Without payement id' => ['', self::API_KEY, self::GOOD_SIGNATURE],
             'Without signature' => [self::PAYMENT_ID, self::API_KEY, ''],
+            'With api key null' => [self::PAYMENT_ID, null, self::GOOD_SIGNATURE],
+            'With payement id null' => [null, self::API_KEY, self::GOOD_SIGNATURE],
+            'With signature null' => [self::PAYMENT_ID, self::API_KEY, null],
         ];
     }
 }

--- a/alma/tests/Unit/Validators/PaymentValidationTest.php
+++ b/alma/tests/Unit/Validators/PaymentValidationTest.php
@@ -61,21 +61,14 @@ class PaymentValidationTest extends TestCase
     }
 
     /**
+     * @dataProvider checkSignatureWrongParamsDataProvider
+     *
      * @throws PaymentValidationException
      */
-    public function testCheckSignatureWithoutApiKeyReturnError()
+    public function testCheckSignatureWithoutParamsReturnError($paymentId, $apiKey, $signature)
     {
         $this->expectException(PaymentValidationException::class);
-        $this->paymentValidation->checkSignature('', self::API_KEY, self::GOOD_SIGNATURE);
-    }
-
-    /**
-     * @throws PaymentValidationException
-     */
-    public function testCheckSignatureWithoutSignatureReturnError()
-    {
-        $this->expectException(PaymentValidationException::class);
-        $this->paymentValidation->checkSignature(self::PAYMENT_ID, self::API_KEY, '');
+        $this->paymentValidation->checkSignature($paymentId, $apiKey, $signature);
     }
 
     /**
@@ -100,6 +93,18 @@ class PaymentValidationTest extends TestCase
             ->method('isHmacValidated')
             ->with(self::PAYMENT_ID, self::API_KEY, self::GOOD_SIGNATURE)
             ->willReturn(true);
-        $this->assertTrue($this->paymentValidation->checkSignature(self::PAYMENT_ID, self::API_KEY, self::GOOD_SIGNATURE));
+        $this->paymentValidation->checkSignature(self::PAYMENT_ID, self::API_KEY, self::GOOD_SIGNATURE);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function checkSignatureWrongParamsDataProvider()
+    {
+        return [
+            'Without api key' => [self::PAYMENT_ID, '', self::GOOD_SIGNATURE],
+            'Without payement id' => ['', self::API_KEY, self::GOOD_SIGNATURE],
+            'Without signature' => [self::PAYMENT_ID, self::API_KEY, ''],
+        ];
     }
 }

--- a/alma/tests/Unit/Validators/PaymentValidationTest.php
+++ b/alma/tests/Unit/Validators/PaymentValidationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Validators;
+
+use Alma\API\Lib\PaymentValidator;
+use Alma\PrestaShop\Exceptions\PaymentValidationException;
+use Alma\PrestaShop\Validators\PaymentValidation;
+use PHPUnit\Framework\TestCase;
+
+class PaymentValidationTest extends TestCase
+{
+    const API_KEY = 'api_test_abc123';
+    const PAYMENT_ID = 'payment_abc123';
+    const WRONG_SIGNATURE = 'wrong_signature';
+    const GOOD_SIGNATURE = 'good_signature';
+    /**
+     * @var PaymentValidation
+     */
+    protected $paymentValidation;
+    /**
+     * @var PaymentValidator
+     */
+    protected $clientPaymentValidator;
+
+    public function setUp()
+    {
+        $this->clientPaymentValidator = $this->createMock(PaymentValidator::class);
+        $this->paymentValidation = new PaymentValidation(
+            $this->createMock(\Context::class),
+            $this->createMock(\Module::class),
+            $this->clientPaymentValidator
+        );
+    }
+
+    public function tearDown()
+    {
+        $this->paymentValidation = null;
+    }
+
+    /**
+     * @throws PaymentValidationException
+     */
+    public function testCheckSignatureWithoutApiKeyReturnError()
+    {
+        $this->expectException(PaymentValidationException::class);
+        $this->paymentValidation->checkSignature('', self::API_KEY, self::GOOD_SIGNATURE);
+    }
+
+    /**
+     * @throws PaymentValidationException
+     */
+    public function testCheckSignatureWithoutSignatureReturnError()
+    {
+        $this->expectException(PaymentValidationException::class);
+        $this->paymentValidation->checkSignature(self::PAYMENT_ID, self::API_KEY, '');
+    }
+
+    /**
+     * @throws PaymentValidationException
+     */
+    public function testCheckSignatureWithBadSignatureReturnError()
+    {
+        $this->clientPaymentValidator->expects($this->once())
+            ->method('isHmacValidated')
+            ->with(self::PAYMENT_ID, self::API_KEY, self::WRONG_SIGNATURE)
+            ->willReturn(false);
+        $this->expectException(PaymentValidationException::class);
+        $this->paymentValidation->checkSignature(self::PAYMENT_ID, self::API_KEY, self::WRONG_SIGNATURE);
+    }
+
+    /**
+     * @throws PaymentValidationException
+     */
+    public function testCheckSignatureWithGoodSignatureReturnTrue()
+    {
+        $this->clientPaymentValidator->expects($this->once())
+            ->method('isHmacValidated')
+            ->with(self::PAYMENT_ID, self::API_KEY, self::GOOD_SIGNATURE)
+            ->willReturn(true);
+        $this->assertTrue($this->paymentValidation->checkSignature(self::PAYMENT_ID, self::API_KEY, self::GOOD_SIGNATURE));
+    }
+}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1818/[-ps]-add-hmac-verification-on-ipn)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We add the call function to `isHmacValidated` in php client to check is the IPN callback is signed by Alma before to validate the order by IPN

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Make an order, close the page before the return validation payment
Call the ipn callback with some other browser or API Client to check if the IPN need the Alma signature

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->