### PR TITLE
fix: create AlmaObjectModel for compatibility with PS1.6 + remove unique key alma_payment_id

### DIFF
--- a/alma/lib/Model/AlmaBusinessDataModel.php
+++ b/alma/lib/Model/AlmaBusinessDataModel.php
@@ -25,16 +25,13 @@
 namespace Alma\PrestaShop\Model;
 
 use Alma\PrestaShop\Logger;
-use Alma\PrestaShop\Traits\ObjectModelTrait;
 
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-class AlmaBusinessDataModel extends \ObjectModel
+class AlmaBusinessDataModel extends AlmaObjectModel
 {
-    use ObjectModelTrait;
-
     /** @var int */
     public $id_alma_business_data;
 
@@ -102,6 +99,24 @@ class AlmaBusinessDataModel extends \ObjectModel
             return $db->getRow($query);
         } catch (\PrestaShopDatabaseException $e) {
             Logger::instance()->warning('Failed to fetch alma_business_data by cart ID: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * @param bool $auto_date
+     * @param bool $null_values
+     *
+     * @return bool|int|string
+     *
+     * @throws \PrestaShopDatabaseException
+     * @throws \PrestaShopException
+     */
+    public function add($auto_date = true, $null_values = false)
+    {
+        if (version_compare(_PS_VERSION_, '1.7.1.0', '<')) {
+            return $this->addWithFullyQualifiedNamespace($auto_date, $null_values);
+        } else {
+            return parent::add($auto_date, $null_values);
         }
     }
 }

--- a/alma/lib/Model/AlmaBusinessDataModel.php
+++ b/alma/lib/Model/AlmaBusinessDataModel.php
@@ -59,7 +59,7 @@ class AlmaBusinessDataModel extends AlmaObjectModel
         'fields' => [
             'id_cart' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'id_order' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
-            'alma_payment_id' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName'],
+            'alma_payment_id' => ['type' => self::TYPE_STRING, 'allow_null' => true, 'validate' => 'isGenericName'],
             'is_bnpl_eligible' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'plan_key' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName'],
         ],

--- a/alma/lib/Model/InsuranceProduct.php
+++ b/alma/lib/Model/InsuranceProduct.php
@@ -25,16 +25,12 @@
 
 namespace Alma\PrestaShop\Model;
 
-use Alma\PrestaShop\Traits\ObjectModelTrait;
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-class InsuranceProduct extends \ObjectModel
+class InsuranceProduct extends AlmaObjectModel
 {
-    use ObjectModelTrait;
-
     /** @var int Id */
     public $id_alma_insurance_product;
 

--- a/alma/lib/Repositories/AlmaBusinessDataRepository.php
+++ b/alma/lib/Repositories/AlmaBusinessDataRepository.php
@@ -47,8 +47,7 @@ class AlmaBusinessDataRepository
             `is_bnpl_eligible` tinyint(1) unsigned NOT NULL DEFAULT \'0\',
             `plan_key` varchar(255) NOT NULL,
             PRIMARY KEY (`id_alma_business_data`),
-            UNIQUE KEY `unique_id_cart` (`id_cart`),
-            UNIQUE KEY `unique_alma_payment_id` (`alma_payment_id`)
+            UNIQUE KEY `unique_id_cart` (`id_cart`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
 
         return \Db::getInstance()->execute($sql);

--- a/alma/lib/Repositories/AlmaBusinessDataRepository.php
+++ b/alma/lib/Repositories/AlmaBusinessDataRepository.php
@@ -47,7 +47,8 @@ class AlmaBusinessDataRepository
             `is_bnpl_eligible` tinyint(1) unsigned NOT NULL DEFAULT \'0\',
             `plan_key` varchar(255) NOT NULL,
             PRIMARY KEY (`id_alma_business_data`),
-            UNIQUE KEY `unique_id_cart` (`id_cart`)
+            UNIQUE KEY `unique_id_cart` (`id_cart`),
+            INDEX `idx_alma_payment_id` (`alma_payment_id`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
 
         return \Db::getInstance()->execute($sql);

--- a/alma/lib/Repositories/AlmaBusinessDataRepository.php
+++ b/alma/lib/Repositories/AlmaBusinessDataRepository.php
@@ -48,7 +48,7 @@ class AlmaBusinessDataRepository
             `plan_key` varchar(255) NOT NULL,
             PRIMARY KEY (`id_alma_business_data`),
             UNIQUE KEY `unique_id_cart` (`id_cart`),
-            INDEX `idx_alma_payment_id` (`alma_payment_id`)
+            UNIQUE KEY `unique_alma_payment_id` (`alma_payment_id`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
 
         return \Db::getInstance()->execute($sql);

--- a/alma/tests/Unit/Services/AlmaBusinessDataServiceTest.php
+++ b/alma/tests/Unit/Services/AlmaBusinessDataServiceTest.php
@@ -242,6 +242,28 @@ class AlmaBusinessDataServiceTest extends TestCase
     /**
      * @return void
      */
+    public function testRunOrderConfirmedBusinessEventWithGetByCartIdReturnFalse()
+    {
+        $orderId = '2';
+        $cartId = '3';
+        $this->almaBusinessDataRepositoryMock->expects($this->once())
+            ->method('updateByCartId')
+            ->with('id_order', $orderId, $cartId);
+        $this->almaBusinessDataModelMock->expects($this->once())
+            ->method('getByCartId')
+            ->with($cartId)
+            ->willReturn(false);
+        $this->clientModelMock->expects($this->never())
+            ->method('getClient');
+        $this->merchantsMock->expects($this->never())
+            ->method('sendOrderConfirmedBusinessEvent');
+        $this->loggerMock->expects($this->never())->method('error');
+        $this->assertNull($this->almaBusinessDataService->runOrderConfirmedBusinessEvent($orderId, $cartId));
+    }
+
+    /**
+     * @return void
+     */
     public function testRunCartInitiatedBusinessEvent()
     {
         $cartId = '1';


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2414/[-ps]-fix-merchant-business-event-for-ps-16)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
In old PS version the ObjectModel wasn't compatible 

Add AlmaObjectModel to fix the issue

Set alma_payment_id at null for the creation

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Up an infra with PS 1.6
Add product in cart
Check in db if the insert is right

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->