### PR TITLE
fix: install module if container of getService Ps_account is null

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -123,41 +123,30 @@ class Alma extends PaymentModule
         $this->tabsHelper = new \Alma\PrestaShop\Helpers\Admin\TabsHelper();
 
         $this->toolsHelper = new \Alma\PrestaShop\Helpers\ToolsHelper();
-
-        $this->handlePSModule();
     }
 
     /**
      * @return void
-     */
-    public function handlePSModule()
-    {
-        if (
-            $this->checkCompatibilityPSModule()
-            && $this->container === null
-        ) {
-            $this->container = new \PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer(
-                $this->name,
-                $this->getLocalPath()
-            );
-        }
-    }
-
-    /**
-     * @return bool
+     *
+     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException
      */
     public function checkCompatibilityPSModule()
     {
-        if (
-            $this->toolsHelper->psVersionCompare('1.6', '<')
-            || !class_exists(\Symfony\Component\Config\ConfigCache::class)
-            || !class_exists(\PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer::class)
-            || _PS_MODE_DEV_ === true
-        ) {
-            return false;
+        if (_PS_MODE_DEV_ === true) {
+            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException('[Alma] Debug mode is activated');
         }
 
-        return true;
+        if (
+            !class_exists(\Symfony\Component\Config\ConfigCache::class)
+            || !class_exists(\PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer::class)
+        ) {
+            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException('[Alma] Classes don\'t exist for PS Account');
+        }
+        if (
+            $this->toolsHelper->psVersionCompare('1.6', '<')
+        ) {
+            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException('[Alma] Prestashop version lower than 1.6');
+        }
     }
 
     /**
@@ -232,8 +221,11 @@ class Alma extends PaymentModule
      */
     public function install()
     {
-        if ($this->checkCompatibilityPSModule()) {
+        try {
+            $this->checkCompatibilityPSModule();
             $this->getService('alma.ps_accounts_installer')->install();
+        } catch (\Alma\PrestaShop\Exceptions\CompatibilityPsAccountException $e) {
+            \Alma\PrestaShop\Logger::instance()->info($e->getMessage());
         }
 
         $coreInstall = parent::install();
@@ -589,6 +581,8 @@ class Alma extends PaymentModule
 
         try {
             $hasPSAccount = $this->renderPSAccount();
+        } catch (\Alma\PrestaShop\Exceptions\CompatibilityPsAccountException $e) {
+            $hasPSAccount = false;
         } catch (\PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException $e) {
             $hasPSAccount = false;
             $suggestPSAccount = true;
@@ -599,12 +593,16 @@ class Alma extends PaymentModule
 
     /**
      * @return bool
+     *
+     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException
      */
     public function renderPSAccount()
     {
-        if (!$this->checkCompatibilityPSModule() || is_null($this->container)) {
-            return false;
-        }
+        $this->checkCompatibilityPSModule();
+        $this->container = new \PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer(
+            $this->name,
+            $this->getLocalPath()
+        );
 
         try {
             $accountsFacade = $this->getService('alma.ps_accounts_facade');

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -152,6 +152,7 @@ class Alma extends PaymentModule
             $this->toolsHelper->psVersionCompare('1.6', '<')
             || !class_exists(\Symfony\Component\Config\ConfigCache::class)
             || !class_exists(\PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer::class)
+            || is_null($this->container)
             || _PS_MODE_DEV_ === true
         ) {
             return false;

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -152,7 +152,6 @@ class Alma extends PaymentModule
             $this->toolsHelper->psVersionCompare('1.6', '<')
             || !class_exists(\Symfony\Component\Config\ConfigCache::class)
             || !class_exists(\PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer::class)
-            || is_null($this->container)
             || _PS_MODE_DEV_ === true
         ) {
             return false;
@@ -603,7 +602,7 @@ class Alma extends PaymentModule
      */
     public function renderPSAccount()
     {
-        if (!$this->checkCompatibilityPSModule()) {
+        if (!$this->checkCompatibilityPSModule() || is_null($this->container)) {
             return false;
         }
 

--- a/alma/controllers/hook/FrontHeaderHookController.php
+++ b/alma/controllers/hook/FrontHeaderHookController.php
@@ -31,7 +31,7 @@ if (!defined('_PS_VERSION_')) {
 use Alma\PrestaShop\Builders\Admin\InsuranceHelperBuilder as AdminInsuranceHelperBuilder;
 use Alma\PrestaShop\Builders\Helpers\InsuranceHelperBuilder;
 use Alma\PrestaShop\Builders\Helpers\SettingsHelperBuilder;
-use Alma\PrestaShop\Helpers\Admin\AdminInsuranceHelper as AdminInsuranceHelper;
+use Alma\PrestaShop\Helpers\Admin\AdminInsuranceHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
 use Alma\PrestaShop\Helpers\InsuranceHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;

--- a/alma/controllers/hook/FrontHeaderHookController.php
+++ b/alma/controllers/hook/FrontHeaderHookController.php
@@ -31,7 +31,7 @@ if (!defined('_PS_VERSION_')) {
 use Alma\PrestaShop\Builders\Admin\InsuranceHelperBuilder as AdminInsuranceHelperBuilder;
 use Alma\PrestaShop\Builders\Helpers\InsuranceHelperBuilder;
 use Alma\PrestaShop\Builders\Helpers\SettingsHelperBuilder;
-use Alma\PrestaShop\Helpers\Admin\InsuranceHelper as AdminInsuranceHelper;
+use Alma\PrestaShop\Helpers\Admin\AdminInsuranceHelper as AdminInsuranceHelper;
 use Alma\PrestaShop\Helpers\ConstantsHelper;
 use Alma\PrestaShop\Helpers\InsuranceHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;

--- a/alma/exceptions/CompatibilityPsAccountException.php
+++ b/alma/exceptions/CompatibilityPsAccountException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Alma\PrestaShop\Exceptions;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class CompatibilityPsAccountException extends AlmaException
+{
+}

--- a/alma/tests/Unit/Controllers/Front/index.php
+++ b/alma/tests/Unit/Controllers/Front/index.php
@@ -1,0 +1,11 @@
+<?php
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2056/[-ps]-fix-install-module-if-container-of-getservice-ps-account-is-null)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We refactored the checkout compatibility of Ps Account
Now we throw an exception if the shop isn't compatible to avoid any error into installation

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Bug identify in the merchant

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->