### PR TITLE
Improve insurance integration stability & prevent unnecessary reloading of widget

### DIFF
--- a/alma/controllers/hook/DisplayProductActionsHookController.php
+++ b/alma/controllers/hook/DisplayProductActionsHookController.php
@@ -120,6 +120,8 @@ class DisplayProductActionsHookController extends FrontendHookController
             ? $productParams['id_product_attribute']
             : null;
 
+        $quantityWanted = isset($productParams['quantity_wanted']) ? $productParams['quantity_wanted'] : 1;
+
         $cmsReference = $this->insuranceHelper->createCmsReference($productId, $productAttributeId);
 
         $staticPrice = $this->productHelper->getPriceStatic($productId, $productAttributeId);
@@ -132,11 +134,12 @@ class DisplayProductActionsHookController extends FrontendHookController
             'productDetails' => $this->handleProductDetails($params),
             'settingsInsurance' => $this->handleSettings($merchantId),
             'iframeUrl' => sprintf(
-                '%s%s?cms_reference=%s&product_price=%s&product_name=%s&merchant_id=%s&customer_session_id=%s&cart_id=%s',
+                '%s%s?cms_reference=%s&product_price=%s&product_quantity=%s&product_name=%s&merchant_id=%s&customer_session_id=%s&cart_id=%s',
                 $this->adminInsuranceHelper->envUrl(),
                 ConstantsHelper::FO_IFRAME_WIDGET_INSURANCE_PATH,
                 $cmsReference,
                 $staticPriceInCents,
+                $quantityWanted,
                 $productName,
                 $merchantId,
                 $this->context->cookie->checksum,


### PR DESCRIPTION
### Reason for change

In some versions of PrestaShop (here, 1.7.2.4), the insurance widget is reloaded in an infinite loop:

https://github.com/user-attachments/assets/b9b2d58d-13bf-4440-b7d2-fd87d125d753

In some other versions (e.g. 1.7.0.6) the reloading only inexplicably happens once instead of infinitely, i.e. 2 consecutive loading of the widget, so 1 extra load.

The root cause for both seems to be the use of PrestaShop events paired with messaging management from the widget iframe.

As a side effect, the whole product details & add to cart section of the product page is reloaded unnecessarily, including our BNPL widget, which makes the sidebar's height jump up & down.

Fixes [ECOM-2184](https://linear.app/almapay/issue/ECOM-2184)

### Code changes

- Started by documenting existing code to better grasp its inner workings
- Then simplified it and refactored the control flow to isolate the code handling prestashop-initiated events from widget-initiated events. This way we only listen to prestashop events to trigger necessary refreshes, and handle widget events without reloading the PrestaShop UI unnecessarily.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

Before making the present changes, I noted different behaviours/bugs depending on different PS versions:
- 1.7.0.6
- 1.7.2.4
- 1.7.8.7

With this PR, the integration should behave the same in all versions and the following issues should not be visible anymore:
- **Insurance modale not always showing on add to cart event:**
    - Click on an insurance option in the widget: the modal opens up
    - Close the modal by choosing "I don't want to protect my purchase"
    - Click on "Add to cart": ❌ the modal does not open and the product is added to the cart immediately
- **Initial load of the widget happens twice:**
    - Open the page of an eligible product
    - ❌ The widget is displayed, and then reloaded once
        - This is noticeable as the BNPL widget will "blink" and the height of the right section thus changes temporarily
        - On PS 1.7.2.4, because of a different reloading behaviour from PS, the reload loop is infinite as seen on the above video
- **The modal sometimes "ignores" the quantity > 1**:
    -  Increase the quantity wanted for a product
    - Click on an insurance option **in the widget** (the bug does not show when clicking Add to Cart)
    - Click on "Protect my purchase" in the modal
        - ❌ The modal closes without offering to protect one or multiple products, despite the quantity being > 1

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] You understand the impact of this PR on existing code/features

### Non applicable
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

<!-- Move here non-applicable items of the checklist, if any -->