### PR TITLE
Chore/add html coverage report

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -100,7 +100,7 @@ tasks:
     deps:
       - tools:install
     cmds:
-      - php ./alma/vendor/bin/phpcs -p alma --standard=PHPCompatibility -s --runtime-set testVersion 5.6-8.1 --ignore=\*/vendor/\*
+      - php ./alma/vendor/bin/phpcs -p alma --standard=PHPCompatibility -s --runtime-set testVersion 5.6-8.1 --ignore=\*/vendor/\*,\*/.coverage/\*
 
   crowdin:
     internal: true

--- a/alma/phpunit.ci.xml
+++ b/alma/phpunit.ci.xml
@@ -28,5 +28,7 @@
             </exclude>
         </whitelist>
     </filter>
-
+    <logging>
+        <log type="coverage-html" target="./.coverage" showUncoveredFiles="true"/>
+    </logging>
 </phpunit>

--- a/alma/tests/ReportConfigForHTMLReport.php
+++ b/alma/tests/ReportConfigForHTMLReport.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Custom Handler for Error during Unit Testing :
+ * While creating the HTML report, there was an issue :
+ * "Generating code coverage report in HTML format ...count(): Parameter must be an array or an object that implements Countable"
+ * This error seems to be due to incompatibilities with PHPUnit 5.7, but we can not upgrade it to stay compatible with PHP 5.6
+ * The code below is a workaround to avoid this error.
+ * It should be removed later when we have an upgrading plan for PHP 5.6
+ * */
+
+namespace Alma\PrestaShop\Tests;
+
+class ReportConfigForHTMLReport
+{
+    private $configFilePath;
+
+    public function __construct($configFilePath)
+    {
+        $this->configFilePath = $configFilePath;
+    }
+
+    public function isHtmlReportFromConfig()
+    {
+        $configContent = file_get_contents($this->configFilePath);
+        // Check & return if the coverage-html option is set
+        return strpos($configContent, 'coverage-html') !== false;
+    }
+
+    public function setErrorReportingLevel($level)
+    {
+        error_reporting($level);
+    }
+
+    public function restoreErrorReportingLevel($originalLevel)
+    {
+        register_shutdown_function(function () use ($originalLevel) {
+            $this->setErrorReportingLevel($originalLevel);
+        });
+    }
+
+    public function handleReportConfig()
+    {
+        if ($this->isHtmlReportFromConfig()) {
+            $originalErrorReportingLevel = error_reporting();
+            $this->setErrorReportingLevel($originalErrorReportingLevel & ~E_WARNING);
+            $this->restoreErrorReportingLevel($originalErrorReportingLevel);
+        }
+    }
+}

--- a/alma/tests/Unit/Builders/Repositories/InsuranceProductRepositoryBuilderTest.php
+++ b/alma/tests/Unit/Builders/Repositories/InsuranceProductRepositoryBuilderTest.php
@@ -29,7 +29,7 @@ use Alma\PrestaShop\Repositories\AlmaInsuranceProductRepository;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Alma\PrestaShop\Builders\InsuranceProductRepositoryBuilder
+ * @covers \Alma\PrestaShop\Builders\Repositories\InsuranceProductRepositoryBuilder
  */
 class InsuranceProductRepositoryBuilderTest extends TestCase
 {
@@ -44,7 +44,7 @@ class InsuranceProductRepositoryBuilderTest extends TestCase
     }
 
     /**
-     * @covers \Alma\PrestaShop\Builders\InsuranceProductRepositoryBuilder::getInstance
+     * @covers \Alma\PrestaShop\Builders\Repositories\InsuranceProductRepositoryBuilder::getInstance
      *
      * @return void
      */

--- a/alma/tests/bootstrap.php
+++ b/alma/tests/bootstrap.php
@@ -25,37 +25,9 @@ require '../../config/config.inc.php';
 
 require 'alma.php';
 
-/*
- * Custom Handler for Error during Unit Testing :
- * While creating the HTML report, there was an issue :
- * "Generating code coverage report in HTML format ...count(): Parameter must be an array or an object that implements Countable"
- * This error seems to be due to incompatibilities with PHPUnit 5.7, but we can not upgrade it to stay compatible with PHP 5.6
- * The code below is a workaround to avoid this error.
- * It should be removed later when we have an upgrading plan for PHP 5.6
- * */
-// Only apply this workaround for the HTML report
-function isHtmlReportFromConfig()
-{
-    $configFilePath = __DIR__ . '/../phpunit.ci.xml';
-    $configContent = file_get_contents($configFilePath);
-    // Check & return if the coverage-html option is set
-    return strpos($configContent, 'coverage-html') !== false;
-}
+// Workaround to avoid error during generation of html report file
+use Alma\PrestaShop\Tests\ReportConfigForHTMLReport;
 
-function setErrorReportingLevel($level)
-{
-    error_reporting($level);
-}
-
-function restoreErrorReportingLevel($originalLevel)
-{
-    register_shutdown_function(function () use ($originalLevel) {
-        setErrorReportingLevel($originalLevel);
-    });
-}
-
-if (isHtmlReportFromConfig()) {
-    $originalErrorReportingLevel = error_reporting();
-    setErrorReportingLevel($originalErrorReportingLevel & ~E_WARNING);
-    restoreErrorReportingLevel($originalErrorReportingLevel);
-}
+$configFilePath = __DIR__ . '/../phpunit.ci.xml';
+$reportConfig = new ReportConfigForHTMLReport($configFilePath);
+$reportConfig->handleReportConfig();

--- a/alma/tests/bootstrap.php
+++ b/alma/tests/bootstrap.php
@@ -24,3 +24,38 @@
 require '../../config/config.inc.php';
 
 require 'alma.php';
+
+/*
+ * Custom Handler for Error during Unit Testing :
+ * While creating the HTML report, there was an issue :
+ * "Generating code coverage report in HTML format ...count(): Parameter must be an array or an object that implements Countable"
+ * This error seems to be due to incompatibilities with PHPUnit 5.7, but we can not upgrade it to stay compatible with PHP 5.6
+ * The code below is a workaround to avoid this error.
+ * It should be removed later when we have an upgrading plan for PHP 5.6
+ * */
+// Only apply this workaround for the HTML report
+function isHtmlReportFromConfig()
+{
+    $configFilePath = __DIR__ . '/../phpunit.ci.xml';
+    $configContent = file_get_contents($configFilePath);
+    // Check & return if the coverage-html option is set
+    return strpos($configContent, 'coverage-html') !== false;
+}
+
+function setErrorReportingLevel($level)
+{
+    error_reporting($level);
+}
+
+function restoreErrorReportingLevel($originalLevel)
+{
+    register_shutdown_function(function () use ($originalLevel) {
+        setErrorReportingLevel($originalLevel);
+    });
+}
+
+if (isHtmlReportFromConfig()) {
+    $originalErrorReportingLevel = error_reporting();
+    setErrorReportingLevel($originalErrorReportingLevel & ~E_WARNING);
+    restoreErrorReportingLevel($originalErrorReportingLevel);
+}


### PR DESCRIPTION
### Reason for change

Fixes ECOM-1917

### Code changes

- Fix path in test as there was a warning `Undefined namespace 'Builders'`
- Add log as HTML report in PHPUnit configuration
- Add a workaround to allow PHPUnit 5.7 to build HTML coverage file correctly
- Exclude `.coverage` folder from php-compatibility verification (as it's a generated folder)

### How to test

- Run `task test` 
- Wait for the `.coverage` folder to be generated
- Open `index.html` in browser
- See HTML report for code coverage :) 