### PR TITLE
Fix force type to string for cms datatheme version

### DIFF
--- a/alma/lib/Helpers/ThemeHelper.php
+++ b/alma/lib/Helpers/ThemeHelper.php
@@ -74,18 +74,16 @@ class ThemeHelper
             if (file_exists($configFilePath)) {
                 $xmlContent = simplexml_load_file($configFilePath);
                 if ($xmlContent && isset($xmlContent->version)) {
-                    $themeVersion = (string) $xmlContent->version['value'];
+                    $themeVersion = isset($xmlContent->version['value']) ? $xmlContent->version['value'] : 'undefined';
                 }
             }
-
-            return $themeVersion;
         }
 
-        if (file_exists($themeConfigPath)) {
+        if (file_exists($themeConfigPath) && class_exists('\Symfony\Component\Yaml\Yaml')) {
             $themeConfig = \Symfony\Component\Yaml\Yaml::parseFile($themeConfigPath);
-            $themeVersion = $themeConfig['version'] ?: 'undefined';
+            $themeVersion = isset($themeConfig['version']) ? $themeConfig['version'] : 'undefined';
         }
 
-        return $themeVersion;
+        return (string) $themeVersion;
     }
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](feature/ecom-2490-ps-fix-force-type-to-string-for-cms_datatheme_version)

### Code changes

Add string type to getThemeVersion return.

Add isset to avoid fatal errors on non-existing index

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->