### PR TITLE
fix: Impossible configure Alma if PS Account version is lower  5.0

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -31,7 +31,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 class Alma extends PaymentModule
 {
     const VERSION = '4.4.0';
-    const PS_ACCOUNT_VERSION_REQUIRED = '5.3.0';
+    const PS_ACCOUNTS_VERSION_REQUIRED = '5.3.0';
 
     public $_path;
     public $local_path;
@@ -166,8 +166,8 @@ class Alma extends PaymentModule
             throw new \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException('[Alma] PS Account is not installed');
         }
 
-        if ($psAccountsModule->version < self::PS_ACCOUNT_VERSION_REQUIRED) {
-            throw new \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException('[Alma] PS Account is not up to date, minimal version required ' . self::PS_ACCOUNT_VERSION_REQUIRED);
+        if ($psAccountsModule->version < self::PS_ACCOUNTS_VERSION_REQUIRED) {
+            throw new \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException('[Alma] PS Account is not up to date, minimal version required ' . self::PS_ACCOUNTS_VERSION_REQUIRED);
         }
     }
 

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -129,24 +129,24 @@ class Alma extends PaymentModule
     /**
      * @return void
      *
-     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException
+     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountsException
      */
-    public function checkPsAccountPresence()
+    public function checkPsAccountsPresence()
     {
         if (_PS_MODE_DEV_ === true) {
-            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException('[Alma] Debug mode is activated');
+            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountsException('[Alma] Debug mode is activated');
         }
 
         if (
             !class_exists(\Symfony\Component\Config\ConfigCache::class)
             || !class_exists(\PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer::class)
         ) {
-            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException('[Alma] Classes don\'t exist for PS Account');
+            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountsException('[Alma] Classes don\'t exist for PS Account');
         }
         if (
             $this->toolsHelper->psVersionCompare('1.6', '<')
         ) {
-            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException('[Alma] Prestashop version lower than 1.6');
+            throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountsException('[Alma] Prestashop version lower than 1.6');
         }
     }
 
@@ -156,17 +156,17 @@ class Alma extends PaymentModule
      * @return void
      *
      * @throws \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException
-     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException
+     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountsException
      */
-    public function checkPsAccountCompatibility()
+    public function checkPsAccountsCompatibility()
     {
-        $this->checkPsAccountPresence();
-        $psAccountModule = \Module::getInstanceByName('ps_accounts');
-        if (!$psAccountModule) {
+        $this->checkPsAccountsPresence();
+        $psAccountsModule = \Module::getInstanceByName('ps_accounts');
+        if (!$psAccountsModule) {
             throw new \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException('[Alma] PS Account is not installed');
         }
 
-        if ($psAccountModule->version < self::PS_ACCOUNT_VERSION_REQUIRED) {
+        if ($psAccountsModule->version < self::PS_ACCOUNT_VERSION_REQUIRED) {
             throw new \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException('[Alma] PS Account is not up to date, minimal version required ' . self::PS_ACCOUNT_VERSION_REQUIRED);
         }
     }
@@ -244,10 +244,10 @@ class Alma extends PaymentModule
     public function install()
     {
         try {
-            $this->checkPsAccountPresence();
+            $this->checkPsAccountsPresence();
             $this->setContainer();
             $this->getService('alma.ps_accounts_installer')->install();
-        } catch (\Alma\PrestaShop\Exceptions\CompatibilityPsAccountException $e) {
+        } catch (\Alma\PrestaShop\Exceptions\CompatibilityPsAccountsException $e) {
             \Alma\PrestaShop\Logger::instance()->info($e->getMessage());
         }
 
@@ -608,29 +608,29 @@ class Alma extends PaymentModule
      */
     public function getContent()
     {
-        $suggestPSAccount = false;
+        $suggestPSAccounts = false;
 
         try {
-            $hasPSAccount = $this->renderPSAccount();
-        } catch (\Alma\PrestaShop\Exceptions\CompatibilityPsAccountException $e) {
-            $hasPSAccount = false;
+            $hasPSAccounts = $this->renderPSAccounts();
+        } catch (\Alma\PrestaShop\Exceptions\CompatibilityPsAccountsException $e) {
+            $hasPSAccounts = false;
         } catch (\PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException $e) {
-            $hasPSAccount = false;
-            $suggestPSAccount = true;
+            $hasPSAccounts = false;
+            $suggestPSAccounts = true;
         }
 
-        return $this->runHookController('getContent', ['hasPSAccount' => $hasPSAccount, 'suggestPSAccount' => $suggestPSAccount]);
+        return $this->runHookController('getContent', ['hasPSAccounts' => $hasPSAccounts, 'suggestPSAccounts' => $suggestPSAccounts]);
     }
 
     /**
      * @return bool
      *
-     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException
+     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountsException
      * @throws \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException
      */
-    public function renderPSAccount()
+    public function renderPSAccounts()
     {
-        $this->checkPsAccountCompatibility();
+        $this->checkPsAccountsCompatibility();
         $this->setContainer();
 
         try {

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -31,6 +31,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 class Alma extends PaymentModule
 {
     const VERSION = '4.4.0';
+    const PS_ACCOUNT_VERSION_REQUIRED = '5.0';
 
     public $_path;
     public $local_path;
@@ -146,6 +147,25 @@ class Alma extends PaymentModule
             $this->toolsHelper->psVersionCompare('1.6', '<')
         ) {
             throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException('[Alma] Prestashop version lower than 1.6');
+        }
+    }
+
+    /**
+     * Check if PS Account is installed and up to date, minimal version required 5.0.
+     *
+     * @return void
+     *
+     * @throws \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException
+     */
+    public function checkPsAccountCompatibility()
+    {
+        $psAccountModule = \Module::getInstanceByName('ps_accounts');
+        if (!$psAccountModule) {
+            throw new \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException('[Alma] PS Account is not installed');
+        }
+
+        if ($psAccountModule->version < self::PS_ACCOUNT_VERSION_REQUIRED) {
+            throw new \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException('[Alma] PS Account is not up to date, minimal version required ' . self::PS_ACCOUNT_VERSION_REQUIRED);
         }
     }
 
@@ -604,10 +624,12 @@ class Alma extends PaymentModule
      * @return bool
      *
      * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException
+     * @throws \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException
      */
     public function renderPSAccount()
     {
         $this->checkCompatibilityPSModule();
+        $this->checkPsAccountCompatibility();
         $this->setContainer();
 
         try {

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -131,7 +131,7 @@ class Alma extends PaymentModule
      *
      * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException
      */
-    public function checkCompatibilityPSModule()
+    public function checkPsAccountPresence()
     {
         if (_PS_MODE_DEV_ === true) {
             throw new \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException('[Alma] Debug mode is activated');
@@ -156,9 +156,11 @@ class Alma extends PaymentModule
      * @return void
      *
      * @throws \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException
+     * @throws \Alma\PrestaShop\Exceptions\CompatibilityPsAccountException
      */
     public function checkPsAccountCompatibility()
     {
+        $this->checkPsAccountPresence();
         $psAccountModule = \Module::getInstanceByName('ps_accounts');
         if (!$psAccountModule) {
             throw new \PrestaShop\PsAccountsInstaller\Installer\Exception\ModuleNotInstalledException('[Alma] PS Account is not installed');
@@ -242,7 +244,7 @@ class Alma extends PaymentModule
     public function install()
     {
         try {
-            $this->checkCompatibilityPSModule();
+            $this->checkPsAccountPresence();
             $this->setContainer();
             $this->getService('alma.ps_accounts_installer')->install();
         } catch (\Alma\PrestaShop\Exceptions\CompatibilityPsAccountException $e) {
@@ -628,7 +630,6 @@ class Alma extends PaymentModule
      */
     public function renderPSAccount()
     {
-        $this->checkCompatibilityPSModule();
         $this->checkPsAccountCompatibility();
         $this->setContainer();
 

--- a/alma/alma.php
+++ b/alma/alma.php
@@ -31,7 +31,7 @@ require_once _PS_MODULE_DIR_ . 'alma/vendor/autoload.php';
 class Alma extends PaymentModule
 {
     const VERSION = '4.4.0';
-    const PS_ACCOUNT_VERSION_REQUIRED = '5.0';
+    const PS_ACCOUNT_VERSION_REQUIRED = '5.3.0';
 
     public $_path;
     public $local_path;

--- a/alma/controllers/hook/GetContentHookController.php
+++ b/alma/controllers/hook/GetContentHookController.php
@@ -206,7 +206,7 @@ final class GetContentHookController extends AdminHookController
         if ((empty($liveKey) && ALMA_MODE_LIVE == $apiMode) || (empty($testKey) && ALMA_MODE_TEST == $apiMode)) {
             $this->context->smarty->assign('validation_error', "missing_key_for_{$apiMode}_mode");
             $this->context->smarty->assign([
-                'suggestPSAccount' => false,
+                'suggestPSAccounts' => false,
             ]);
 
             $this->hasKey = false;
@@ -540,8 +540,8 @@ final class GetContentHookController extends AdminHookController
 
             $this->assignSmartyAlertClasses();
             $this->context->smarty->assign('tip', 'fill_api_keys');
-            $this->context->smarty->assign('suggestPSAccount', false);
-            $this->context->smarty->assign('hasPSAccount', false);
+            $this->context->smarty->assign('suggestPSAccounts', false);
+            $this->context->smarty->assign('hasPSAccounts', false);
 
             $extraMessage = $this->module->display($this->module->file, 'getContent.tpl');
         }
@@ -829,9 +829,9 @@ final class GetContentHookController extends AdminHookController
     public function run($params)
     {
         $this->context->smarty->assign([
-            'hasPSAccount' => $params['hasPSAccount'],
+            'hasPSAccounts' => $params['hasPSAccounts'],
             'updated' => true,
-            'suggestPSAccount' => $params['suggestPSAccount'],
+            'suggestPSAccounts' => $params['suggestPSAccounts'],
         ]);
 
         $this->assignSmartyAlertClasses();
@@ -863,7 +863,7 @@ final class GetContentHookController extends AdminHookController
             $messages = '';
         }
 
-        if ($params['hasPSAccount'] || $params['suggestPSAccount']) {
+        if ($params['hasPSAccounts'] || $params['suggestPSAccounts']) {
             $messages = $this->module->display($this->module->file, 'getContent.tpl');
         }
 

--- a/alma/exceptions/CompatibilityPsAccountsException.php
+++ b/alma/exceptions/CompatibilityPsAccountsException.php
@@ -6,6 +6,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-class CompatibilityPsAccountException extends AlmaException
+class CompatibilityPsAccountsException extends AlmaException
 {
 }

--- a/alma/translations/de.php
+++ b/alma/translations/de.php
@@ -260,7 +260,7 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Enter your API key';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Find your API live key on your %1$s Alma dashboard%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'Um den Testmodus zu verwenden, rufen Sie Ihren Test-API-Schlüssel von Ihrem %1$ssandbox dashboard%2$s ab.';
-$_MODULE['<{alma}prestashop>notificationconfiguration_41d0063d3bb7d3067f46734fac8b27c4'] = 'Wir bieten das PrestaShop Account Modul zum Download an';
+$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'Wir bieten das PrestaShop Account Modul zum Download an';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'Das Modul %1$sfinden Sie hier%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = ' Steigern Sie Ihre Leistung und erhalten Sie Einblicke!';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_5b64cb0849dd12ea528c04f2fe66ae4d'] = 'Indem Sie diese Option akzeptieren, ermöglichen Sie es Alma, die Nutzung Ihrer Zahlungsmittel zu analysieren, [1]mehr Informationen zu erhalten, um[/1] durchzuführen und diese Daten mit Ihnen zu teilen. Sie können [2]jederzeit abbestellen und Ihre Daten[/2] löschen.';

--- a/alma/translations/en.php
+++ b/alma/translations/en.php
@@ -260,7 +260,7 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Enter your API key';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Find your API live key on your %1$s Alma dashboard%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'To use Test mode, retrieve your Test API key from your %1$ssandbox dashboard%2$s';
-$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'We offer to download the PrestaShop Account module';
+$_MODULE['<{alma}prestashop>notificationconfiguration_b040aba3ff898146cd8c1fb8cfd04daf'] = 'We offer to download or update the PrestaShop Account module (minimum required version %1$s)';
 $_MODULE['<{alma}prestashop>notificationconfiguration_9700e091d54b8ff1fafcd27518c75b23'] = 'Link your store to your PrestaShop account to take full advantage of the modules offered by the PrestaShop Marketplace and optimize your experience.';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'You can find the module %1$shere%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = ' Increase your performance & get insights !';

--- a/alma/translations/en.php
+++ b/alma/translations/en.php
@@ -260,7 +260,8 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Enter your API key';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Find your API live key on your %1$s Alma dashboard%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'To use Test mode, retrieve your Test API key from your %1$ssandbox dashboard%2$s';
-$_MODULE['<{alma}prestashop>notificationconfiguration_41d0063d3bb7d3067f46734fac8b27c4'] = 'We offer to download the PrestaShop Account module';
+$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'We offer to download the PrestaShop Account module';
+$_MODULE['<{alma}prestashop>notificationconfiguration_9700e091d54b8ff1fafcd27518c75b23'] = 'Link your store to your PrestaShop account to take full advantage of the modules offered by the PrestaShop Marketplace and optimize your experience.';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'You can find the module %1$shere%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = ' Increase your performance & get insights !';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_5b64cb0849dd12ea528c04f2fe66ae4d'] = 'By accepting this option, you enable Alma to analyse the usage of your payment methods, [1]get more information to perform[/1] and share this data with you. You can [2]unsubscribe and erase your data[/2] at any moment.';

--- a/alma/translations/es.php
+++ b/alma/translations/es.php
@@ -260,7 +260,7 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Introduce tu clave API';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Encuentra tu API live key en tu %1$s Alma dashboard%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'Para utilizar el modo de prueba, obtenga su clave de API de prueba en el panel de control de su sandbox %1$s%2$s';
-$_MODULE['<{alma}prestashop>notificationconfiguration_41d0063d3bb7d3067f46734fac8b27c4'] = 'Te proponemos descargar el módulo Cuenta PrestaShop';
+$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'Te proponemos descargar el módulo Cuenta PrestaShop';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'Encontrará el módulo %1$saquí%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = ' Aumenta tu rendimiento y obtén información';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_5b64cb0849dd12ea528c04f2fe66ae4d'] = 'Al aceptar esta opción, permites a Alma analizar el uso de tus métodos de pago, [1]obtener más información para realizar[/1] y compartir estos datos contigo. Puedes [2]darte de baja y borrar tus datos[/2] en cualquier momento.';

--- a/alma/translations/fr.php
+++ b/alma/translations/fr.php
@@ -261,7 +261,7 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Entrez votre clé API';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Trouvez votre clé API sur votre tableau de bord %1$s Alma%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'Pour utiliser le mode test, récupérez votre clé API de test dans le tableau de bord de votre sandbox %1$s%2$s';
-$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'Nous vous proposons de télécharger le module PrestaShop Account';
+$_MODULE['<{alma}prestashop>notificationconfiguration_b040aba3ff898146cd8c1fb8cfd04daf'] = 'Nous vous proposons de télécharger ou de mettre à jour le module PrestaShop Account (version minimale requise %1$s)';
 $_MODULE['<{alma}prestashop>notificationconfiguration_9700e091d54b8ff1fafcd27518c75b23'] = 'Liez votre boutique à votre compte PrestaShop pour profiter pleinement des modules proposés par PrestaShop Marketplace et optimiser votre expérience.';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'Vous pouvez trouver le module %1$sici%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = ' Augmentez vos performances et obtenez des informations !';

--- a/alma/translations/fr.php
+++ b/alma/translations/fr.php
@@ -148,7 +148,8 @@ $_MODULE['<{alma}prestashop>admininsurancehelper_f1206f9fadc5ce41694f69129aecac2
 $_MODULE['<{alma}prestashop>admininsurancehelper_7442e29d7d53e549b78d93c46b8cdcfc'] = 'Commandes';
 $_MODULE['<{alma}prestashop>insuranceservice_d87aee5118a62a7ff6c21e4ac31006c5'] = 'Par la présente, je reconnais accepter de souscrire à l\'assurance proposée par Alma. Ce faisant, je confirme avoir préalablement pris connaissance de la [notice d\'information valant conditions générales], du [document d\'information sur le produit d\'assurance], et de la [fiche d\'information et de conseil précontractuelle]. J\'y adhère sans réserve et accepte de signer électroniquement les différents documents formant mon contrat, le cas échéant. Je consens expressément à la collecte et à l\'utilisation de mes données personnelles aux fins de la souscription et de la gestion de mon (mes) contrat(s) d\'assurance.';
 $_MODULE['<{alma}prestashop>adminalmainsuranceconfiguration_b824200e9b8aca1fbb762d6566ff0cd7'] = 'Votre configuration a été sauvegardée';
-$_MODULE['<{alma}prestashop>adminalmainsuranceconfiguration_4a39c6a33c3441762924914168d2a387'] = 'Erreur lors de la création de la configuration Assurance Alma : %1$s';
+$_MODULE['<{alma}prestashop>adminalmainsuranceconfiguration_a6bf06f186e2fccecad054fd831c2144'] = '[Alma] Erreur sur le produit d\'assurance pendant le changement de configuration : %1$s';
+$_MODULE['<{alma}prestashop>adminalmainsuranceconfiguration_b42688965893bdb7a37cf1197e506e25'] = '[Alma] Erreur de création de configuration sur l\'assurance Alma : %1$s';
 $_MODULE['<{alma}prestashop>adminalmainsuranceorders_a66f446516cd125af12bd25073f88b78'] = 'Commandes avec assurance';
 $_MODULE['<{alma}prestashop>adminalmainsuranceorders_49414cda71621b3ee718ae5ff40804c5'] = 'Ordonnance Id';
 $_MODULE['<{alma}prestashop>adminalmainsuranceorders_63d5049791d9d79d86e9a108b0a999ca'] = 'Référence';
@@ -260,7 +261,8 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Entrez votre clé API';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Trouvez votre clé API sur votre tableau de bord %1$s Alma%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'Pour utiliser le mode test, récupérez votre clé API de test dans le tableau de bord de votre sandbox %1$s%2$s';
-$_MODULE['<{alma}prestashop>notificationconfiguration_41d0063d3bb7d3067f46734fac8b27c4'] = 'Nous vous proposons de télécharger le module PrestaShop Account';
+$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'Nous vous proposons de télécharger le module PrestaShop Account';
+$_MODULE['<{alma}prestashop>notificationconfiguration_9700e091d54b8ff1fafcd27518c75b23'] = 'Liez votre boutique à votre compte PrestaShop pour profiter pleinement des modules proposés par PrestaShop Marketplace et optimiser votre expérience.';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'Vous pouvez trouver le module %1$sici%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = ' Augmentez vos performances et obtenez des informations !';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_5b64cb0849dd12ea528c04f2fe66ae4d'] = 'En acceptant cette option, vous permettez à Alma d\'analyser l\'utilisation de vos moyens de paiement, [1]d\'obtenir plus d\'informations pour effectuer[/1] et de partager ces données avec vous. Vous pouvez à tout moment vous désinscrire [2]et effacer vos données[/2] .';

--- a/alma/translations/it.php
+++ b/alma/translations/it.php
@@ -260,7 +260,7 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Inserire la chiave API';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Trovate la vostra chiave API live sul vostro cruscotto %1$s Alma%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'Per utilizzare la modalità Test, recuperare la chiave API Test dalla dashboard di %1$ssandbox%2$s.';
-$_MODULE['<{alma}prestashop>notificationconfiguration_41d0063d3bb7d3067f46734fac8b27c4'] = 'Vi proponiamo di scaricare il modulo Account di PrestaShop';
+$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'Vi proponiamo di scaricare il modulo Account di PrestaShop';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'È possibile trovare il modulo %1$squi%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = 'Aumenta le tue prestazioni e ricevi approfondimenti sulle tue vendite!';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_5b64cb0849dd12ea528c04f2fe66ae4d'] = 'Attivando questa opzione, permetti ad Alma di analizzare l\'utilizzo dei tuoi metodi di pagamento [1]al fine[/1] di migliorare il servizio e condividerti un approfondimento sui dati analizzati. Puoi [2]annullare l\'iscrizione e cancellare i tuoi dati[/2] in qualsiasi momento.';

--- a/alma/translations/nl.php
+++ b/alma/translations/nl.php
@@ -260,7 +260,7 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Voer je API-sleutel in';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Vind je API live key op je %1$s Alma dashboard%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'Om de Testmodus te gebruiken, haalt je je Test API-sleutel op van jouw %1$ssandbox dashboard%2$s';
-$_MODULE['<{alma}prestashop>notificationconfiguration_41d0063d3bb7d3067f46734fac8b27c4'] = 'Wij bieden aan om de PrestaShop Account module te downloaden';
+$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'Wij bieden aan om de PrestaShop Account module te downloaden';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'Je kunt de module %1$shier vinden%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = ' Verhoog je prestaties & krijg inzichten!';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_5b64cb0849dd12ea528c04f2fe66ae4d'] = 'Door deze optie te aanvaarden, stel je Alma in staat het gebruik van je betaalmethoden te analyseren, [1]meer informatie te verkrijgen om beter te presteren[/1] en deze gegevens met jou te delen. Je kunt [2]je op elk moment uitschrijven en je data wissen[/2].';

--- a/alma/translations/pt.php
+++ b/alma/translations/pt.php
@@ -260,7 +260,7 @@ $_MODULE['<{alma}prestashop>notificationconfiguration_e243bbd390b43c9ee6047fab4a
 $_MODULE['<{alma}prestashop>notificationconfiguration_cf5ec9fb9f7214a3db82a5a39fec5b48'] = 'Introduza a sua chave API';
 $_MODULE['<{alma}prestashop>notificationconfiguration_055f421849c2a1c32b885c95540f827c'] = 'Encontre a sua chave de acesso à API no seu painel de controlo %1$s Alma%2$s';
 $_MODULE['<{alma}prestashop>notificationconfiguration_53b458e8453e3694811e61c96527d638'] = 'Para utilizar o modo de teste, recupere a sua chave de API de teste a partir do seu painel de controlo da caixa de areia %1$s%2$s';
-$_MODULE['<{alma}prestashop>notificationconfiguration_41d0063d3bb7d3067f46734fac8b27c4'] = 'Oferecemos a possibilidade de descarregar o módulo Conta PrestaShop';
+$_MODULE['<{alma}prestashop>notificationconfiguration_42deb316427c319fae8ef1e9a2ebfacb'] = 'Oferecemos a possibilidade de descarregar o módulo Conta PrestaShop';
 $_MODULE['<{alma}prestashop>notificationconfiguration_6997dde298b14fbf6a7c95bd39fe8dc4'] = 'Pode encontrar o módulo %1$saqui%2$s';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_a6b0ef107f0d278df612764187bbdece'] = ' Aumente o seu desempenho e obtenha conhecimentos!';
 $_MODULE['<{alma}prestashop>notificationshareofcheckout_5b64cb0849dd12ea528c04f2fe66ae4d'] = 'Ao aceitar esta opção, permite à Alma analisar a utilização dos seus métodos de pagamento, [1]obter mais informações para realizar[/1] e partilhar estes dados consigo. Pode [2]cancelar e apagar os seus dados[/2] a qualquer momento.';

--- a/alma/views/templates/hook/getContent.tpl
+++ b/alma/views/templates/hook/getContent.tpl
@@ -98,7 +98,7 @@
             {$validation_error|escape:'htmlall':'UTF-8'}
         {/if}
     </div>
-{elseif isset($tip) && (!isset($hasPSAccount) && !$hasPSAccount) || _PS_MODE_DEV_}
+{elseif isset($tip) && (!isset($hasPSAccounts) && !$hasPSAccounts) || _PS_MODE_DEV_}
     {include file="./_partials/notificationFirstInstallation.tpl"}
 {/if}
 {if isset($updated) && $updated}

--- a/alma/views/templates/hook/notificationConfiguration.tpl
+++ b/alma/views/templates/hook/notificationConfiguration.tpl
@@ -95,10 +95,10 @@
 {if isset($suggestPSAccount) && $suggestPSAccount}
     <div class="alma alert alert-dismissible alert-info">
         <h2>
-            {l s='We offer to download the PrestaShop Account module ' mod='alma'}
+            {l s='We offer to download the PrestaShop Account module' mod='alma'}
         </h2>
         <p>
-            {l s='Link your store to your PrestaShop account to take full advantage of the modules offered by the PrestaShop Marketplace and optimize your experience.'}
+            {l s='Link your store to your PrestaShop account to take full advantage of the modules offered by the PrestaShop Marketplace and optimize your experience.' mod='alma'}
         </p>
         {almaDisplayHtml}
             {l s='You can find the module %1$shere%2$s' sprintf=['<a href="https://addons.prestashop.com/en/administrative-tools/49648-prestashop-account.html" target=\"_blank\">', '</a>'] mod='alma'}

--- a/alma/views/templates/hook/notificationConfiguration.tpl
+++ b/alma/views/templates/hook/notificationConfiguration.tpl
@@ -20,7 +20,7 @@
  * @copyright 2018-2024 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
-{if isset($hasPSAccount) && $hasPSAccount}
+{if isset($hasPSAccounts) && $hasPSAccounts}
     <div class="ps-account-container">
         {if isset($hasKey) && !$hasKey}
             {include file="./_partials/notificationFirstInstallation.tpl"}
@@ -73,8 +73,8 @@
     {if isset($hasKey) && !$hasKey}
         <script>
             window.onload = function() {
-                psAccountIsCompleted = window.psaccountsVue.isOnboardingCompleted();
-                if (psAccountIsCompleted != true) {
+                psAccountsIsCompleted = window.psaccountsVue.isOnboardingCompleted();
+                if (psAccountsIsCompleted != true) {
                     document.getElementById("alma_config_form").remove()
                     $('.alma.first-installation').each(function() {
                         $(this).remove();
@@ -92,7 +92,7 @@
         </script>
     {/if}
 {/if}
-{if isset($suggestPSAccount) && $suggestPSAccount}
+{if isset($suggestPSAccounts) && $suggestPSAccounts}
     <div class="alma alert alert-dismissible alert-info">
         <h2>
             {l s='We offer to download the PrestaShop Account module' mod='alma'}

--- a/alma/views/templates/hook/notificationConfiguration.tpl
+++ b/alma/views/templates/hook/notificationConfiguration.tpl
@@ -95,7 +95,7 @@
 {if isset($suggestPSAccounts) && $suggestPSAccounts}
     <div class="alma alert alert-dismissible alert-info">
         <h2>
-            {l s='We offer to download the PrestaShop Account module' mod='alma'}
+            {l s='We offer to download or update the PrestaShop Account module (minimum required version %1$s)' sprintf=[Alma::PS_ACCOUNTS_VERSION_REQUIRED] mod='alma'}
         </h2>
         <p>
             {l s='Link your store to your PrestaShop account to take full advantage of the modules offered by the PrestaShop Marketplace and optimize your experience.' mod='alma'}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2162/zepelucheclubcom-500-internal-sever-error)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We added a verification version of PS Account. If PS Account was lower that 5.0 PS Account Service returned an error that we didn't handle.
Now if the version is lower 5.0 we suggest to install the PS Account module (default message)

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Install Ps Account lower that 5.0.
Install our module.
Try to configure it

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] You understand the impact of this PR on existing code/features
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] The changes include adequate logging and Datadog traces

<!-- Move here non-applicable items of the checklist, if any -->