### PR TITLE
Prevent crash when there is not quantity input on product page

### DIFF
--- a/alma/views/js/alma-product-insurance.js
+++ b/alma/views/js/alma-product-insurance.js
@@ -28,7 +28,6 @@
 
         let loaded = false;
         let insuranceSelected = false;
-        let selectedAlmaInsurance = null;
         let addToCartFlow = false;
         let quantity = getQuantity();
         let almaEligibilityAnswer = false;
@@ -105,11 +104,15 @@
         }
 
 
+        function getQuantityInput() {
+            return document.querySelector('.qty [name="qty"]');
+        }
+
         // Retrieve wanted product quantity from the quantity selector
         function getQuantity() {
             let quantity = 1;
 
-            const qtyInput = document.querySelector('.qty [name="qty"]');
+            const qtyInput = getQuantityInput();
             if (qtyInput) {
                 quantity = Number(qtyInput.value);
             }
@@ -126,8 +129,10 @@
                 quantity = 1;
             }
 
-            const qtyInput = document.querySelector('.qty [name="qty"]');
-            qtyInput.value = quantity;
+            const qtyInput = getQuantityInput();
+            if (qtyInput) {
+                qtyInput.value = quantity;
+            }
         }
 
         // Display/hide a spinner on the add to cart button
@@ -176,7 +181,8 @@
 
                 // Widget is sending us selected insurance data
                 case 'getSelectedInsuranceData':
-                    if (parseInt(document.querySelector('.qty [name="qty"]').value) !== quantity) {
+                    const qtyInput = getQuantityInput();
+                    if (qtyInput && parseInt(qtyInput.value) !== quantity) {
                         quantity = getQuantity();
                     }
 


### PR DESCRIPTION
### Reason for change

Some e-commerce merchants remove the quantity input from the product page because it does not make sense to purchase their products multiple times (e.g. bikes, sofas)

Our current insurance code crashes when this is the case.

Fixes [ECOM-2200](https://linear.app/almapay/issue/ECOM-2200)

### Code changes

- Simply check whether we find an actual input before trying to read its value

### How to test

_As a reviewer, you are encouraged to test the PR locally._

- Open a product page
- Remove the quantity input from the DOM using the developer tools
- Use the insurance widget & add a product to the cart : it should work


### Checklist for authors and reviewers

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)
