### PR TITLE
fix: issue with some translation in payment buttons

### DIFF
--- a/alma/lib/Helpers/PaymentOptionTemplateHelper.php
+++ b/alma/lib/Helpers/PaymentOptionTemplateHelper.php
@@ -172,7 +172,7 @@ class PaymentOptionTemplateHelper
 
         if ($isDeferred) {
             $templateVar['installmentText'] = sprintf(
-                $this->translationHelper->getTranslation('0 € today then %1$s on %2$s', 'PaymentOptionsHookController'),
+                $this->translationHelper->l('0 € today then %1$s on %2$s', 'PaymentOptionTemplateHelper'),
                 $this->priceHelper->formatPriceToCentsByCurrencyId(
                     $plans[0]['purchase_amount'] + $plans[0]['customer_fee']
                 ),

--- a/alma/lib/Helpers/PlanHelper.php
+++ b/alma/lib/Helpers/PlanHelper.php
@@ -128,18 +128,18 @@ class PlanHelper
             $plans[$keyPlan]['human_date'] = $this->dateHelper->getDateFormat($locale, $paymentPlan['due_date']);
 
             if (0 === $keyPlan) {
-                $plans[$keyPlan]['human_date'] = $this->translationHelper->getTranslation('Today', 'PaymentService');
+                $plans[$keyPlan]['human_date'] = $this->translationHelper->l('Today', 'PlanHelper');
                 continue;
             }
 
             if ($isPayNow) {
-                $plans[$keyPlan]['human_date'] = $this->translationHelper->getTranslation('Total', 'PaymentService');
+                $plans[$keyPlan]['human_date'] = $this->translationHelper->l('Total', 'PlanHelper');
                 continue;
             }
 
             if ($this->settingsHelper->isDeferredTriggerLimitDays($feePlans, $key)) {
                 $plans[$keyPlan]['human_date'] = sprintf(
-                    $this->translationHelper->getTranslation('%s month later', 'PaymentService'),
+                    $this->translationHelper->l('%s month later', 'PaymentService'),
                     $keyPlan
                 );
 

--- a/alma/lib/Helpers/TranslationHelper.php
+++ b/alma/lib/Helpers/TranslationHelper.php
@@ -51,7 +51,7 @@ class TranslationHelper
      *
      * @return mixed
      */
-    public function getTranslation($string, $file)
+    public function l($string, $file)
     {
         return $this->module->l($string, $file);
     }

--- a/alma/tests/Unit/Helper/PaymentOptionTemplateHelperTest.php
+++ b/alma/tests/Unit/Helper/PaymentOptionTemplateHelperTest.php
@@ -91,7 +91,7 @@ class PaymentOptionTemplateHelperTest extends TestCase
         $this->settingsHelperMock->shouldReceive('getModeActive')->andReturn('test');
         $this->settingsHelperMock->shouldReceive('getIdMerchant')->andReturn('merchantId');
         $this->configurationHelperMock->shouldReceive('isInPageEnabled')->andReturn(true);
-        $this->translationHelperMock->shouldReceive('getTranslation')->andReturn('My translation');
+        $this->translationHelperMock->shouldReceive('l')->andReturn('My translation');
         $this->priceHelperMock->shouldReceive('formatPriceToCentsByCurrencyId')->andReturn('110.00');
         $this->dateHelperMock->shouldReceive('getDateFormat')->andReturn('22/05/2024');
 
@@ -163,7 +163,7 @@ class PaymentOptionTemplateHelperTest extends TestCase
         $this->settingsHelperMock->shouldReceive('getModeActive')->andReturn('test');
         $this->settingsHelperMock->shouldReceive('getIdMerchant')->andReturn('merchantId');
         $this->configurationHelperMock->shouldReceive('isInPageEnabled')->andReturn(true);
-        $this->translationHelperMock->shouldReceive('getTranslation')->andReturn('My translation');
+        $this->translationHelperMock->shouldReceive('l')->andReturn('My translation');
         $this->priceHelperMock->shouldReceive('formatPriceToCentsByCurrencyId')->andReturn('110.00');
         $this->dateHelperMock->shouldReceive('getDateFormat')->andReturn('22/05/2024');
 

--- a/alma/tests/Unit/Helper/TranslationHelperTest.php
+++ b/alma/tests/Unit/Helper/TranslationHelperTest.php
@@ -34,6 +34,6 @@ class TranslationHelperTest extends TestCase
         $translationHelperBuilder = new TranslationHelperBuilder();
         $translationHelper = $translationHelperBuilder->getInstance();
 
-        $this->assertEquals('Today', $translationHelper->getTranslation('Today', 'PaymentService'));
+        $this->assertEquals('Today', $translationHelper->l('Today', 'PaymentService'));
     }
 }

--- a/alma/translations/en.php
+++ b/alma/translations/en.php
@@ -32,6 +32,7 @@ $_MODULE['<{alma}prestashop>alma_7bab99339291e7eea710b4a998e663de'] = 'Alma requ
 $_MODULE['<{alma}prestashop>alma_fbb47375d2272bef79f5722a183bf1ec'] = 'Alma requires the JSON PHP extension.';
 $_MODULE['<{alma}prestashop>alma_7fb83ba9cf3cc38857a2ddae98534d22'] = 'Alma requires OpenSSL >= 1.0.1';
 $_MODULE['<{alma}prestashop>modulefactorytest_5914ca153abaf8a2af61e13e7fe7e829'] = 'My wording to translate';
+$_MODULE['<{alma}prestashop>translationhelpertest_1dd1c5fb7f25cd41b291d43a89e3aefd'] = 'Today';
 $_MODULE['<{alma}prestashop>wrongcredentialsexception_cc76de47de858ac2fa2964f534ecfdfb'] = 'Could not connect to Alma using your API keys.';
 $_MODULE['<{alma}prestashop>wrongcredentialsexception_733b6ddadc31fd97174b0cfe69b584c9'] = 'Please double check your keys on your %1$sAlma dashboard%2$s.';
 $_MODULE['<{alma}prestashop>wrongparamsexception_8ec75b5f68c49d1d6541b1e318a8120d'] = 'Error(s) key(s): %1$s.';
@@ -139,7 +140,11 @@ $_MODULE['<{alma}prestashop>paymentvalidation_2ea09287a94f2bc88b459fc7d5a31b6b']
 $_MODULE['<{alma}prestashop>paymentvalidation_6f11098989b14063e0a4cfe362734850'] = 'Alma - %d monthly installments';
 $_MODULE['<{alma}prestashop>refundhelper_446ae76a36687f9dbc62430e7006ca91'] = 'We regret to inform you that there was an issue during the payment process, your Alma payment will be fully refunded. Please retry your payment to complete your order.';
 $_MODULE['<{alma}prestashop>refundhelper_448edd2d5c593906afa202847b8d79c0'] = 'We apologize for the inconvenience, but there was an issue during the payment process, and we were unable to refund your Alma payment. To fix this, we kindly ask you to contact our support team with your payment reference: %s. Our team will be happy to assist you in ensuring that you receive your full refund. Thank you for your cooperation.';
+$_MODULE['<{alma}prestashop>planhelper_1dd1c5fb7f25cd41b291d43a89e3aefd'] = 'Today';
+$_MODULE['<{alma}prestashop>planhelper_96b0141273eabab320119c467cdcaf17'] = 'Total';
+$_MODULE['<{alma}prestashop>planhelper_9bbd94e0a507283ae202812ea1bd6f20'] = '%s month later';
 $_MODULE['<{alma}prestashop>orderhelper_7960c85fd5916169fc5038a2192094f8'] = 'Error: Could not find Alma transaction';
+$_MODULE['<{alma}prestashop>paymentoptiontemplatehelper_9088921432b295dfe6f02863b2dc0ff8'] = '0 € today then %1$s on %2$s';
 $_MODULE['<{alma}prestashop>customfieldshelper_2c53dea2326232a2d867ddd1d2206aa0'] = 'Pay now by credit card';
 $_MODULE['<{alma}prestashop>customfieldshelper_300de0751d957421cc332ba21c43a598'] = 'Pay in %d installments';
 $_MODULE['<{alma}prestashop>customfieldshelper_726c61fad46c135efb4198820e5484ba'] = 'Buy now Pay in %d days';

--- a/alma/translations/fr.php
+++ b/alma/translations/fr.php
@@ -32,6 +32,7 @@ $_MODULE['<{alma}prestashop>alma_7bab99339291e7eea710b4a998e663de'] = 'Alma néc
 $_MODULE['<{alma}prestashop>alma_fbb47375d2272bef79f5722a183bf1ec'] = 'Alma nécessite l\'extension PHP JSON';
 $_MODULE['<{alma}prestashop>alma_7fb83ba9cf3cc38857a2ddae98534d22'] = 'Alma nécessite OpenSSL >= 1.0.1';
 $_MODULE['<{alma}prestashop>modulefactorytest_5914ca153abaf8a2af61e13e7fe7e829'] = 'Ma formulation à traduire';
+$_MODULE['<{alma}prestashop>translationhelpertest_1dd1c5fb7f25cd41b291d43a89e3aefd'] = 'Aujourd\'hui';
 $_MODULE['<{alma}prestashop>wrongcredentialsexception_cc76de47de858ac2fa2964f534ecfdfb'] = 'Impossible de se connecter à Alma en utilisant vos clés API.';
 $_MODULE['<{alma}prestashop>wrongcredentialsexception_733b6ddadc31fd97174b0cfe69b584c9'] = 'Veuillez vérifier vos clés sur votre tableau de bord %1$sAlma%2$s.';
 $_MODULE['<{alma}prestashop>wrongparamsexception_8ec75b5f68c49d1d6541b1e318a8120d'] = 'Clé(s) d\'erreur : %1$s.';
@@ -134,7 +135,11 @@ $_MODULE['<{alma}prestashop>paymentvalidation_2ea09287a94f2bc88b459fc7d5a31b6b']
 $_MODULE['<{alma}prestashop>paymentvalidation_6f11098989b14063e0a4cfe362734850'] = 'Alma - Paiement en %d fois';
 $_MODULE['<{alma}prestashop>refundhelper_446ae76a36687f9dbc62430e7006ca91'] = 'Nous avons le regret de vous informer qu\'il y a eu un problème lors du processus de paiement, votre paiement Alma sera entièrement remboursé. Veuillez réessayer votre paiement pour terminer votre commande.';
 $_MODULE['<{alma}prestashop>refundhelper_448edd2d5c593906afa202847b8d79c0'] = 'Nous nous excusons pour la gêne occasionnée, mais il y a eu un problème pendant le processus de paiement, et nous n\'avons pas été en mesure de vous rembourser votre paiement Alma. Pour résoudre ce problème, nous vous demandons de contacter notre équipe d\'assistance en indiquant la référence de votre paiement : %s. Notre équipe sera heureuse de vous aider à obtenir le remboursement intégral de votre paiement. Nous vous remercions de votre coopération.';
+$_MODULE['<{alma}prestashop>planhelper_1dd1c5fb7f25cd41b291d43a89e3aefd'] = 'Aujourd\'hui';
+$_MODULE['<{alma}prestashop>planhelper_96b0141273eabab320119c467cdcaf17'] = 'Total';
+$_MODULE['<{alma}prestashop>planhelper_9bbd94e0a507283ae202812ea1bd6f20'] = 'Dans %s mois';
 $_MODULE['<{alma}prestashop>orderhelper_7960c85fd5916169fc5038a2192094f8'] = 'Erreur : La transaction Alma n\'a pas pu être récupérée';
+$_MODULE['<{alma}prestashop>paymentoptiontemplatehelper_9088921432b295dfe6f02863b2dc0ff8'] = '0 € aujourd\'hui puis %1$s le %2$s';
 $_MODULE['<{alma}prestashop>customfieldshelper_2c53dea2326232a2d867ddd1d2206aa0'] = 'Payer maintenant par carte bancaire';
 $_MODULE['<{alma}prestashop>customfieldshelper_300de0751d957421cc332ba21c43a598'] = 'Payer en %d fois';
 $_MODULE['<{alma}prestashop>customfieldshelper_726c61fad46c135efb4198820e5484ba'] = 'Payer dans %d jours';


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2147/eurl-mecatera-word-in-english-in-the-checkout-module)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We created an helper to test some function with translations. But Prestashop doesn't handle the translation is the function doesn't named `->l()` I renamed our function with `->l()` to handle all our translation

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Install the FR language un the store `Translation > Add / Update a language > Add French`
Install our module and enable de Pay later (+15/+30)
Go to the front, change the langue in FR
Go to the checkout, select a pay later and see if the payment button pay later is well translated.

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)