### PR TITLE
Fix/js product details

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -95,6 +95,9 @@
                     return;
                 }
 
+                // There's a bug in some PS 1.7 versions where quantity_wanted is not set to the actual quantity value
+                AlmaInsurance.productDetails.quantity_wanted = getQuantity()
+
                 refreshWidget();
                 addModalListenerToAddToCart();
             });

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -33,7 +33,7 @@
         let almaEligibilityAnswer = false;
 
         //Insurance
-        $("body").on("hidden.bs.modal", "#blockcart-modal", function (e) {
+        $("body").on("hidden.bs.modal", "#blockcart-modal", function () {
             removeInsurance();
         });
         handleInsuranceProductPage();
@@ -280,9 +280,10 @@
         }
 
         function handleInsuranceProductPage() {
-            if (AlmaInsurance.productDetails.id === $('#alma-insurance-global').data('insurance-id')) {
+            const $almaInsuranceGlobal = $('#alma-insurance-global');
+            if (AlmaInsurance.productDetails.id === $almaInsuranceGlobal.data('insurance-id')) {
                 //$('.product-prices').hide(); // To hide the price of the insurance product page
-                let tagInformationInsurance = '<div class="alert alert-info" id="alma-alert-insurance-product">' + $('#alma-insurance-global').data('message-insurance-page') + '</div>';
+                let tagInformationInsurance = '<div class="alert alert-info" id="alma-alert-insurance-product">' + $almaInsuranceGlobal.data('message-insurance-page') + '</div>';
                 $(tagInformationInsurance).insertAfter('.product-variants');
             }
         }

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -20,19 +20,20 @@
  * @copyright 2018-2024 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
-if (!document.getElementById('alma-widget-insurance-product-page')) {
-    throw new Error('[Alma] Product details not found. You need to add the hook displayProductActions in your template product page.');
-}
-const settings = getSettingsInsurance();
-let insuranceSelected = false;
-let selectedAlmaInsurance = null;
-let addToCartFlow = false;
-let productDetails = JSON.parse(document.querySelector('.alma-widget-insurance .js-product-details').dataset.product);
-let quantity = getQuantity();
-let almaEligibilityAnswer = false;
-
 (function ($) {
     $(function () {
+        if (!document.getElementById('alma-widget-insurance-product-page')) {
+            throw new Error('[Alma] Product details not found. You need to add the hook displayProductActions in your template product page.');
+        }
+
+        const settings = getSettingsInsurance();
+        let insuranceSelected = false;
+        let selectedAlmaInsurance = null;
+        let addToCartFlow = false;
+        let productDetails = JSON.parse(document.querySelector('.alma-widget-insurance .js-product-details').dataset.product);
+        let quantity = getQuantity();
+        let almaEligibilityAnswer = false;
+
         //Insurance
         $("body").on("hidden.bs.modal", "#blockcart-modal", function (e) {
             removeInsurance();
@@ -41,245 +42,236 @@ let almaEligibilityAnswer = false;
         btnLoaders('start');
         onloadAddInsuranceInputOnProductAlma();
         if (typeof prestashop !== 'undefined') {
-            prestashop.on(
-                'updateProduct',
-                function (event) {
-                    let addToCart = document.querySelector('.add-to-cart');
+            prestashop.on('updateProduct', function (event) {
+                let addToCart = document.querySelector('.add-to-cart');
 
-                    if (event.event !== undefined) {
-                        quantity = getQuantity();
+                if (event.event !== undefined) {
+                    quantity = getQuantity();
+                }
+                if (event.eventType === 'updatedProductQuantity') {
+                    quantity = getQuantity();
+                    if (event.event) {
+                        quantity = event.event.target.value;
                     }
-                    if (event.eventType === 'updatedProductQuantity') {
-                        quantity = getQuantity();
-                        if (event.event) {
-                            quantity = event.event.target.value;
+                    removeInsurance();
+                }
+                if (event.eventType === 'updatedProductCombination') {
+                    removeInsurance();
+                }
+                if (typeof event.selectedAlmaInsurance !== 'undefined' && event.selectedAlmaInsurance !== null) {
+                    insuranceSelected = true;
+                    addInputsInsurance(event);
+                }
+                if (typeof event.selectedInsuranceData !== 'undefined' && event.selectedInsuranceData) {
+                    removeInputInsurance();
+                }
+                if (addToCartFlow) {
+                    addToCart.click();
+                    insuranceSelected = false;
+                    addToCartFlow = false;
+                }
+            });
+            prestashop.on('updatedProduct', function (data) {
+                // TODO:
+                //  - use data.product_details to load latest product details from the data-product attribute of the div
+                //  - fallback to #product-details[data-product] if for any reason we cannot find what we need in `data`
+                //  - have a last fallback to making our own AJAX call?
+
+                document.querySelector('.qty [name="qty"]').value = quantity;
+
+                productDetails = JSON.parse(document.querySelector('.alma-widget-insurance .js-product-details').dataset.product);
+                productDetails.quantity_wanted = parseInt(quantity);
+
+                document.querySelector('.alma-widget-insurance .js-product-details').dataset.product = JSON.stringify(productDetails);
+                refreshWidget();
+                addModalListenerToAddToCart();
+            });
+        }
+
+
+        function getQuantity() {
+            var quantity = 1;
+            if (document.querySelector('.qty [name="qty"]')) {
+                quantity = parseInt(document.querySelector('.qty [name="qty"]').value);
+            }
+            return quantity
+        }
+
+        function getSettingsInsurance() {
+            if (document.querySelector('#alma-widget-insurance-product-page')) {
+                return JSON.parse(document.querySelector('#alma-widget-insurance-product-page').dataset.almaInsuranceSettings);
+            }
+
+            return null;
+        }
+
+        function btnLoaders(action) {
+            const addBtn = $(".add-to-cart");
+            if (action === 'start') {
+                $('<div id="insuranceSpinner" class="spinner"></div>').insertBefore($(".add-to-cart i"));
+                addBtn.attr("disabled", "disabled");
+            }
+            if (action === 'stop') {
+                $(".spinner").remove();
+                addBtn.removeAttr("disabled");
+                addModalListenerToAddToCart();
+            }
+        }
+
+        // ** Add input insurance in form to add to cart **
+        function onloadAddInsuranceInputOnProductAlma() {
+            let currentResolve;
+
+            window.addEventListener('message', (e) => {
+                let widgetInsurance = document.getElementById('alma-widget-insurance-product-page');
+                if (e.data.type === 'almaEligibilityAnswer') {
+                    almaEligibilityAnswer = e.data.eligibilityCallResponseStatus.response.eligibleProduct;
+                    btnLoaders('stop');
+                    if (almaEligibilityAnswer) {
+                        prestashop.emit('updateProduct', {
+                            reason: {
+                                productUrl: window.location.href,
+                            }
+                        });
+                    } else {
+                        widgetInsurance.style.display = 'none';
+                        let addToCart = document.querySelector('.add-to-cart');
+                        if (addToCart) {
+                            addToCart.removeEventListener("click", insuranceListener)
                         }
-                        removeInsurance();
-                    }
-                    if (event.eventType === 'updatedProductCombination') {
-                        removeInsurance();
-                    }
-                    if (typeof event.selectedAlmaInsurance !== 'undefined' && event.selectedAlmaInsurance !== null) {
-                        insuranceSelected = true;
-                        addInputsInsurance(event);
-                    }
-                    if (typeof event.selectedInsuranceData !== 'undefined' && event.selectedInsuranceData) {
-                        removeInputInsurance();
-                    }
-                    if (addToCartFlow) {
-                        addToCart.click();
-                        insuranceSelected = false;
-                        addToCartFlow = false;
                     }
                 }
-            );
-            prestashop.on(
-                'updatedProduct',
-                function () {
-                    document.querySelector('.qty [name="qty"]').value = quantity;
-                    productDetails = JSON.parse(document.querySelector('.alma-widget-insurance .js-product-details').dataset.product);
-                    productDetails.quantity_wanted = parseInt(quantity);
-                    document.querySelector('.alma-widget-insurance .js-product-details').dataset.product = JSON.stringify(productDetails);
-                    refreshWidget();
-                    addModalListenerToAddToCart();
+                if (e.data.type === 'changeWidgetHeight') {
+                    widgetInsurance.style.height = e.data.widgetHeight + 'px';
                 }
-            );
+                if (e.data.type === 'getSelectedInsuranceData') {
+                    if (parseInt(document.querySelector('.qty [name="qty"]').value) !== quantity) {
+                        quantity = getQuantity();
+                    }
+                    insuranceSelected = true;
+                    selectedAlmaInsurance = e.data.selectedInsuranceData;
+                    prestashop.emit('updateProduct', {
+                        reason: {
+                            productUrl: window.location.href
+                        },
+                        selectedAlmaInsurance: selectedAlmaInsurance,
+                        selectedInsuranceData: e.data.declinedInsurance,
+                        selectedInsuranceQuantity: e.data.selectedInsuranceQuantity
+                    });
+                } else if (currentResolve) {
+                    currentResolve(e.data);
+                }
+            });
+        }
+
+        function refreshWidget() {
+            let cmsReference = createCmsReference(productDetails);
+            let priceAmount = productDetails.price_amount;
+            if (productDetails.price_amount === undefined) {
+                priceAmount = productDetails.price;
+            }
+            let staticPriceToCents = Math.round(priceAmount * 100);
+
+            quantity = productDetails.quantity_wanted;
+            if (productDetails.quantity_wanted <= 0) {
+                quantity = 1;
+            }
+
+            getProductDataForApiCall(cmsReference, staticPriceToCents, productDetails.name, settings.merchant_id, quantity, settings.cart_id, settings.session_id, insuranceSelected);
+        }
+
+        function createCmsReference(productDetails) {
+            if (productDetails.id_product !== null) {
+                if (productDetails.id_product_attribute <= '0') {
+                    return productDetails.id_product;
+                }
+
+                return productDetails.id_product + '-' + productDetails.id_product_attribute;
+            }
+
+            return undefined;
+        }
+
+        function addInputsInsurance(event) {
+            let formAddToCart = document.getElementById('add-to-cart-or-refresh');
+            let selectedInsuranceQuantity = event.selectedInsuranceQuantity;
+
+            if (selectedInsuranceQuantity > quantity) {
+                selectedInsuranceQuantity = quantity
+            }
+
+            handleInput('alma_id_insurance_contract', event.selectedAlmaInsurance.insuranceContractId, formAddToCart);
+            handleInput('alma_quantity_insurance', selectedInsuranceQuantity, formAddToCart);
+
+        }
+
+        function handleInput(inputName, value, form) {
+            let elementInput = document.getElementById(inputName);
+            if (elementInput == null) {
+                let input = document.createElement('input');
+                input.setAttribute('value', value);
+                input.setAttribute('name', inputName);
+                input.setAttribute('class', 'alma_insurance_input');
+                input.setAttribute('id', inputName);
+                input.setAttribute('type', 'hidden');
+
+                form.prepend(input);
+            } else {
+                elementInput.setAttribute('value', value);
+            }
+        }
+
+        function removeInsurance() {
+            resetInsurance();
+            insuranceSelected = false;
+            removeInputInsurance();
+        }
+
+        function removeInputInsurance() {
+            let inputsInsurance = document.getElementById('add-to-cart-or-refresh').querySelectorAll('.alma_insurance_input');
+            inputsInsurance.forEach((input) => {
+                input.remove();
+            });
+        }
+
+        function addModalListenerToAddToCart() {
+            if (settings.isAddToCartPopupActivated === true && almaEligibilityAnswer) {
+                const addToCart = getAddToCartButton();
+                if (addToCart) {
+                    // If we change the quantity the DOM is reloaded then we need to remove and add the listener again
+                    addToCart.removeEventListener("click", insuranceListener);
+                    addToCart.addEventListener("click", insuranceListener);
+                }
+            }
+        }
+
+        function getAddToCartButton() {
+            let addToCart = document.querySelector('button.add-to-cart');
+            // TODO: Ravate specific to generalise with selector configuration
+            if (!addToCart) {
+                addToCart = document.querySelector('.add-to-cart a, .add-to-cart button').first();
+            }
+
+            return addToCart;
+        }
+
+        function insuranceListener(event) {
+            if (!insuranceSelected) {
+                event.preventDefault();
+                event.stopPropagation();
+                openModal('popupModal', quantity);
+                insuranceSelected = true;
+                addToCartFlow = true;
+            }
+            insuranceSelected = false;
+        }
+
+        function handleInsuranceProductPage() {
+            if (productDetails.id === $('#alma-insurance-global').data('insurance-id')) {
+                //$('.product-prices').hide(); // To hide the price of the insurance product page
+                let tagInformationInsurance = '<div class="alert alert-info" id="alma-alert-insurance-product">' + $('#alma-insurance-global').data('message-insurance-page') + '</div>';
+                $(tagInformationInsurance).insertAfter('.product-variants');
+            }
         }
     });
 })(jQuery);
-
-function getQuantity() {
-    var quantity = 1;
-    if (document.querySelector('.qty [name="qty"]')) {
-        quantity = parseInt(document.querySelector('.qty [name="qty"]').value);
-    }
-    return quantity
-}
-
-function getSettingsInsurance() {
-    if (document.querySelector('#alma-widget-insurance-product-page')) {
-        return JSON.parse(document.querySelector('#alma-widget-insurance-product-page').dataset.almaInsuranceSettings);
-    }
-
-    return null;
-}
-
-function btnLoaders(action) {
-    const addBtn = $(".add-to-cart");
-    if (action === 'start') {
-        $('<div id="insuranceSpinner" class="spinner"></div>').insertBefore($(".add-to-cart i"));
-        addBtn.attr("disabled", "disabled");
-    }
-    if (action === 'stop') {
-        $(".spinner").remove();
-        addBtn.removeAttr("disabled");
-        addModalListenerToAddToCart();
-    }
-}
-
-// ** Add input insurance in form to add to cart **
-function onloadAddInsuranceInputOnProductAlma() {
-    let currentResolve;
-
-    window.addEventListener('message', (e) => {
-        let widgetInsurance = document.getElementById('alma-widget-insurance-product-page');
-        if (e.data.type === 'almaEligibilityAnswer') {
-            almaEligibilityAnswer = e.data.eligibilityCallResponseStatus.response.eligibleProduct;
-            btnLoaders('stop');
-            if (almaEligibilityAnswer) {
-                prestashop.emit('updateProduct', {
-                    reason:{
-                        productUrl: window.location.href,
-                    }
-                });
-            } else {
-                widgetInsurance.style.display = 'none';
-                let addToCart = document.querySelector('.add-to-cart');
-                if (addToCart) {
-                    addToCart.removeEventListener("click", insuranceListener)
-                }
-            }
-        }
-        if (e.data.type === 'changeWidgetHeight') {
-            widgetInsurance.style.height = e.data.widgetHeight + 'px';
-        }
-        if (e.data.type === 'getSelectedInsuranceData') {
-            if (parseInt(document.querySelector('.qty [name="qty"]').value) !== quantity) {
-                quantity = getQuantity();
-            }
-            insuranceSelected = true;
-            selectedAlmaInsurance = e.data.selectedInsuranceData;
-            prestashop.emit('updateProduct', {
-                reason:{
-                    productUrl: window.location.href
-                },
-                selectedAlmaInsurance: selectedAlmaInsurance,
-                selectedInsuranceData: e.data.declinedInsurance,
-                selectedInsuranceQuantity: e.data.selectedInsuranceQuantity
-            });
-        } else if (currentResolve) {
-            currentResolve(e.data);
-        }
-    });
-}
-
-function refreshWidget() {
-    let cmsReference = createCmsReference(productDetails);
-    let priceAmount = productDetails.price_amount;
-    if (productDetails.price_amount === undefined) {
-        priceAmount = productDetails.price;
-    }
-    let staticPriceToCents = Math.round(priceAmount * 100);
-
-    quantity = productDetails.quantity_wanted;
-    if (productDetails.quantity_wanted <= 0) {
-        quantity = 1;
-    }
-
-    getProductDataForApiCall(
-        cmsReference,
-        staticPriceToCents,
-        productDetails.name,
-        settings.merchant_id,
-        quantity,
-        settings.cart_id,
-        settings.session_id,
-        insuranceSelected
-    );
-}
-
-function createCmsReference(productDetails) {
-    if (productDetails.id_product !== null) {
-        if (productDetails.id_product_attribute <= '0') {
-            return productDetails.id_product;
-        }
-
-        return productDetails.id_product + '-' + productDetails.id_product_attribute;
-    }
-
-    return undefined;
-}
-
-function addInputsInsurance(event) {
-    let formAddToCart = document.getElementById('add-to-cart-or-refresh');
-    let selectedInsuranceQuantity = event.selectedInsuranceQuantity;
-
-    if (selectedInsuranceQuantity > quantity) {
-        selectedInsuranceQuantity = quantity
-    }
-
-    handleInput('alma_id_insurance_contract', event.selectedAlmaInsurance.insuranceContractId, formAddToCart);
-    handleInput('alma_quantity_insurance', selectedInsuranceQuantity, formAddToCart);
-
-}
-
-function handleInput(inputName, value, form) {
-    let elementInput = document.getElementById(inputName);
-    if (elementInput == null) {
-        let input = document.createElement('input');
-        input.setAttribute('value', value);
-        input.setAttribute('name', inputName);
-        input.setAttribute('class', 'alma_insurance_input');
-        input.setAttribute('id', inputName);
-        input.setAttribute('type', 'hidden');
-
-        form.prepend(input);
-    } else {
-        elementInput.setAttribute('value', value);
-    }
-}
-
-function removeInsurance() {
-    resetInsurance();
-    insuranceSelected = false;
-    removeInputInsurance();
-}
-
-function removeInputInsurance() {
-    let inputsInsurance = document.getElementById('add-to-cart-or-refresh').querySelectorAll('.alma_insurance_input');
-    inputsInsurance.forEach((input) => {
-        input.remove();
-    });
-}
-
-function addModalListenerToAddToCart() {
-    if (settings.isAddToCartPopupActivated === true && almaEligibilityAnswer) {
-        const addToCart = getAddToCartButton();
-        if (addToCart) {
-            // If we change the quantity the DOM is reloaded then we need to remove and add the listener again
-            addToCart.removeEventListener("click", insuranceListener);
-            addToCart.addEventListener("click", insuranceListener);
-        }
-    }
-}
-
-function getAddToCartButton() {
-    let addToCart = document.querySelector('button.add-to-cart');
-    // TODO: Ravate specific to generalise with selector configuration
-    if (!addToCart) {
-        addToCart = document.querySelector('.add-to-cart a, .add-to-cart button').first();
-    }
-
-    return addToCart;
-}
-
-function insuranceListener(event) {
-        if (!insuranceSelected) {
-            event.preventDefault();
-            event.stopPropagation();
-            openModal('popupModal', quantity);
-            insuranceSelected = true;
-            addToCartFlow = true;
-        }
-        insuranceSelected = false;
-}
-
-function handleInsuranceProductPage() {
-    if (productDetails.id === $('#alma-insurance-global').data('insurance-id')) {
-        //$('.product-prices').hide(); // To hide the price of the insurance product page
-        let tagInformationInsurance = '<div class="alert alert-info" id="alma-alert-insurance-product">' +
-            $('#alma-insurance-global').data('message-insurance-page')
-            + '</div>';
-        $(tagInformationInsurance).insertAfter('.product-variants');
-    }
-}

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -90,7 +90,7 @@
 
 
         function getQuantity() {
-            var quantity = 1;
+            let quantity = 1;
             if (document.querySelector('.qty [name="qty"]')) {
                 quantity = parseInt(document.querySelector('.qty [name="qty"]').value);
             }
@@ -106,14 +106,14 @@
         }
 
         function btnLoaders(action) {
-            const addBtn = $(".add-to-cart");
+            const $addBtn = $(".add-to-cart");
             if (action === 'start') {
                 $('<div id="insuranceSpinner" class="spinner"></div>').insertBefore($(".add-to-cart i"));
-                addBtn.attr("disabled", "disabled");
+                $addBtn.attr("disabled", "disabled");
             }
             if (action === 'stop') {
                 $(".spinner").remove();
-                addBtn.removeAttr("disabled");
+                $addBtn.removeAttr("disabled");
                 addModalListenerToAddToCart();
             }
         }
@@ -181,15 +181,16 @@
         }
 
         function createCmsReference(productDetails) {
-            if (productDetails.id_product !== null) {
-                if (productDetails.id_product_attribute <= '0') {
-                    return productDetails.id_product;
-                }
-
-                return productDetails.id_product + '-' + productDetails.id_product_attribute;
+            if (!productDetails.id_product) {
+                return
             }
 
-            return undefined;
+            // TODO: check why comparing to string value
+            if (productDetails.id_product_attribute <= '0') {
+                return productDetails.id_product;
+            }
+
+            return productDetails.id_product + '-' + productDetails.id_product_attribute;
         }
 
         function addInputsInsurance(event) {
@@ -202,7 +203,6 @@
 
             handleInput('alma_id_insurance_contract', event.selectedAlmaInsurance.insuranceContractId, formAddToCart);
             handleInput('alma_quantity_insurance', selectedInsuranceQuantity, formAddToCart);
-
         }
 
         function handleInput(inputName, value, form) {

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -43,7 +43,7 @@
         onloadAddInsuranceInputOnProductAlma();
         if (typeof prestashop !== 'undefined') {
             prestashop.on('updateProduct', function (event) {
-                let addToCart = document.querySelector('.add-to-cart');
+                let addToCart = getAddToCartButton();
 
                 if (event.event !== undefined) {
                     quantity = getQuantity();

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -95,8 +95,10 @@
                     return;
                 }
 
-                // There's a bug in some PS 1.7 versions where quantity_wanted is not set to the actual quantity value
-                AlmaInsurance.productDetails.quantity_wanted = getQuantity()
+                // There's a bug in some PS 1.7 versions where quantity_wanted is not set to the actual quantity value,
+                // while in later versions it's correctly set but the quantity input value is reset to 1
+                AlmaInsurance.productDetails.quantity_wanted = quantity
+                setQuantity(AlmaInsurance.productDetails.quantity_wanted)
 
                 refreshWidget();
                 addModalListenerToAddToCart();
@@ -106,10 +108,18 @@
 
         function getQuantity() {
             let quantity = 1;
-            if (document.querySelector('.qty [name="qty"]')) {
-                quantity = parseInt(document.querySelector('.qty [name="qty"]').value);
+
+            const qtyInput = document.querySelector('.qty [name="qty"]');
+            if (qtyInput) {
+                quantity = Number(qtyInput.value);
             }
+
             return quantity
+        }
+
+        function setQuantity(quantity) {
+            const qtyInput = document.querySelector('.qty [name="qty"]');
+            qtyInput.value = quantity;
         }
 
         function btnLoaders(action) {

--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -73,7 +73,7 @@
                 // Update product details data from the PrestaShop-sent data
                 if (data.product_details) {
                     const shadowDiv = document.createElement('div');
-                    shadowDiv.innerHTML = data.product_details;
+                    $(shadowDiv).html(data.product_details);
 
                     const psProductDetails = shadowDiv.querySelector('[data-product]');
                     if (!psProductDetails || !psProductDetails.dataset.product) {

--- a/alma/views/templates/hook/displayProductActions.tpl
+++ b/alma/views/templates/hook/displayProductActions.tpl
@@ -20,7 +20,13 @@
  * @copyright 2018-2024 Alma SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
  *}
-<div class="alma-widget-insurance" id="alma-widget-insurance-product-page" data-alma-insurance-settings="{$settingsInsurance}" style="height: 100%" >
-    <div id="product-details" class="js-product-details" data-product="{$product.embedded_attributes|json_encode}" style="display:none;"></div>
+<div class="alma-widget-insurance" id="alma-widget-insurance-product-page" style="height: 100%" >
+    {literal}
+    <script type="text/javascript">
+        window.AlmaInsurance = window.AlmaInsurance || { };
+        window.AlmaInsurance.settings = {/literal}{$settingsInsurance nofilter};{literal}
+        window.AlmaInsurance.productDetails = {/literal}{$productDetails nofilter};{literal}
+    </script>
+    {/literal}
     <iframe id="product-alma-iframe" src="{$iframeUrl}"></iframe>
 </div>


### PR DESCRIPTION
### Reason for change

The insurance integration conflicts with PrestaShop's product details pane on product pages, and prevents its display.

Fixes [ECOM-2155](https://linear.app/almapay/issue/ECOM-2155)

### Code changes

- Cleaned the JS global scope by moving all variables/functions into the self-executing function in `alma-product-insurance.js`
- Changed from JSON output into data attributes to JSON output into plain JavaScript objects in the global `window.AlmaInsurance` object
- Stopped trying to reload product details data from the DOM; using the data passed along the `updatedProduct` event by PrestaShop

### How to test

_As a reviewer, you are encouraged to test the PR locally._

- Load a product page for an insurance-eligible product
    👉 The insurance widget should be displayed
    👉 You should be able to switch from the product description to the product display panel
    👉 There should be no error in the console about `dataset.product` being `null`/`undefined`


### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] You understand the impact of this PR on existing code/features
- [X] The changes include adequate logging and Datadog traces
- [X] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
