### PR TITLE
fix: inject Module in OrderHelper to use translation function

### DIFF
--- a/alma/controllers/hook/DisplayRefundsHookController.php
+++ b/alma/controllers/hook/DisplayRefundsHookController.php
@@ -31,6 +31,7 @@ if (!defined('_PS_VERSION_')) {
 use Alma\API\Entities\Payment;
 use Alma\API\RequestError;
 use Alma\PrestaShop\Builders\Helpers\PriceHelperBuilder;
+use Alma\PrestaShop\Exceptions\OrderException;
 use Alma\PrestaShop\Exceptions\PaymentNotFoundException;
 use Alma\PrestaShop\Helpers\ClientHelper;
 use Alma\PrestaShop\Helpers\OrderHelper;
@@ -199,7 +200,11 @@ final class DisplayRefundsHookController extends AdminHookController
             throw new PaymentNotFoundException('Alma is not available');
         }
         $orderHelper = new OrderHelper();
-        $orderPayment = $orderHelper->ajaxGetOrderPayment($order);
+        try {
+            $orderPayment = $orderHelper->getOrderPayment($order);
+        } catch (OrderException $e) {
+            throw new PaymentNotFoundException($e->getMessage());
+        }
         $paymentId = $orderPayment->transaction_id;
         if (empty($paymentId)) {
             throw new PaymentNotFoundException("[Alma] paymentId doesn't exist");

--- a/alma/controllers/hook/StateHookController.php
+++ b/alma/controllers/hook/StateHookController.php
@@ -193,15 +193,14 @@ final class StateHookController extends AdminHookController
      *
      * @return void
      *
-     * @throws ParametersException
-     * @throws RequestException
-     * @throws \PrestaShopException
+     * @throws \Alma\API\Exceptions\ParametersException
+     * @throws \Alma\API\Exceptions\RequestException
      */
     private function refund($order)
     {
         if (SettingsHelper::isRefundEnabledByState()) {
             try {
-                $orderPayment = $this->orderHelper->ajaxGetOrderPayment($order);
+                $orderPayment = $this->orderHelper->getOrderPayment($order);
                 $idPayment = $orderPayment->transaction_id;
                 $this->orderHelper->checkIfIsOrderAlma($order);
 
@@ -224,14 +223,12 @@ final class StateHookController extends AdminHookController
      * @param \Order $order
      *
      * @return void
-     *
-     * @throws \PrestaShopException
      */
     private function triggerPayment($order)
     {
         if ($this->settingsHelper->isPaymentTriggerEnabledByState()) {
             try {
-                $orderPayment = $this->orderHelper->ajaxGetOrderPayment($order);
+                $orderPayment = $this->orderHelper->getOrderPayment($order);
                 $idPayment = $orderPayment->transaction_id;
                 $this->orderHelper->checkIfIsOrderAlma($order);
 

--- a/alma/lib/Helpers/OrderHelper.php
+++ b/alma/lib/Helpers/OrderHelper.php
@@ -51,6 +51,9 @@ class OrderHelper
      * @var array
      */
     private $orders;
+    /**
+     * @var \Module
+     */
     private $module;
 
     /**
@@ -60,6 +63,7 @@ class OrderHelper
 
     public function __construct()
     {
+        $this->module = \Module::getInstanceByName(ConstantsHelper::ALMA_MODULE_NAME);
         $this->defaultStatesExcluded = [6, 7, 8];
         $this->orders = [];
         $this->orderRepository = new OrderRepository();
@@ -72,6 +76,9 @@ class OrderHelper
      * @param string $endDate
      *
      * @return \Order[]
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
      */
     public function getOrdersByDate($startDate, $endDate)
     {
@@ -99,6 +106,8 @@ class OrderHelper
      * @param string $endDate
      *
      * @return array
+     *
+     * @throws \PrestaShopDatabaseException
      */
     public function getOrdersIdByDate($startDate, $endDate)
     {

--- a/alma/lib/Helpers/ShareOfCheckoutHelper.php
+++ b/alma/lib/Helpers/ShareOfCheckoutHelper.php
@@ -128,7 +128,9 @@ class ShareOfCheckoutHelper
      *
      * @return void
      *
-     * @throws RequestError
+     * @throws \Alma\API\RequestError
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
      */
     public function shareDays()
     {
@@ -489,6 +491,9 @@ class ShareOfCheckoutHelper
      * @param string $date
      *
      * @return array
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
      */
     public function getPayload($date)
     {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2266/groupe-h4-error-when-consulting-payments)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Inject Module Class in OrderHelper to use the l() function for the translation

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Make an order with valid order value at false and change the status of this order

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->
- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] You understand the impact of this PR on existing code/features


### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)