### PR TITLE
Use new payment endpoint for order status

### DIFF
--- a/alma/controllers/hook/StateHookController.php
+++ b/alma/controllers/hook/StateHookController.php
@@ -134,6 +134,8 @@ final class StateHookController extends AdminHookController
         }
 
         $order = new \Order($params['id_order']);
+
+        /** @var \OrderState $newStatus */
         $newStatus = $params['newOrderStatus'];
 
         switch ($newStatus->id) {
@@ -156,18 +158,7 @@ final class StateHookController extends AdminHookController
                 break;
         }
 
-        try {
-            $this->orderService->manageStatusUpdate($order, $newStatus);
-        } catch (\Exception $e) {
-            $this->almaLogger->info(
-                sprintf(
-                    'Impossible to update order status: Error : %s, Code : %s, Type : %s',
-                    $e->getMessage(),
-                    $e->getCode(),
-                    get_class($e)
-                )
-            );
-        }
+        $this->orderService->manageStatusUpdate($order, $newStatus);
     }
 
     /**

--- a/alma/exceptions/OrderServiceException.php
+++ b/alma/exceptions/OrderServiceException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Exceptions;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class OrderServiceException extends AlmaException
+{
+}

--- a/alma/lib/Helpers/ClientHelper.php
+++ b/alma/lib/Helpers/ClientHelper.php
@@ -31,6 +31,8 @@ if (!defined('_PS_VERSION_')) {
 use Alma;
 use Alma\API\Client;
 use Alma\API\Entities\Merchant;
+use Alma\API\Exceptions\ParametersException;
+use Alma\API\Exceptions\RequestException;
 use Alma\API\RequestError;
 use Alma\PrestaShop\Exceptions\ClientException;
 use Alma\PrestaShop\Logger;
@@ -50,12 +52,12 @@ class ClientHelper
     }
 
     /**
-     * @deprecated Use create in ClientFactory instead
-     *
      * @param $apiKey
      * @param $mode
      *
      * @return Client|null
+     *
+     * @deprecated Use create in ClientFactory instead
      */
     public static function createInstance($apiKey, $mode = null)
     {
@@ -147,18 +149,21 @@ class ClientHelper
     }
 
     /**
-     * @param string $orderExternalId
-     * @param array $data
+     * @param string $paymentId
+     * @param string $merchantOrderReference
+     * @param string $status
+     * @param bool|null $isShipped
      *
-     * @return null
+     * @return void
      *
-     * @throws Alma\API\Exceptions\ParametersException
-     * @throws Alma\API\Exceptions\RequestException
      * @throws ClientException
+     * @throws ParametersException
+     * @throws RequestError
+     * @throws RequestException
      */
-    public function sendOrderStatus($orderExternalId, $data)
+    public function sendOrderStatus($paymentId, $merchantOrderReference, $status, $isShipped = null)
     {
-        $this->getClientOrdersEndpoint()->sendStatus($orderExternalId, $data);
+        $this->getClientPaymentsEndpoint()->addOrderStatusByMerchantOrderReference($paymentId, $merchantOrderReference, $status, $isShipped);
     }
 
     /**

--- a/alma/lib/Services/OrderService.php
+++ b/alma/lib/Services/OrderService.php
@@ -24,9 +24,13 @@
 
 namespace Alma\PrestaShop\Services;
 
-use Alma\API\Entities\Payment;
-use Alma\PrestaShop\Exceptions\AlmaException;
+use Alma\API\Exceptions\ParametersException;
+use Alma\API\Exceptions\RequestException;
+use Alma\API\RequestError;
+use Alma\PrestaShop\Exceptions\ClientException;
+use Alma\PrestaShop\Exceptions\OrderServiceException;
 use Alma\PrestaShop\Helpers\ClientHelper;
+use Alma\PrestaShop\Logger;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -37,7 +41,11 @@ class OrderService
     /**
      * @var ClientHelper
      */
-    protected $clientHelper;
+    private $clientHelper;
+    /**
+     * @var Logger|mixed
+     */
+    private $logger;
 
     /**
      * @param ClientHelper $clientHelper
@@ -45,104 +53,122 @@ class OrderService
     public function __construct($clientHelper)
     {
         $this->clientHelper = $clientHelper;
+        $this->logger = Logger::instance();
     }
 
     /**
-     * @param \OrderCore $order
-     * @param \OrderStateCore $orderState
+     * Manage send at order status update
+     *
+     * @param \Order $order
+     * @param \OrderState $orderState
      *
      * @return void
-     *
-     * @throws AlmaException
-     * @throws \Alma\API\Exceptions\ParametersException
-     * @throws \Alma\API\Exceptions\RequestException
-     * @throws \Alma\API\RequestError
-     * @throws \Alma\PrestaShop\Exceptions\ClientException
      */
-    public function manageStatusUpdate($order, $orderState = null)
+    public function manageStatusUpdate($order, $orderState)
     {
         if ($order->module !== 'alma') {
             return;
         }
 
-        if (!$orderState) {
-            $orderState = $order->getCurrentOrderState();
-        }
+        try {
+            $stateName = $this->getStateName($orderState);
+            $paymentTransactionId = $this->getPaymentTransactionId($order);
+            $this->sendStatus(
+                $paymentTransactionId,
+                $order->reference,
+                $stateName,
+                $orderState->shipped
+            );
+        } catch (OrderServiceException $e) {
+            $this->logger->warning('Impossible to update order status: ' . $e->getMessage());
 
-        if (!$orderState) {
             return;
         }
-
-        $paymentTransactionId = $this->getPaymentTransactionId($order);
-        $almaPayment = $this->getAlmaPayment($paymentTransactionId, $order->reference);
-
-        $this->clientHelper->sendOrderStatus($almaPayment->orders[0]->id, [
-           'status' => $orderState->getFieldByLang('name'),
-           'is_shipped' => (bool) $orderState->shipped,
-       ]);
     }
 
     /**
-     * @param \OrderCore $order
+     * Call the clientHelper to send the order status and handle the exceptions
+     *
+     * @param $paymentTransactionId
+     * @param $reference
+     * @param $stateName
+     * @param $shipped
+     *
+     * @return void
+     *
+     * @throws OrderServiceException
+     */
+    private function sendStatus($paymentTransactionId, $reference, $stateName, $shipped)
+    {
+        try {
+            $this->clientHelper->sendOrderStatus($paymentTransactionId, $reference, $stateName, $shipped);
+
+            return;
+        } catch (ClientException $e) {
+            $errorMessage = $e->getMessage();
+        } catch (ParametersException $e) {
+            $errorMessage = $e->getMessage();
+        } catch (RequestException $e) {
+            $errorMessage = $e->getMessage();
+        } catch (RequestError $e) {
+            $errorMessage = $e->getMessage();
+        }
+        $this->logger->warning('Error while sending order status: ' . $errorMessage);
+        throw new OrderServiceException('Error while sending order status');
+    }
+
+    /**
+     * Get the order state name
+     *
+     * @param \OrderState $orderState
+     *
+     * @return mixed
+     *
+     * @throws OrderServiceException
+     */
+    private function getStateName($orderState)
+    {
+        try {
+            return $orderState->getFieldByLang('name');
+        } catch (\PrestaShopException $e) {
+            $this->logger->warning('Error while getting order state name: ' . $e->getMessage());
+            throw new OrderServiceException('Error while getting order state name');
+        }
+    }
+
+    /**
+     * Extract Alma payment Id from Order transaction_id property
+     *
+     * @param \Order $order
      *
      * @return string
      *
-     * @throws AlmaException
+     * @throws OrderServiceException
      */
-    public function getPaymentTransactionId($order)
+    private function getPaymentTransactionId($order)
     {
-        // Retrieve the order Status from Alma
+        /** @var \OrderPayment $payments */
         $payments = $order->getOrderPayments();
 
         if (count($payments) === 0) {
-            throw new AlmaException(sprintf('No payment found for order "%s"', $order->id));
+            throw new OrderServiceException(sprintf('No payment found for order "%s"', $order->id));
+        }
+        if (empty($payments[0]->transaction_id)) {
+            throw new OrderServiceException(sprintf('No transaction ID found for order "%s"', $order->id));
         }
 
         return $payments[0]->transaction_id;
     }
 
     /**
-     * @param string $paymentTransactionId
+     * You can set a custom logger generally use for testing purpose
      *
-     * @return Payment
-     *
-     * @throws AlmaException
-     * @throws \Alma\API\RequestError
-     * @throws \Alma\PrestaShop\Exceptions\ClientException
-     */
-    public function getAlmaPayment($paymentTransactionId, $orderReference)
-    {
-        /**
-         * @var Payment $almaPayment
-         */
-        $almaPayment = $this->clientHelper->getPaymentByTransactionId($paymentTransactionId);
-
-        if (
-            !$almaPayment
-            || count($almaPayment->orders) == 0
-            || !isset($almaPayment->orders[0]->id)
-            || !isset($almaPayment->orders[0]->merchant_reference)
-        ) {
-            throw new AlmaException(sprintf('No alma payments found for transaction id "%s"', $paymentTransactionId));
-        }
-
-        $this->checkOrderReference($almaPayment->orders[0]->merchant_reference, $orderReference);
-
-        return $almaPayment;
-    }
-
-    /**
-     * @param string $merchantReference
-     * @param string $orderReference
+     * @param Logger $logger
      *
      * @return void
-     *
-     * @throws AlmaException
      */
-    public function checkOrderReference($merchantReference, $orderReference)
+    public function setCustomLogger($logger)
     {
-        if ($merchantReference !== $orderReference) {
-            throw new AlmaException(sprintf('Merchant reference from Alma order "%s" does not match order reference "%s"', $merchantReference, $orderReference));
-        }
+        $this->logger = $logger;
     }
 }

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -315,8 +315,6 @@ class PaymentValidation
                 $alma->payments->addOrder($payment->id, [
                     'merchant_reference' => $order->reference,
                 ]);
-
-                $this->orderService->manageStatusUpdate($order);
             } catch (\Exception $e) {
                 $msg = "[Alma] Error updating order reference {$order->reference}: {$e->getMessage()}";
                 Logger::instance()->error($msg);

--- a/alma/tests/Unit/Helper/ClientHelperTest.php
+++ b/alma/tests/Unit/Helper/ClientHelperTest.php
@@ -28,6 +28,7 @@ use Alma\API\Client;
 use Alma\API\ClientContext;
 use Alma\API\Endpoints\Configuration;
 use Alma\API\Endpoints\Orders;
+use Alma\API\Endpoints\Payments;
 use Alma\API\Entities\Payment;
 use Alma\API\Exceptions\ParametersException;
 use Alma\API\Exceptions\RequestException;
@@ -93,14 +94,14 @@ class ClientHelperTest extends TestCase
      */
     public function testSendOrderStatusWrongParameters()
     {
-        $orderEndpoint = Mockery::mock(Orders::class)->makePartial();
-        $orderEndpoint->shouldReceive('sendStatus')->andThrow(ParametersException::class);
+        $paymentEndpoint = Mockery::mock(Payments::class)->makePartial();
+        $paymentEndpoint->shouldReceive('addOrderStatusByMerchantOrderReference')->andThrow(ParametersException::class);
 
         $clientHelper = Mockery::mock(ClientHelper::class)->makePartial();
-        $clientHelper->shouldReceive('getClientOrdersEndpoint')->andReturn($orderEndpoint);
+        $clientHelper->shouldReceive('getClientPaymentsEndpoint')->andReturn($paymentEndpoint);
 
         $this->expectException(ParametersException::class);
-        $clientHelper->sendOrderStatus('transactionId', []);
+        $clientHelper->sendOrderStatus('transactionId', 'merchantOrderReference', 'status', true);
     }
 
     /**
@@ -109,14 +110,14 @@ class ClientHelperTest extends TestCase
      */
     public function testSendOrderStatusBadRequest()
     {
-        $orderEndpoint = Mockery::mock(Orders::class)->makePartial();
-        $orderEndpoint->shouldReceive('sendStatus')->andThrow(RequestException::class);
+        $paymentEndpoint = Mockery::mock(Payments::class)->makePartial();
+        $paymentEndpoint->shouldReceive('addOrderStatusByMerchantOrderReference')->andThrow(RequestException::class);
 
         $clientHelper = Mockery::mock(ClientHelper::class)->makePartial();
-        $clientHelper->shouldReceive('getClientOrdersEndpoint')->andReturn($orderEndpoint);
+        $clientHelper->shouldReceive('getClientOrdersEndpoint')->andReturn($paymentEndpoint);
 
         $this->expectException(RequestException::class);
-        $clientHelper->sendOrderStatus('transactionId', []);
+        $clientHelper->sendOrderStatus('transactionId', 'merchantOrderReference', 'status', true);
     }
 
     /**

--- a/alma/tests/Unit/Helper/ClientHelperTest.php
+++ b/alma/tests/Unit/Helper/ClientHelperTest.php
@@ -66,26 +66,26 @@ class ClientHelperTest extends TestCase
      * And there is no alma client
      * Then I expect a client exception
      */
-    public function testSendOrderEndpointNoAlmaClient()
+    public function testEndpointNoAlmaClient()
     {
         $this->clientHelperMock->shouldReceive('getAlmaClient')->andThrow(ClientException::class);
 
         $this->expectException(ClientException::class);
-        $this->clientHelperMock->getClientOrdersEndpoint();
+        $this->clientHelperMock->getClientPaymentsEndpoint();
     }
 
     /**
      * When i call an api
      * Then I expect a endpoint orders
      */
-    public function testSendOrderEndpoint()
+    public function testGetClientPaymentEndpoint()
     {
         $almaClient = new \stdClass();
-        $almaClient->orders = new Orders(Mockery::mock(ClientContext::class));
+        $almaClient->payments = new Payments(Mockery::mock(ClientContext::class));
 
         $this->clientHelperMock->shouldReceive('getAlmaClient')->andReturn($almaClient);
 
-        $this->assertInstanceOf(Orders::class, $this->clientHelperMock->getClientOrdersEndpoint());
+        $this->assertInstanceOf(Payments::class, $this->clientHelperMock->getClientPaymentsEndpoint());
     }
 
     /**
@@ -114,7 +114,7 @@ class ClientHelperTest extends TestCase
         $paymentEndpoint->shouldReceive('addOrderStatusByMerchantOrderReference')->andThrow(RequestException::class);
 
         $clientHelper = Mockery::mock(ClientHelper::class)->makePartial();
-        $clientHelper->shouldReceive('getClientOrdersEndpoint')->andReturn($paymentEndpoint);
+        $clientHelper->shouldReceive('getClientPaymentsEndpoint')->andReturn($paymentEndpoint);
 
         $this->expectException(RequestException::class);
         $clientHelper->sendOrderStatus('transactionId', 'merchantOrderReference', 'status', true);

--- a/alma/tests/Unit/Services/OrderServiceTest.php
+++ b/alma/tests/Unit/Services/OrderServiceTest.php
@@ -24,280 +24,133 @@
 
 namespace Alma\PrestaShop\Tests\Unit\Services;
 
-use Alma\API\Entities\Order;
-use Alma\API\Entities\Payment;
-use Alma\API\Exceptions\ParametersException;
-use Alma\API\Exceptions\RequestException;
-use Alma\PrestaShop\Builders\Services\OrderServiceBuilder;
-use Alma\PrestaShop\Exceptions\AlmaException;
 use Alma\PrestaShop\Helpers\ClientHelper;
+use Alma\PrestaShop\Logger;
 use Alma\PrestaShop\Services\OrderService;
 use PHPUnit\Framework\TestCase;
 
 class OrderServiceTest extends TestCase
 {
-    /**
-     * @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\Order|(\Order&\Mockery\LegacyMockInterface)|(\Order&\Mockery\MockInterface)
-     */
-    protected $orderMock;
-
-    /**
-     * @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\OrderState|(\OrderState&\Mockery\LegacyMockInterface)|(\OrderState&\Mockery\MockInterface)
-     */
-    protected $orderStateMock;
-
-    /**
-     * @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\OrderState|(\OrderState&\Mockery\LegacyMockInterface)|(\OrderState&\Mockery\MockInterface)
-     */
-    protected $psPaymentMock;
-
-    /**
-     * @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\OrderState|(\OrderState&\Mockery\LegacyMockInterface)|(\OrderState&\Mockery\MockInterface)
-     */
-    protected $clientHelperMock;
-
-    /**
-     * @var string
-     */
-    protected $orderReference;
-
-    /**
-     * @var OrderService
-     */
-    protected $orderService;
+    private $clientHelperMock;
+    private $loggerMock;
+    private $orderStateMock;
+    private $orderService;
 
     public function setUp()
     {
-        $this->orderMock = \Mockery::mock(\Order::class);
-        $this->orderStateMock = \Mockery::mock(\OrderState::class)->makePartial();
-        $this->orderStateMock->shouldReceive('getFieldByLang')->andReturn('orderState');
+        $this->clientHelperMock = $this->createMock(ClientHelper::class);
+        $this->loggerMock = $this->createMock(Logger::class);
+        $this->orderStateMock = $this->createMock(\OrderStateCore::class);
 
-        $this->psPaymentMock = \Mockery::mock(Payment::class);
-        $this->psPaymentMock->transaction_id = 'transactionId';
-
-        $this->clientHelperMock = \Mockery::mock(ClientHelper::class);
-        $this->orderReference = '123456';
-
-        $orderServiceBuilder = new OrderServiceBuilder();
-        $this->orderService = $orderServiceBuilder->getInstance();
-    }
-
-    public function testOrderNotAlma()
-    {
-        $this->orderMock->module = 'notAlma';
-
-        $this->assertNull($this->orderService->manageStatusUpdate($this->orderMock, $this->orderStateMock));
-    }
-
-    /**
-     * When I have no order payments
-     * Then I except an AlmaException
-     */
-    public function testGetPaymentTransactionIdNotFound()
-    {
-        $this->orderMock->shouldReceive('getOrderPayments')->andReturn([]);
-        $this->orderMock->id = 1;
-        $this->orderMock->module = 'alma';
-
-        $this->expectException(AlmaException::class);
-        $this->expectExceptionMessage('No payment found for order "1"');
-        $this->orderService->getPaymentTransactionId($this->orderMock);
-    }
-
-    /**
-     * When I have order payments
-     * Then I expect the transaction id
-     */
-    public function testGetPaymentTransactionIdFound()
-    {
-        $payment = new \stdClass();
-        $payment->transaction_id = 'transactionId';
-
-        $this->orderMock->shouldReceive('getOrderPayments')->andReturn([
-            $payment,
-        ]);
-        $this->orderMock->id = 1;
-        $this->orderMock->module = 'alma';
-
-        $this->orderService->getPaymentTransactionId($this->orderMock);
-        $this->assertEquals('transactionId', $this->orderService->getPaymentTransactionId($this->orderMock));
-    }
-
-    /**
-     * When i want to retrieve alma payments with a wrong transaction id
-     * Then i expect an Alma Exception
-     */
-    public function testGetAlmaPaymentNotFound()
-    {
-        $this->clientHelperMock->shouldReceive('getPaymentByTransactionId')->andReturn(null);
-
-        $orderService = \Mockery::mock(OrderService::class, [$this->clientHelperMock])->makePartial();
-
-        $this->expectException(AlmaException::class);
-        $this->expectExceptionMessage('No alma payments found for transaction id "transactionId"');
-        $orderService->getAlmaPayment('transactionId', $this->orderReference);
-    }
-
-    /**
-     * When i want to retrieve alma payments
-     * And The alma payment does not contains orders
-     * Then i expect an Alma Exception
-     */
-    public function testGetAlmaPaymentNoOrders()
-    {
-        $almaPayment = new \stdClass();
-        $almaPayment->orders = [];
-
-        $this->clientHelperMock->shouldReceive('getPaymentByTransactionId')->andReturn($almaPayment);
-
-        $orderService = \Mockery::mock(OrderService::class, [$this->clientHelperMock])->makePartial();
-
-        $this->expectException(AlmaException::class);
-        $this->expectExceptionMessage('No alma payments found for transaction id "transactionId"');
-        $orderService->getAlmaPayment('transactionId', $this->orderReference);
-    }
-
-    /**
-     * When i want to retrieve alma payments
-     * And The alma payment does contains order with no id
-     * Then i expect an Alma Exception
-     */
-    public function testGetAlmaPaymentNoIdOrders()
-    {
-        $order = new \stdClass();
-
-        $almaPayment = new \stdClass();
-        $almaPayment->orders = [$order];
-
-        $this->clientHelperMock->shouldReceive('getPaymentByTransactionId')->andReturn($almaPayment);
-
-        $orderService = \Mockery::mock(OrderService::class, [$this->clientHelperMock])->makePartial();
-
-        $this->expectException(AlmaException::class);
-        $this->expectExceptionMessage('No alma payments found for transaction id "transactionId"');
-        $orderService->getAlmaPayment('transactionId', $this->orderReference);
-    }
-
-    /**
-     * When i want to retrieve alma payments
-     * And The alma payment does contains order with no order reference
-     * Then i expect an Alma Exception
-     */
-    public function testGetAlmaPaymentNoReferenceOrders()
-    {
-        $order = new \stdClass();
-        $order->id = '987654';
-
-        $almaPayment = new \stdClass();
-        $almaPayment->orders = [$order];
-
-        $this->clientHelperMock->shouldReceive('getPaymentByTransactionId')->andReturn($almaPayment);
-
-        $orderService = \Mockery::mock(OrderService::class, [$this->clientHelperMock])->makePartial();
-
-        $this->expectException(AlmaException::class);
-        $this->expectExceptionMessage('No alma payments found for transaction id "transactionId"');
-        $orderService->getAlmaPayment('transactionId', $this->orderReference);
-    }
-
-    /**
-     * When i want to retrieve alma payments
-     * And The alma payment order has a wrong reference
-     * Then i expect an Alma Exception
-     */
-    public function testGetAlmaPaymentWrongReferenceOrders()
-    {
-        $order = new \stdClass();
-        $order->id = '987654';
-        $order->merchant_reference = '987654';
-
-        $almaPayment = new \stdClass();
-        $almaPayment->orders = [$order];
-
-        $this->clientHelperMock->shouldReceive('getPaymentByTransactionId')->andReturn($almaPayment);
-
-        $orderService = \Mockery::mock(OrderService::class, [$this->clientHelperMock])->makePartial();
-        $this->expectException(AlmaException::class);
-        $this->expectExceptionMessage('Merchant reference from Alma order "987654" does not match order reference "123456"');
-        $orderService->getAlmaPayment('transactionId', $this->orderReference);
-    }
-
-    /**
-     * When i call the send status api with wrong data
-     * Then i expect a Parameters exception
-     */
-    public function testManageStatusUpdateWithWrongData()
-    {
-        $order = new \stdClass();
-        $order->id = 'OrderId';
-
-        $almaPayment = new \stdClass();
-        $almaPayment->orders = [$order];
-
-        $this->clientHelperMock->shouldReceive('sendOrderStatus')->andThrow(new ParametersException());
-
-        $orderService = \Mockery::mock(OrderService::class, [$this->clientHelperMock])->makePartial();
-        $orderService->shouldReceive('getPaymentTransactionId')->andReturn('transactionId');
-        $orderService->shouldReceive('getAlmaPayment')->andReturn($almaPayment);
-
-        $this->orderMock->module = 'alma';
-
-        $this->expectException(ParametersException::class);
-        $orderService->manageStatusUpdate($this->orderMock, $this->orderStateMock);
-    }
-
-    /**
-     * When i call the send status api and the request fails
-     * Then i expect a Request exception
-     */
-    public function testManageStatusUpdateWithWrongQuery()
-    {
-        $order = new \stdClass();
-        $order->id = 'OrderId';
-
-        $almaPayment = new \stdClass();
-        $almaPayment->orders = [$order];
-
-        $this->clientHelperMock->shouldReceive('sendOrderStatus')->andThrow(new RequestException());
-
-        $orderService = \Mockery::mock(OrderService::class, [$this->clientHelperMock])->makePartial();
-        $orderService->shouldReceive('getPaymentTransactionId')->andReturn('transactionId');
-        $orderService->shouldReceive('getAlmaPayment')->andReturn($almaPayment);
-
-        $this->orderMock->module = 'alma';
-
-        $this->expectException(RequestException::class);
-        $orderService->manageStatusUpdate($this->orderMock, $this->orderStateMock);
-    }
-
-    public function testManageStatusUpdateWithFailure()
-    {
-        $this->clientHelperMock->shouldReceive('sendOrderStatus')->andReturn(new RequestException());
-    }
-
-    public function testManageStatusUpdateWithNoParamOrderState()
-    {
-        $this->orderMock = \Mockery::mock(\Order::class)->makePartial();
-        $this->orderMock->shouldReceive('getCurrentOrderState')->andReturn($this->orderStateMock);
-
-        $this->psPaymentMock = \Mockery::mock(Payment::class);
-        $this->psPaymentMock->transaction_id = 'transactionId';
-
-        $this->clientHelperMock = \Mockery::mock(ClientHelper::class);
-        $this->orderReference = '123456';
-
-        $orderServiceBuilder = new OrderServiceBuilder();
-        $this->orderService = $orderServiceBuilder->getInstance();
-
-        $this->assertNull($this->orderService->manageStatusUpdate($this->orderMock));
+        $this->orderService = new OrderService($this->clientHelperMock);
+        $this->orderService->setCustomLogger($this->loggerMock);
     }
 
     public function tearDown()
     {
-        $this->orderMock = null;
-        $this->orderStateMock = null;
-        $this->psPaymentMock = null;
         $this->clientHelperMock = null;
         $this->orderService = null;
+    }
+
+    /**
+     * Given no alma module
+     * When manageStatusUpdate is called
+     * Then direct return void
+     */
+    public function testNoAlmaModuleReturnVoid()
+    {
+        $order = new \OrderCore();
+        $this->assertNull($this->orderService->manageStatusUpdate($order, $this->orderStateMock));
+    }
+
+    /**
+     * Given an alma module
+     * and no order state
+     * When manageStatusUpdate is called
+     * Then log a warning
+     * and return void
+     */
+    public function testNoOrderStateReturnVoid()
+    {
+        $order = new \OrderCore();
+        $order->module = 'alma';
+        $this->loggerMock->expects($this->atLeast(1))->method('warning');
+        $this->orderStateMock
+            ->expects($this->once())
+            ->method('getFieldByLang')
+            ->willThrowException(new \PrestaShopException());
+        $this->assertNull($this->orderService->manageStatusUpdate($order, $this->orderStateMock));
+    }
+
+    /**
+     * Given an alma module and an order state
+     * and no payment
+     * When manageStatusUpdate is called
+     * and return void
+     */
+    public function testNoPaymentReturnVoid()
+    {
+        $order = $this->createMock(\Order::class);
+        $order->module = 'alma';
+        $order->method('getOrderPayments')->willReturn([]);
+        $this->orderStateWithStatus();
+        $this->assertNull($this->orderService->manageStatusUpdate($order, $this->orderStateMock));
+    }
+
+    /**
+     * Given an alma module and an order state
+     * and a payment without transaction ID
+     * When manageStatusUpdate is called
+     * and return void
+     */
+    public function testNoTransactionIdReturnVoid()
+    {
+        $orderPayment = $this->createMock(\OrderPayment::class);
+        $orderPayment->transaction_id = '';
+
+        $order = $this->createMock(\Order::class);
+        $order->module = 'alma';
+        $order->method('getOrderPayments')->willReturn([$orderPayment]);
+        $this->orderStateWithStatus();
+        $this->assertNull($this->orderService->manageStatusUpdate($order, $this->orderStateMock));
+    }
+
+    /**
+     * Given an alma module and an order state
+     * and a payment with a transaction ID
+     * When manageStatusUpdate is called
+     * Then Call Client Helper SendOrderStatus with params
+     */
+    public function testSendOrderStatusIsCalledWithParams()
+    {
+        $orderPayment = $this->createMock(\OrderPayment::class);
+        $orderPayment->transaction_id = 'payment_123456';
+
+        $order = $this->createMock(\Order::class);
+        $order->module = 'alma';
+        $order->reference = 'my_reference';
+        $order->method('getOrderPayments')->willReturn([$orderPayment]);
+
+        $this->orderStateWithStatus();
+        $this->orderStateMock->shipped = false;
+
+        $this->clientHelperMock
+            ->expects($this->once())
+            ->method('sendOrderStatus')
+            ->with('payment_123456', 'my_reference', 'My Status', false);
+
+        $this->assertNull($this->orderService->manageStatusUpdate($order, $this->orderStateMock));
+    }
+
+    /**
+     * Mock order state with status
+     *
+     * @return void
+     */
+    private function orderStateWithStatus()
+    {
+        $this->orderStateMock
+            ->method('getFieldByLang')
+            ->willReturn('My Status');
     }
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2385/[ps]-use-the-new-endpoint-for-order-status)

### Code changes

Remove get payment
Replace v2/orders/... enpoint by v1/payment/.../orders/.../status endpoint.


### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->