### PR TITLE
Fix wrong data types being sent to Insurance API

### DIFF
--- a/alma/lib/Model/CustomerModel.php
+++ b/alma/lib/Model/CustomerModel.php
@@ -59,7 +59,7 @@ class CustomerModel extends \CustomerCore
      */
     public function getBirthday()
     {
-        if ($this->birthday === '0000-00-00') {
+        if (strpos($this->birthday, '0000-00-00') !== false) {
             return null;
         }
 

--- a/alma/lib/Services/InsuranceApiService.php
+++ b/alma/lib/Services/InsuranceApiService.php
@@ -172,10 +172,10 @@ class InsuranceApiService
         try {
             $result = $this->almaApiClient->insurance->subscription(
                 $subscriptionData,
-                $order->id,
+                strval($order->id),
                 $idTransaction,
                 $this->context->cookie->checksum,
-                $order->id_cart
+                strval($order->id_cart)
             );
 
             if (isset($result['subscriptions'])) {
@@ -184,11 +184,12 @@ class InsuranceApiService
         } catch (\Exception  $e) {
             Logger::instance()->error(
                 sprintf(
-                    '[Alma] Error when subscribing insurance contract, message "%s", trace "%s", subscriptionData : "%s", idTransaction : "%s"',
+                    '[Alma] Error when subscribing insurance contract, message "%s", trace "%s", subscriptionData : "%s", idTransaction : "%s", API response: "%s"',
                     $e->getMessage(),
                     $e->getTraceAsString(),
                     json_encode($subscriptionData),
-                    $idTransaction
+                    $idTransaction,
+                    $e->response ? json_encode($e->response->json) : null
                 )
             );
         }


### PR DESCRIPTION
### Reason for change

In most recent versions of PrestaShop, order ID and cart ID gets passed as integers instead of string, and the default birthdate is now a DateTime instead of a Date.

Those differences in data types cause our API to reject our calls to create a subscripiton.

[Linear task](https://linear.app/almapay/issue/MPP-LINEAR_ISSUE_ID)

### Code changes

- Enforced string types for order/cart ID
- Changed how we detect PrestaShop's "empty" birth date to work with both Date (`0000-00-00`) and DateTime (`0000-00-00 00:00:00`)
- Improved error reporting


### How to test

_As a reviewer, you are encouraged to test the PR locally._

- Run on a 8.1.16/8.1.7 and buy a product with insurance: the insurance should be correctly activated upon checkout 


### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [X] You understand the impact of this PR on existing code/features
- [X] The changes include adequate logging and Datadog traces

### Non applicable

- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)
