### PR TITLE
fix: Deduplicate business event calls

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -229,6 +229,8 @@ class Alma extends PaymentModule
      * @override
      *
      * @return bool
+     *
+     * @throws \PrestaShopException
      */
     public function install()
     {

--- a/alma/controllers/hook/ActionCartSaveHookController.php
+++ b/alma/controllers/hook/ActionCartSaveHookController.php
@@ -138,9 +138,7 @@ class ActionCartSaveHookController extends FrontendHookController
 
         $this->almaBusinessDataService->createTableIfNotExist();
 
-        if ($this->almaBusinessDataService->isAlmaBusinessDataTableExist() &&
-            !$this->almaBusinessDataService->isAlmaBusinessDataExistByCart($newCart->id)
-        ) {
+        if (!$this->almaBusinessDataService->isAlmaBusinessDataExistByCart($newCart->id)) {
             $this->almaBusinessDataService->runCartInitiatedBusinessEvent((string) $newCart->id);
         }
 

--- a/alma/controllers/hook/ActionCartSaveHookController.php
+++ b/alma/controllers/hook/ActionCartSaveHookController.php
@@ -136,7 +136,11 @@ class ActionCartSaveHookController extends FrontendHookController
         $baseCart = $this->contextCart;
         $newCart = $params['cart'];
 
-        if (!$this->almaBusinessDataService->isAlmaBusinessDataExistByCart($newCart->id)) {
+        $this->almaBusinessDataService->createTableIfNotExist();
+
+        if ($this->almaBusinessDataService->isAlmaBusinessDataTableExist() &&
+            !$this->almaBusinessDataService->isAlmaBusinessDataExistByCart($newCart->id)
+        ) {
             $this->almaBusinessDataService->runCartInitiatedBusinessEvent((string) $newCart->id);
         }
 

--- a/alma/controllers/hook/ActionValidateOrderHookController.php
+++ b/alma/controllers/hook/ActionValidateOrderHookController.php
@@ -81,7 +81,11 @@ class ActionValidateOrderHookController extends FrontendHookController
             return;
         }
 
-        $this->almaBusinessDataService->runOrderConfirmedBusinessEvent($order->id, $cart->id);
+        try {
+            $this->almaBusinessDataService->runOrderConfirmedBusinessEvent($order->id, $cart->id);
+        } catch (\PrestaShopException $e) {
+            Logger::instance()->error('[Alma] Error to connect business data service: ' . $e->getMessage());
+        }
 
         if ($this->insuranceHelper->isInsuranceActivated()) {
             try {

--- a/alma/lib/Repositories/AlmaBusinessDataRepository.php
+++ b/alma/lib/Repositories/AlmaBusinessDataRepository.php
@@ -36,6 +36,8 @@ class AlmaBusinessDataRepository
      * Creates table ps_alma_business_data
      *
      * @return bool
+     *
+     * @throws \PrestaShopException
      */
     public function createTable()
     {
@@ -51,6 +53,22 @@ class AlmaBusinessDataRepository
             UNIQUE KEY `unique_alma_payment_id` (`alma_payment_id`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
 
+        // For version less than 1.6.1.0 ObjectModel doesn't handle the allow_null attribute for set NULL value on alma_payment_id field
+        // We can't create UNIQUE KEY for alma_payment_id field
+        if (version_compare(_PS_VERSION_, '1.6.1.0', '<')) {
+            $sql = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'alma_business_data` (
+                `id_alma_business_data` int(10) NOT NULL AUTO_INCREMENT,
+                `id_cart` int(10) NOT NULL,
+                `id_order` int(10) DEFAULT NULL,
+                `alma_payment_id` varchar(255) DEFAULT NULL,
+                `is_bnpl_eligible` tinyint(1) unsigned NOT NULL DEFAULT \'0\',
+                `plan_key` varchar(255) NOT NULL,
+                PRIMARY KEY (`id_alma_business_data`),
+                UNIQUE KEY `unique_id_cart` (`id_cart`),
+                INDEX `idx_alma_payment_id` (`alma_payment_id`)
+            ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
+        }
+
         return \Db::getInstance()->execute($sql);
     }
 
@@ -62,6 +80,8 @@ class AlmaBusinessDataRepository
      * @param string $cartId
      *
      * @return bool
+     *
+     * @throws \PrestaShopException
      */
     public function updateByCartId($field, $value, $cartId)
     {
@@ -76,6 +96,8 @@ class AlmaBusinessDataRepository
      * @param string $where
      *
      * @return bool|void
+     *
+     * @throws \PrestaShopException
      */
     private function update($field, $value, $where = '')
     {
@@ -89,6 +111,18 @@ class AlmaBusinessDataRepository
             );
         } catch (\PrestaShopDatabaseException $e) {
             Logger::instance()->warning('Failed to update alma_business_data: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * @return array|bool|\mysqli_result|\PDOStatement|resource|void|null
+     */
+    public function checkIfTableExist()
+    {
+        try {
+            return \Db::getInstance()->executeS('SHOW TABLES LIKE "' . _DB_PREFIX_ . 'alma_business_data"');
+        } catch (\PrestaShopException $e) {
+            Logger::instance()->warning('Failed to check if alma_business_data table exist: ' . $e->getMessage());
         }
     }
 }

--- a/alma/lib/Services/AlmaBusinessDataService.php
+++ b/alma/lib/Services/AlmaBusinessDataService.php
@@ -92,6 +92,8 @@ class AlmaBusinessDataService
      * @param int $cartId
      *
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function runOrderConfirmedBusinessEvent($orderId, $cartId)
     {
@@ -140,8 +142,6 @@ class AlmaBusinessDataService
             $this->logger->error('[Alma] Error in CartInitiatedBusinessEvent constructor: ' . $e->getMessage());
         } catch (ClientException $e) {
             $this->logger->error('[Alma] Error Alma Client: ' . $e->getMessage());
-        } catch (\PrestaShopDatabaseException $e) {
-            $this->logger->error('[Alma] Error in PrestaShopDatabaseException : ' . $e->getMessage());
         } catch (\PrestaShopException $e) {
             $this->logger->error('[Alma] Error in PrestaShopException : ' . $e->getMessage());
         } catch (RequestException $e) {
@@ -163,8 +163,11 @@ class AlmaBusinessDataService
      * Return bool if the plans are eligible for BNPL without Pay Now
      *
      * @param Eligibility $plans
+     * @param $cartId
      *
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function saveBnplEligibleStatus($plans, $cartId)
     {
@@ -193,6 +196,8 @@ class AlmaBusinessDataService
      * @param int $cartId
      *
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function updateBnplEligibleStatus($isEligible, $cartId)
     {
@@ -204,6 +209,8 @@ class AlmaBusinessDataService
      * @param int $cartId
      *
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function updatePlanKey($planKey, $cartId)
     {
@@ -215,6 +222,8 @@ class AlmaBusinessDataService
      * @param int $cartId
      *
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function updateOrderId($orderId, $cartId)
     {
@@ -226,9 +235,33 @@ class AlmaBusinessDataService
      * @param int $cartId
      *
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function updateAlmaPaymentId($almaPaymentId, $cartId)
     {
         $this->almaBusinessDataRepository->updateByCartId('alma_payment_id', $almaPaymentId, $cartId);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAlmaBusinessDataTableExist()
+    {
+        return !empty($this->almaBusinessDataRepository->checkIfTableExist());
+    }
+
+    /**
+     * @return void
+     */
+    public function createTableIfNotExist()
+    {
+        if (!$this->isAlmaBusinessDataTableExist()) {
+            try {
+                $this->almaBusinessDataRepository->createTable();
+            } catch (\PrestaShopException $e) {
+                $this->logger->warning('[Alma] Error in create table alma_business_data: ' . $e->getMessage());
+            }
+        }
     }
 }

--- a/alma/tests/Unit/Services/AlmaBusinessDataServiceTest.php
+++ b/alma/tests/Unit/Services/AlmaBusinessDataServiceTest.php
@@ -395,6 +395,8 @@ class AlmaBusinessDataServiceTest extends TestCase
 
     /**
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function testUpdateBnplEligibleStatus()
     {
@@ -407,6 +409,8 @@ class AlmaBusinessDataServiceTest extends TestCase
 
     /**
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function testUpdatePlanKey()
     {
@@ -419,6 +423,8 @@ class AlmaBusinessDataServiceTest extends TestCase
 
     /**
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function testUpdateOrderId()
     {
@@ -431,6 +437,8 @@ class AlmaBusinessDataServiceTest extends TestCase
 
     /**
      * @return void
+     *
+     * @throws \PrestaShopException
      */
     public function testUpdateAlmaPaymentId()
     {
@@ -553,6 +561,66 @@ class AlmaBusinessDataServiceTest extends TestCase
                     ]),
                 ],
                 true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider almaBusinessDataTableDataProvider
+     *
+     * @return void
+     */
+    public function testIsAlmaBusinessDataTableExist($table, $expected)
+    {
+        $this->almaBusinessDataRepositoryMock->expects($this->once())
+            ->method('checkIfTableExist')
+            ->willReturn($table);
+        $this->assertEquals($expected, $this->almaBusinessDataService->isAlmaBusinessDataTableExist());
+    }
+
+    /**
+     * @dataProvider almaBusinessDataTableDataProvider
+     *
+     * @return void
+     */
+    public function testCreateTableIfNotExist($table, $tableExist)
+    {
+        $this->almaBusinessDataRepositoryMock->expects($this->once())
+            ->method('checkIfTableExist')
+            ->willReturn($table);
+        $expectCreateTableIfNotExist = $tableExist ? $this->never() : $this->once();
+        $this->almaBusinessDataRepositoryMock->expects($expectCreateTableIfNotExist)
+            ->method('createTable');
+        $this->assertNull($this->almaBusinessDataService->createTableIfNotExist());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateTableIfNotExistWithThrowPrestashopException()
+    {
+        $this->almaBusinessDataRepositoryMock->expects($this->once())
+            ->method('createTable')
+            ->willThrowException(new \PrestaShopException());
+        $this->loggerMock->expects($this->once())->method('warning');
+        $this->almaBusinessDataService->createTableIfNotExist();
+    }
+
+    /**
+     * @return array[]
+     */
+    public function almaBusinessDataTableDataProvider()
+    {
+        return [
+            'table exist' => [
+                [
+                    ['Tables_in_prestashop' => 'ps_alma_business_data'],
+                ],
+                true,
+            ],
+            'table not exist' => [
+                [],
+                false,
             ],
         ];
     }

--- a/alma/upgrade/upgrade-4.7.1.php
+++ b/alma/upgrade/upgrade-4.7.1.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+use Alma\PrestaShop\Helpers\ConstantsHelper;
+use Alma\PrestaShop\Logger;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @throws \Alma\PrestaShop\Exceptions\AlmaException
+ */
+function upgrade_module_4_7_1($module)
+{
+    /* @var \Alma $module */
+    require_once _PS_MODULE_DIR_ . 'alma/upgrade/autoload_upgrade.php';
+
+    // Retrieve the current version of the module before migration
+    $sql = 'SELECT version FROM ' . _DB_PREFIX_ . 'module WHERE name = "' . pSQL($module->name) . '"';
+    $currentVersion = Db::getInstance()->getValue($sql);
+
+    if (
+        Module::isEnabled($module->name)
+        && $currentVersion
+        && version_compare($currentVersion, '1.4.3', '>=')
+        && version_compare($currentVersion, '2.0.0', '<=')
+    ) {
+        return false;
+    }
+
+    //Start migration here
+
+    // Update table alma_business_data for Prestashop version less than 1.6.1.0
+    if (version_compare(_PS_VERSION_, '1.6.1.0', '<')) {
+        $sql = 'ALTER TABLE `' . _DB_PREFIX_ . 'alma_business_data`
+        DROP INDEX `unique_alma_payment_id`,
+        ADD INDEX `idx_alma_payment_id` (`alma_payment_id`);';
+
+        try {
+            return Db::getInstance()->execute($sql);
+        } catch (PrestaShopException $e) {
+            Logger::instance()->warning('[Alma] Error during migration table alma_business_data: ' . $e->getMessage());
+        }
+    }
+
+    if (version_compare(_PS_VERSION_, ConstantsHelper::PRESTASHOP_VERSION_1_7_0_2, '>')) {
+        Tools::clearAllCache();
+        Tools::clearXMLCache();
+    }
+
+    return true;
+}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2416/[prestashop]-deduplicate-business-event-calls)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We check before business event if table exist
If table doesn't exist we create it
If we can't create it we don't send the business event call

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Try to remove the table before to add product in cart and check if the table is created

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->