### PR TITLE
Fix: Update HTML element in FrontHeaderHookController for better semantic structure

### DIFF
--- a/alma/controllers/hook/FrontHeaderHookController.php
+++ b/alma/controllers/hook/FrontHeaderHookController.php
@@ -492,6 +492,6 @@ TAG;
     {
         $settings = json_encode($this->settingsHelper->getInPageSettings());
 
-        return "<div id='alma-inpage-global' data-settings='{$settings}'></div>";
+        return "<meta id='alma-inpage-global' data-settings='{$settings}'></meta>";
     }
 }


### PR DESCRIPTION
## Reason for change

The current implementation uses a `<div>` element within the HTML `<head>` section to store Alma payment configuration data. This creates semantic HTML issues as `<div>` elements should not be placed in the `<head>` section. This incorrect placement causes Smarty template engine to attempt corrections, which breaks the data binding on the `<body>` element, ultimately causing payment methods and order validation to malfunction.

Issue : https://github.com/alma/alma-installments-prestashop/pull/634

## Code changes

- Replaced the `<div>` element with a `<meta>` element in the `almaInPageHeader()` method
- Maintained the same data structure and attributes while using a more semantically appropriate HTML element
- This change ensures proper HTML structure while preserving the functionality of storing Alma payment configuration

## How to test

1. Install the module on a PrestaShop installation
2. Configure Alma payment settings
3. Verify that the configuration data is properly loaded in the page source
4. Check that all payment methods are working correctly on the checkout page or or in the browser development bar, check that the body tag has the ID "order"
5. Complete a test order to ensure the order validation process works as expected
6. Verify that the HTML validation passes without Smarty making unwanted corrections

## Checklist for authors and reviewers

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [x] The changes maintain existing functionality while fixing the HTML semantic issue
- [x] You understand the impact of this PR on existing code/features
- [x] The fix resolves payment method functionality issues

## Non applicable

- The automated tests compliance
- Documentation updates (no API changes)
- Logging and Datadog traces (UI-only change)