### PR TITLE
fix: Inpage on prestashop 1.6 with third party module of checkout

### DIFF
--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -79,6 +79,7 @@ function onloadAlma() {
         removeLoaderButtonPayment(button);
         button.addEventListener('click', function (e) {
             e.preventDefault();
+            e.stopPropagation();
             let paymentOptionId = this.getAttribute('id');
             let url = this.getAttribute('href');
             let settingInpage = document.querySelector('#alma-inpage-' + paymentOptionId);


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2057/[-ps]-fix-inpage-on-prestashop-16-with-third-party-module-of-checkout)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We added a stopPropagation in event click payment button on Prestashop 1.6 for fix an parent event for some third party module of checkout

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Need to test in the merchant env

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->