### PR TITLE
Fix a conflict with product details panel

### DIFF
--- a/alma/views/css/alma-insurance.css
+++ b/alma/views/css/alma-insurance.css
@@ -94,7 +94,7 @@
 -- Product Details
  */
 .alma-widget-insurance .js-product-details,
-.alma-widget-insurance #product-details {
+#alma-product-details {
     display: none;
 }
 

--- a/alma/views/templates/hook/displayProductActions.tpl
+++ b/alma/views/templates/hook/displayProductActions.tpl
@@ -21,6 +21,6 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
 <div class="alma-widget-insurance" id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" style="height: 100%" >
-    <div id="product-details" class="js-product-details" data-product="{$product.embedded_attributes|json_encode}" style="display:none;"></div>
-    <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
+    <div id="alma-product-details" class="js-product-details" data-product="{$product.embedded_attributes|json_encode}" style="display:none;"></div>
+    <iframe id="product-alma-iframe" sandbox="allow-scripts allow-same-origin" src="{$iframeUrl}"></iframe>
 </div>


### PR DESCRIPTION
### Reason for change

Latest release (4.4.0) of the module introduced a bug: the insurance DOM conflicts with PrestaShop's and prevents the product details panel to show on product pages

Fixes [MPP-2155](https://linear.app/almapay/issue/MPP-2155)

### Code changes

Changed `#product-details` in our template with `#alma-product-details`

### How to test

_As a reviewer, you are encouraged to test the PR locally._

https://github.com/user-attachments/assets/e44950c3-ee8a-4ded-8592-262c980417a7

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)
