### PR TITLE
fix: automatic height insurance widget

### DIFF
--- a/alma/lib/Helpers/HookHelper.php
+++ b/alma/lib/Helpers/HookHelper.php
@@ -101,7 +101,7 @@ class HookHelper
             'operand' => '>=',
         ],
         'actionObjectProductInCartDeleteAfter' => [
-            'version' => '8.1.4',
+            'version' => '1.7.1',
             'operand' => '>',
         ],
         'actionCartSave' => 'all',

--- a/alma/views/css/alma-insurance.css
+++ b/alma/views/css/alma-insurance.css
@@ -91,6 +91,13 @@
 }
 
 /**
+-- Product Details
+ */
+.alma-widget-insurance .js-product-details{
+    display: none;
+}
+
+/**
 -- Loader dot
  */
 .alma-loader-dot-container {

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -27,8 +27,7 @@ const settings = getSettingsInsurance();
 let insuranceSelected = false;
 let selectedAlmaInsurance = null;
 let addToCartFlow = false;
-//TODO: Need to refresh the productDetails on change reference
-let productDetails = JSON.parse(document.getElementById('alma-product-details').dataset.productDetails);
+let productDetails = JSON.parse(document.querySelector('.alma-widget-insurance .js-product-details').dataset.product);
 let quantity = getQuantity();
 let almaEligibilityAnswer = false;
 
@@ -79,7 +78,7 @@ let almaEligibilityAnswer = false;
                 function () {
                     document.querySelector('.qty [name="qty"]').value = quantity;
                     productDetails.quantity_wanted = parseInt(quantity);
-                    document.getElementById('alma-product-details').dataset.productDetails = JSON.stringify(productDetails);
+                    document.querySelector('.alma-widget-insurance .js-product-details').dataset.product = JSON.stringify(productDetails);
                     refreshWidget();
                     addModalListenerToAddToCart();
                 }
@@ -254,9 +253,10 @@ function addModalListenerToAddToCart() {
 }
 
 function getAddToCartButton() {
-    let addToCart = document.querySelector('.add-to-cart');
+    let addToCart = document.querySelector('button.add-to-cart');
+    // TODO: Ravate specific to generalise with selector configuration
     if (!addToCart) {
-        addToCart = document.querySelector('.add-to-cart a, .add-to-cart button');
+        addToCart = document.querySelector('.add-to-cart a, .add-to-cart button').first();
     }
 
     return addToCart;

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -77,6 +77,7 @@ let almaEligibilityAnswer = false;
                 'updatedProduct',
                 function () {
                     document.querySelector('.qty [name="qty"]').value = quantity;
+                    productDetails = JSON.parse(document.querySelector('.alma-widget-insurance .js-product-details').dataset.product);
                     productDetails.quantity_wanted = parseInt(quantity);
                     document.querySelector('.alma-widget-insurance .js-product-details').dataset.product = JSON.stringify(productDetails);
                     refreshWidget();

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -125,13 +125,7 @@ function onloadAddInsuranceInputOnProductAlma() {
             almaEligibilityAnswer = e.data.eligibilityCallResponseStatus.response.eligibleProduct;
             btnLoaders('stop');
             if (almaEligibilityAnswer) {
-                let heightIframe = e.data.widgetSize.height;
-                let stringHeightIframe = heightIframe + 'px';
-                if (heightIframe <= 45) {
-                    stringHeightIframe = '100%';
-                }
-
-                document.getElementById('alma-widget-insurance-product-page').style.height = stringHeightIframe;
+                document.getElementById('alma-widget-insurance-product-page').style.height = e.data.widgetSize.height + 'px';
                 prestashop.emit('updateProduct', {
                     reason:{
                         productUrl: window.location.href,

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -27,6 +27,7 @@ const settings = getSettingsInsurance();
 let insuranceSelected = false;
 let selectedAlmaInsurance = null;
 let addToCartFlow = false;
+//TODO: Need to refresh the productDetails on change reference
 let productDetails = JSON.parse(document.getElementById('alma-product-details').dataset.productDetails);
 let quantity = getQuantity();
 let almaEligibilityAnswer = false;
@@ -121,22 +122,26 @@ function onloadAddInsuranceInputOnProductAlma() {
     let currentResolve;
 
     window.addEventListener('message', (e) => {
+        let widgetInsurance = document.getElementById('alma-widget-insurance-product-page');
         if (e.data.type === 'almaEligibilityAnswer') {
             almaEligibilityAnswer = e.data.eligibilityCallResponseStatus.response.eligibleProduct;
             btnLoaders('stop');
             if (almaEligibilityAnswer) {
-                document.getElementById('alma-widget-insurance-product-page').style.height = e.data.widgetSize.height + 'px';
                 prestashop.emit('updateProduct', {
                     reason:{
                         productUrl: window.location.href,
                     }
                 });
             } else {
+                widgetInsurance.style.display = 'none';
                 let addToCart = document.querySelector('.add-to-cart');
                 if (addToCart) {
                     addToCart.removeEventListener("click", insuranceListener)
                 }
             }
+        }
+        if (e.data.type === 'changeWidgetHeight') {
+            widgetInsurance.style.height = e.data.widgetHeight + 'px';
         }
         if (e.data.type === 'getSelectedInsuranceData') {
             if (parseInt(document.querySelector('.qty [name="qty"]').value) !== quantity) {

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -20,7 +20,7 @@
  * @copyright 2018-2024 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
-if (!document.getElementById('alma-product-details')) {
+if (!document.getElementById('alma-widget-insurance-product-page')) {
     throw new Error('[Alma] Product details not found. You need to add the hook displayProductActions in your template product page.');
 }
 const settings = getSettingsInsurance();

--- a/alma/views/templates/hook/displayProductActions.tpl
+++ b/alma/views/templates/hook/displayProductActions.tpl
@@ -21,6 +21,6 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
 <div class="alma-widget-insurance" id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" style="height: 100%" >
-    <div id="alma-product-details" class="js-product-details" data-product="{$product.embedded_attributes|json_encode}" style="display:none;"></div>
+    <div id="product-details" class="js-product-details" data-product="{$product.embedded_attributes|json_encode}" style="display:none;"></div>
     <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
 </div>

--- a/alma/views/templates/hook/displayProductActions.tpl
+++ b/alma/views/templates/hook/displayProductActions.tpl
@@ -20,7 +20,7 @@
  * @copyright 2018-2024 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
-<div id="alma-product-details" data-product-details="{$productDetails}" style="display:none;"></div>
 <div class="alma-widget-insurance" id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" style="height: 100%" >
+    <div id="alma-product-details" class="js-product-details" data-product="{$product.embedded_attributes|json_encode}" style="display:none;"></div>
     <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
 </div>

--- a/alma/views/templates/hook/displayProductActions.tpl
+++ b/alma/views/templates/hook/displayProductActions.tpl
@@ -21,6 +21,6 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
 <div id="alma-product-details" data-product-details="{$productDetails}" style="display:none;"></div>
-<div class="alma-widget-insurance" id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" style="height: 0px" >
+<div class="alma-widget-insurance" id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" style="height: 100%" >
     <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
 </div>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2095/[-ps]-fix-handle-height-insurance-widget)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
By default we define the height of widget at 100%
And we remove the hack about the height data send in postMessage if lower that 45px

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Display the widget in the product page
Change the product reference
Change the quantity
See if the widget is updated with the height and data
Remove the product in the cart to see if the product and insurance are removed
[Link to the infra for QA](https://qa-fix-widget-insurance-prestashop-1-7-8-7.integrations.getalma.eu)

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->