### PR TITLE
feat: Send the endpoint_url during the upgrade

### DIFF
--- a/alma/controllers/front/cmsdataexport.php
+++ b/alma/controllers/front/cmsdataexport.php
@@ -89,7 +89,7 @@ class AlmaCmsDataExportModuleFrontController extends ModuleFrontController
         $cmsFeature = new CmsFeatures($this->cmsDataHelper->getCmsFeatureArray());
 
         $payload = $this->payloadFormatter->formatConfigurationPayload($cmsInfo, $cmsFeature);
-        $this->ajaxRenderAndExit(json_encode(['success' => $payload]));
+        $this->ajaxRenderAndExit(json_encode($payload));
     }
 
     /**

--- a/alma/lib/Helpers/CmsDataHelper.php
+++ b/alma/lib/Helpers/CmsDataHelper.php
@@ -140,12 +140,11 @@ class CmsDataHelper
             'alma_enabled' => (bool) (int) $this->settingsHelper->getKey(SettingsHelper::ALMA_FULLY_CONFIGURED), // clef fully configured
             'widget_cart_activated' => (bool) (int) $this->settingsHelper->getKey(CartEligibilityAdminFormBuilder::ALMA_SHOW_ELIGIBILITY_MESSAGE),
             'widget_product_activated' => (bool) (int) $this->settingsHelper->getKey(ProductEligibilityAdminFormBuilder::ALMA_SHOW_PRODUCT_ELIGIBILITY),
-            'used_fee_plans' => json_decode($this->settingsHelper->getKey(PnxAdminFormBuilder::ALMA_FEE_PLANS), true),
+            'used_fee_plans' => $this->getUsedFeePlans(),
             //'payment_method_position' => null, // not applicable - position is set in the used_fee_plans
             'in_page_activated' => (bool) (int) $this->settingsHelper->getKey(InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE),
             'log_activated' => (bool) (int) $this->settingsHelper->getKey(DebugAdminFormBuilder::ALMA_ACTIVATE_LOGGING),
             'excluded_categories' => $this->settingsHelper->getCategoriesExcludedNames(),
-            //'excluded_categories_activated' => '',// not applicable - it's not possible to disable the exclusion
             'specific_features' => [], // no specific features in Prestashop
             'country_restriction' => $this->getCountriesRestrictions(),
             'custom_widget_css' => (bool) $this->settingsHelper->getKey(ProductEligibilityAdminFormBuilder::ALMA_WIDGET_POSITION_SELECTOR),
@@ -158,7 +157,20 @@ class CmsDataHelper
      */
     private function getCountriesRestrictions()
     {
-        // TODO : Need to implement this method with the db ps_module_country
         return [];
+    }
+
+    /**
+     * @return array|null
+     */
+    private function getUsedFeePlans()
+    {
+        $feePlans = json_decode($this->settingsHelper->getKey(PnxAdminFormBuilder::ALMA_FEE_PLANS), true);
+
+        if (empty($feePlans)) {
+            return null;
+        }
+
+        return $feePlans;
     }
 }

--- a/alma/tests/Unit/Helper/CmsDataHelperTest.php
+++ b/alma/tests/Unit/Helper/CmsDataHelperTest.php
@@ -116,4 +116,38 @@ class CmsDataHelperTest extends TestCase
 
         $this->assertEquals($expected, $this->cmsDataHelper->getCmsFeatureArray());
     }
+
+    /**
+     * @return void
+     */
+    public function testGetCmsFeatureArrayWithFeePlansEmptyReturnNull()
+    {
+        $this->settingsHelper->method('getKey')->willReturnMap(
+            [
+                [SettingsHelper::ALMA_FULLY_CONFIGURED, null, false],
+                [CartEligibilityAdminFormBuilder::ALMA_SHOW_ELIGIBILITY_MESSAGE, null, false],
+                [ProductEligibilityAdminFormBuilder::ALMA_SHOW_PRODUCT_ELIGIBILITY, null, false],
+                [PnxAdminFormBuilder::ALMA_FEE_PLANS, null, '{}'],
+                [InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, null, true],
+                [DebugAdminFormBuilder::ALMA_ACTIVATE_LOGGING, null, true],
+                [ProductEligibilityAdminFormBuilder::ALMA_WIDGET_POSITION_SELECTOR, null, '#selectorCss'],
+            ]
+        );
+        $this->shopModel->method('isMultisite')->willReturn(false);
+        $expected = [
+            'alma_enabled' => false,
+            'widget_cart_activated' => false,
+            'widget_product_activated' => false,
+            'used_fee_plans' => null,
+            'in_page_activated' => true,
+            'log_activated' => true,
+            'excluded_categories' => null,
+            'specific_features' => [],
+            'country_restriction' => [],
+            'custom_widget_css' => (bool) '#selectorCss',
+            'is_multisite' => false,
+        ];
+
+        $this->assertEquals($expected, $this->cmsDataHelper->getCmsFeatureArray());
+    }
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2240/[-ps]-send-the-endpoint-url-during-the-upgrade-of-the-module)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
- We send the endpoint url during the update of the module 4.6.0
- We normalized the payload returned for the gather CMS data
- We return null in the used_fee_plans key if the array is empty

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
- Update the module in version 4.6.0 and see if the endpoint url is sent to Alma
- Check the data returned for Gather CMS Data without the `success` key
- Check the unit test about the data returned if used_fee_plans is an array empty

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->