### PR TITLE
fix: unit test for context link issue from ps_checkout module

### DIFF
--- a/alma/lib/Helpers/ContextHelper.php
+++ b/alma/lib/Helpers/ContextHelper.php
@@ -59,11 +59,25 @@ class ContextHelper
     /**
      * @param ContextFactory $contextFactory
      * @param ModuleFactory $moduleFactory
+     *
+     * @throws \Alma\PrestaShop\Exceptions\AlmaException
      */
     public function __construct($contextFactory, $moduleFactory)
     {
         $this->contextLink = $contextFactory->getContextLink();
         $this->moduleName = $moduleFactory->getModuleName();
+    }
+
+    /**
+     * Created for unit test
+     *
+     * @param $contextLink
+     *
+     * @return void
+     */
+    public function setContextLink($contextLink)
+    {
+        $this->contextLink = $contextLink;
     }
 
     /**

--- a/alma/tests/Unit/Helper/ContextHelperTest.php
+++ b/alma/tests/Unit/Helper/ContextHelperTest.php
@@ -26,9 +26,6 @@ namespace Alma\PrestaShop\Tests\Unit\Helper;
 
 use Alma\PrestaShop\Builders\Helpers\ContextHelperBuilder;
 use Alma\PrestaShop\Exceptions\AlmaException;
-use Alma\PrestaShop\Factories\ContextFactory;
-use Alma\PrestaShop\Factories\ModuleFactory;
-use Alma\PrestaShop\Helpers\ContextHelper;
 use PHPUnit\Framework\TestCase;
 
 class ContextHelperTest extends TestCase
@@ -37,15 +34,30 @@ class ContextHelperTest extends TestCase
      * @var \Alma\PrestaShop\Helpers\ContextHelper
      */
     protected $contextHelper;
+    /**
+     * @var \Link
+     */
+    protected $contextLinkMock;
 
     public function setUp()
     {
+        $this->contextLinkMock = $this->createMock(\Link::class);
         $contextHelperBuilder = new ContextHelperBuilder();
         $this->contextHelper = $contextHelperBuilder->getInstance();
     }
 
-    public function testGetModuleLink()
+    public function tearDown()
     {
+        $this->contextHelper = null;
+        $this->contextLinkMock = null;
+    }
+
+    public function testGetModuleLinkReturnLink()
+    {
+        $this->contextHelper->setContextLink($this->contextLinkMock);
+        $base = $this->getBase(true, false);
+        $this->contextLinkMock->method('getModuleLink')
+            ->willReturn($base . 'module/alma/payment?key=general_1_0_0');
         $result = $this->contextHelper->getModuleLink(
             'payment',
             ['key' => 'general_1_0_0'],
@@ -55,66 +67,15 @@ class ContextHelperTest extends TestCase
             false
         );
 
-        $base = $this->getBase(true, false);
         $this->assertEquals($base . 'module/alma/payment?key=general_1_0_0', $result);
+    }
 
-        $result = $this->contextHelper->getModuleLink(
-            'payment',
-            ['key' => 'general_1_0_0'],
-            false,
-            null,
-            null,
-            false
-        );
-
-        $base = $this->getBase(false, false);
-        $this->assertEquals($base . 'module/alma/payment?key=general_1_0_0', $result);
-
-        $result = $this->contextHelper->getModuleLink(
-            'payment',
-            ['key' => 'general_1_0_0'],
-            false,
-            1,
-            null,
-            false
-        );
-
-        $base = $this->getBase(false, false);
-        $this->assertEquals($base . 'module/alma/payment?key=general_1_0_0', $result);
-
-        $result = $this->contextHelper->getModuleLink(
-            'payment',
-            ['key' => 'general_1_0_0'],
-            false,
-            1,
-            1,
-            false
-        );
-
-        $base = $this->getBase(false, false);
-        $this->assertEquals($base . 'module/alma/payment?key=general_1_0_0', $result);
-
-        $result = $this->contextHelper->getModuleLink(
-            'payment',
-            ['key' => 'general_1_0_0'],
-            false,
-            1,
-            1,
-            true
-        );
-
-        $base = $this->getBase(false, true);
-        $this->assertEquals($base . 'module/alma/payment?key=general_1_0_0', $result);
-
-        $contextFactory = \Mockery::mock(ContextFactory::class)->makePartial();
-        $contextFactory->shouldReceive('getContextLink')->andReturn(null);
-
-        $moduleFactory = \Mockery::mock(ModuleFactory::class)->makePartial();
-        $moduleFactory->shouldReceive('getModuleName')->andReturn('Alma');
-
+    public function testGetModuleLinkWithoutContextLinkAndThrowException()
+    {
+        $this->contextLinkMock = null;
+        $this->contextHelper->setContextLink($this->contextLinkMock);
         $this->expectException(AlmaException::class);
-        $contextHelper = \Mockery::mock(ContextHelper::class, [$contextFactory, $moduleFactory])->makePartial();
-        $contextHelper->getModuleLink(
+        $this->contextHelper->getModuleLink(
             'payment',
             ['key' => 'general_1_0_0'],
             false,


### PR DESCRIPTION
### Reason for change

Fix our unit test because an update of the module ps_checkout break our test who wasn't really unit

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/MPP-LINEAR_ISSUE_ID)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->