### PR TITLE
feat: Add position at checkout for GatherCMSData

### DIFF
--- a/alma/lib/Helpers/CmsDataHelper.php
+++ b/alma/lib/Helpers/CmsDataHelper.php
@@ -142,7 +142,7 @@ class CmsDataHelper
             'widget_cart_activated' => (bool) (int) $this->settingsHelper->getKey(CartEligibilityAdminFormBuilder::ALMA_SHOW_ELIGIBILITY_MESSAGE),
             'widget_product_activated' => (bool) (int) $this->settingsHelper->getKey(ProductEligibilityAdminFormBuilder::ALMA_SHOW_PRODUCT_ELIGIBILITY),
             'used_fee_plans' => $this->getUsedFeePlans(),
-            //'payment_method_position' => null, // not applicable - position is set in the used_fee_plans
+            'payment_method_position' => (int) $this->almaModuleModel->getPosition(),
             'in_page_activated' => (bool) (int) $this->settingsHelper->getKey(InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE),
             'log_activated' => (bool) (int) $this->settingsHelper->getKey(DebugAdminFormBuilder::ALMA_ACTIVATE_LOGGING),
             'excluded_categories' => $this->settingsHelper->getCategoriesExcludedNames(),

--- a/alma/tests/Unit/Helper/CmsDataHelperTest.php
+++ b/alma/tests/Unit/Helper/CmsDataHelperTest.php
@@ -86,110 +86,89 @@ class CmsDataHelperTest extends TestCase
     }
 
     /**
+     * @dataProvider getCmsFeatureArrayDataProvider
+     *
      * @return void
      */
-    public function testGetCmsFeatureArray()
+    public function testGetCmsFeatureArray($jsonFeePlans, $getPosition, $expected)
     {
         $this->settingsHelper->method('getKey')->willReturnMap(
             [
                 [SettingsHelper::ALMA_FULLY_CONFIGURED, null, false],
                 [CartEligibilityAdminFormBuilder::ALMA_SHOW_ELIGIBILITY_MESSAGE, null, false],
                 [ProductEligibilityAdminFormBuilder::ALMA_SHOW_PRODUCT_ELIGIBILITY, null, false],
-                [PnxAdminFormBuilder::ALMA_FEE_PLANS, null, '{"general_1_0_0":{"enabled":"1"}}'],
+                [PnxAdminFormBuilder::ALMA_FEE_PLANS, null, $jsonFeePlans],
                 [InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, null, true],
                 [DebugAdminFormBuilder::ALMA_ACTIVATE_LOGGING, null, true],
                 [ProductEligibilityAdminFormBuilder::ALMA_WIDGET_POSITION_SELECTOR, null, '#selectorCss'],
             ]
         );
         $this->shopModel->method('isMultisite')->willReturn(false);
-        $this->almaModuleModel->method('getPosition')->willReturn('4');
-        $expected = [
-            'alma_enabled' => false,
-            'widget_cart_activated' => false,
-            'widget_product_activated' => false,
-            'used_fee_plans' => ['general_1_0_0' => ['enabled' => '1']],
-            'payment_method_position' => 4,
-            'in_page_activated' => true,
-            'log_activated' => true,
-            'excluded_categories' => null,
-            'specific_features' => [],
-            'country_restriction' => [],
-            'custom_widget_css' => (bool) '#selectorCss',
-            'is_multisite' => false,
-        ];
+        $this->almaModuleModel->method('getPosition')->willReturn($getPosition);
 
         $this->assertEquals($expected, $this->cmsDataHelper->getCmsFeatureArray());
     }
 
     /**
-     * @return void
+     * @return array[]
      */
-    public function testGetCmsFeatureArrayWithFeePlansEmptyReturnNull()
+    public function getCmsFeatureArrayDataProvider()
     {
-        $this->settingsHelper->method('getKey')->willReturnMap(
-            [
-                [SettingsHelper::ALMA_FULLY_CONFIGURED, null, false],
-                [CartEligibilityAdminFormBuilder::ALMA_SHOW_ELIGIBILITY_MESSAGE, null, false],
-                [ProductEligibilityAdminFormBuilder::ALMA_SHOW_PRODUCT_ELIGIBILITY, null, false],
-                [PnxAdminFormBuilder::ALMA_FEE_PLANS, null, '{}'],
-                [InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, null, true],
-                [DebugAdminFormBuilder::ALMA_ACTIVATE_LOGGING, null, true],
-                [ProductEligibilityAdminFormBuilder::ALMA_WIDGET_POSITION_SELECTOR, null, '#selectorCss'],
-            ]
-        );
-        $this->shopModel->method('isMultisite')->willReturn(false);
-        $this->almaModuleModel->method('getPosition')->willReturn('3');
-        $expected = [
-            'alma_enabled' => false,
-            'widget_cart_activated' => false,
-            'widget_product_activated' => false,
-            'used_fee_plans' => null,
-            'payment_method_position' => 3,
-            'in_page_activated' => true,
-            'log_activated' => true,
-            'excluded_categories' => null,
-            'specific_features' => [],
-            'country_restriction' => [],
-            'custom_widget_css' => (bool) '#selectorCss',
-            'is_multisite' => false,
+        return [
+            'With fee plans and getPosition' => [
+                'jsonFeePlans' => '{"general_1_0_0":{"enabled":"1"}}',
+                'getPosition' => '4',
+                'expected' => [
+                    'alma_enabled' => false,
+                    'widget_cart_activated' => false,
+                    'widget_product_activated' => false,
+                    'used_fee_plans' => ['general_1_0_0' => ['enabled' => '1']],
+                    'payment_method_position' => 4,
+                    'in_page_activated' => true,
+                    'log_activated' => true,
+                    'excluded_categories' => null,
+                    'specific_features' => [],
+                    'country_restriction' => [],
+                    'custom_widget_css' => (bool) '#selectorCss',
+                    'is_multisite' => false,
+                ],
+            ],
+            'Without fee plans and with getPosition' => [
+                'jsonFeePlans' => '{}',
+                'getPosition' => '3',
+                'expected' => [
+                    'alma_enabled' => false,
+                    'widget_cart_activated' => false,
+                    'widget_product_activated' => false,
+                    'used_fee_plans' => null,
+                    'payment_method_position' => 3,
+                    'in_page_activated' => true,
+                    'log_activated' => true,
+                    'excluded_categories' => null,
+                    'specific_features' => [],
+                    'country_restriction' => [],
+                    'custom_widget_css' => (bool) '#selectorCss',
+                    'is_multisite' => false,
+                ],
+            ],
+            'With fee plans and without getPosition' => [
+                'jsonFeePlans' => '{"general_1_0_0":{"enabled":"1"}}',
+                'getPosition' => '',
+                'expected' => [
+                    'alma_enabled' => false,
+                    'widget_cart_activated' => false,
+                    'widget_product_activated' => false,
+                    'used_fee_plans' => ['general_1_0_0' => ['enabled' => '1']],
+                    'payment_method_position' => 0,
+                    'in_page_activated' => true,
+                    'log_activated' => true,
+                    'excluded_categories' => null,
+                    'specific_features' => [],
+                    'country_restriction' => [],
+                    'custom_widget_css' => (bool) '#selectorCss',
+                    'is_multisite' => false,
+                ],
+            ],
         ];
-
-        $this->assertEquals($expected, $this->cmsDataHelper->getCmsFeatureArray());
-    }
-
-    /**
-     * @return void
-     */
-    public function testGetCmsFeatureArrayWithPositionEmptyReturnZero()
-    {
-        $this->settingsHelper->method('getKey')->willReturnMap(
-            [
-                [SettingsHelper::ALMA_FULLY_CONFIGURED, null, false],
-                [CartEligibilityAdminFormBuilder::ALMA_SHOW_ELIGIBILITY_MESSAGE, null, false],
-                [ProductEligibilityAdminFormBuilder::ALMA_SHOW_PRODUCT_ELIGIBILITY, null, false],
-                [PnxAdminFormBuilder::ALMA_FEE_PLANS, null, '{"general_1_0_0":{"enabled":"1"}}'],
-                [InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, null, true],
-                [DebugAdminFormBuilder::ALMA_ACTIVATE_LOGGING, null, true],
-                [ProductEligibilityAdminFormBuilder::ALMA_WIDGET_POSITION_SELECTOR, null, '#selectorCss'],
-            ]
-        );
-        $this->shopModel->method('isMultisite')->willReturn(false);
-        $this->almaModuleModel->method('getPosition')->willReturn('');
-        $expected = [
-            'alma_enabled' => false,
-            'widget_cart_activated' => false,
-            'widget_product_activated' => false,
-            'used_fee_plans' => ['general_1_0_0' => ['enabled' => '1']],
-            'payment_method_position' => 0,
-            'in_page_activated' => true,
-            'log_activated' => true,
-            'excluded_categories' => null,
-            'specific_features' => [],
-            'country_restriction' => [],
-            'custom_widget_css' => (bool) '#selectorCss',
-            'is_multisite' => false,
-        ];
-
-        $this->assertEquals($expected, $this->cmsDataHelper->getCmsFeatureArray());
     }
 }

--- a/alma/tests/Unit/Helper/CmsDataHelperTest.php
+++ b/alma/tests/Unit/Helper/CmsDataHelperTest.php
@@ -102,11 +102,13 @@ class CmsDataHelperTest extends TestCase
             ]
         );
         $this->shopModel->method('isMultisite')->willReturn(false);
+        $this->almaModuleModel->method('getPosition')->willReturn('4');
         $expected = [
             'alma_enabled' => false,
             'widget_cart_activated' => false,
             'widget_product_activated' => false,
             'used_fee_plans' => ['general_1_0_0' => ['enabled' => '1']],
+            'payment_method_position' => 4,
             'in_page_activated' => true,
             'log_activated' => true,
             'excluded_categories' => null,
@@ -136,11 +138,49 @@ class CmsDataHelperTest extends TestCase
             ]
         );
         $this->shopModel->method('isMultisite')->willReturn(false);
+        $this->almaModuleModel->method('getPosition')->willReturn('3');
         $expected = [
             'alma_enabled' => false,
             'widget_cart_activated' => false,
             'widget_product_activated' => false,
             'used_fee_plans' => null,
+            'payment_method_position' => 3,
+            'in_page_activated' => true,
+            'log_activated' => true,
+            'excluded_categories' => null,
+            'specific_features' => [],
+            'country_restriction' => [],
+            'custom_widget_css' => (bool) '#selectorCss',
+            'is_multisite' => false,
+        ];
+
+        $this->assertEquals($expected, $this->cmsDataHelper->getCmsFeatureArray());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetCmsFeatureArrayWithPositionEmptyReturnZero()
+    {
+        $this->settingsHelper->method('getKey')->willReturnMap(
+            [
+                [SettingsHelper::ALMA_FULLY_CONFIGURED, null, false],
+                [CartEligibilityAdminFormBuilder::ALMA_SHOW_ELIGIBILITY_MESSAGE, null, false],
+                [ProductEligibilityAdminFormBuilder::ALMA_SHOW_PRODUCT_ELIGIBILITY, null, false],
+                [PnxAdminFormBuilder::ALMA_FEE_PLANS, null, '{"general_1_0_0":{"enabled":"1"}}'],
+                [InpageAdminFormBuilder::ALMA_ACTIVATE_INPAGE, null, true],
+                [DebugAdminFormBuilder::ALMA_ACTIVATE_LOGGING, null, true],
+                [ProductEligibilityAdminFormBuilder::ALMA_WIDGET_POSITION_SELECTOR, null, '#selectorCss'],
+            ]
+        );
+        $this->shopModel->method('isMultisite')->willReturn(false);
+        $this->almaModuleModel->method('getPosition')->willReturn('');
+        $expected = [
+            'alma_enabled' => false,
+            'widget_cart_activated' => false,
+            'widget_product_activated' => false,
+            'used_fee_plans' => ['general_1_0_0' => ['enabled' => '1']],
+            'payment_method_position' => 0,
             'in_page_activated' => true,
             'log_activated' => true,
             'excluded_categories' => null,

--- a/alma/tests/Unit/Model/AlmaModuleModelTest.php
+++ b/alma/tests/Unit/Model/AlmaModuleModelTest.php
@@ -106,7 +106,12 @@ class AlmaModuleModelTest extends TestCase
         ];
     }
 
-    public function testGetPosition()
+    /**
+     * @dataProvider getPositionDataProvider
+     *
+     * @return void
+     */
+    public function testGetPosition($hookModule, $expected)
     {
         $hookName = 'paymentOptions';
         if (version_compare(_PS_VERSION_, '1.7', '<')) {
@@ -122,32 +127,25 @@ class AlmaModuleModelTest extends TestCase
         )->willReturnSelf();
         $this->dbQueryMock->method('orderBy')->willReturnSelf();
         $this->dbMock->method('getRow')
-            ->willReturn(['position' => 3]);
+            ->willReturn($hookModule);
 
-        $this->assertEquals('3', $this->almaModuleModel->getPosition());
+        $this->assertEquals($expected, $this->almaModuleModel->getPosition());
     }
 
     /**
-     * @return void
+     * @return array[]
      */
-    public function testGetPositionWithQueryReturnFalse()
+    public function getPositionDataProvider()
     {
-        $hookName = 'paymentOptions';
-        if (version_compare(_PS_VERSION_, '1.7', '<')) {
-            $hookName = 'displayPayment';
-        }
-
-        $this->dbQueryMock->method('select')->willReturnSelf();
-        $this->dbQueryMock->method('from')->willReturnSelf();
-        $this->dbQueryMock->method('join')->willReturnSelf();
-        $this->dbQueryMock->method('where')->withConsecutive(
-            ['h.name = "' . pSQL($hookName) . '"'],
-            ['m.name = "' . pSQL('alma') . '"']
-        )->willReturnSelf();
-        $this->dbQueryMock->method('orderBy')->willReturnSelf();
-        $this->dbMock->method('getRow')
-            ->willReturn(false);
-
-        $this->assertEquals('', $this->almaModuleModel->getPosition());
+        return [
+            'With SQL return position' => [
+                'hookModule' => ['position' => 3],
+                'expected' => '3',
+            ],
+            'Without SQL return position' => [
+                'hookModule' => false,
+                'expected' => '',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2373/via-prestashop-get-alma-payment-positionranking-at-checkout)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We added function to getPosition of alma in hook paymentOptions for PS 1.7 and displayPayment for PS 16

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
BackOffice :
Install the module
Go to Design->position
Search the hook paymentOptions for PS1.7 or displayPayment for PS 1.6
Change the position of alma in the hook
Front:
Make Get of Gather CMS Data (with postman) and check the value of `payment_method_position`
Change the position and check again the return (in postman)

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->