### PR TITLE
Fix/maj linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,9 @@ jobs:
       with:
         python-version: 3.12
 
+    - name: Run linter
+      run: task lint:ci
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -50,23 +53,6 @@ jobs:
       run: task test
       env:
         XDEBUG_MODE: coverage
-
-    - name: Build linter image
-      run: task lint:build
-
-    - name: Authenticating to Artifact Registry
-      uses: "docker/login-action@v3"
-      with:
-        registry: "${{ env.REGISTRY_NAME }}"
-        username: "oauth2accesstoken"
-        password: "${{ steps.gcloud-auth.outputs.access_token }}"
-
-    - name: Publish the Docker image to Google Artifact Registry
-      run: |
-        docker push "lint:ps"
-
-    - name: Run linter
-      run: task lint:ci
 
     - name: Install semgrep
       run: pip install semgrep

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,14 +45,28 @@ jobs:
           *.cache-from=type=gha
           *.cache-to=type=gha
 
-    - name: Run linter
-      run: task lint:ci
-
     - name: Run unit Tests and Coverage
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'hotfix') }}
       run: task test
       env:
         XDEBUG_MODE: coverage
+
+    - name: Build linter image
+      run: task lint:build
+
+    - name: Authenticating to Artifact Registry
+      uses: "docker/login-action@v3"
+      with:
+        registry: "${{ env.REGISTRY_NAME }}"
+        username: "oauth2accesstoken"
+        password: "${{ steps.gcloud-auth.outputs.access_token }}"
+
+    - name: Publish the Docker image to Google Artifact Registry
+      run: |
+        docker push "lint:ps"
+
+    - name: Run linter
+      run: task lint:ci
 
     - name: Install semgrep
       run: pip install semgrep

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -66,7 +66,7 @@ tasks:
   lint:ci:
     desc: Run linter within docker-compose for the CI
     deps:
-      - docker:build
+      - lint:build
     cmds:
       - ./scripts/lint-ci.sh
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,7 +68,7 @@ tasks:
     deps:
       - docker:build
     cmds:
-      - docker compose run --no-deps --rm --entrypoint "php" -w /var/www/html/modules prestashop alma/vendor/bin/php-cs-fixer fix --dry-run --diff alma
+      - ./scripts/lint-ci.sh
 
   lint:build:
     desc: Build lint container (php-cs-fixer)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,10 +89,15 @@ tasks:
     cmds:
       - ./scripts/lint-fix.sh
 
+  php-compatibility:build:
+    desc: Build php-compatibility container (phpcs)
+    cmds:
+      - docker build -t php-compatibility:ps -f php-compatibility.Dockerfile .
+
   php-compatibility:
     desc: Check compatibility code in PHP-CS container
     deps:
-      - lint:build
+      - php-compatibility:build
     cmds:
       - ./scripts/php-compatibility.sh
 

--- a/alma/.php-cs-fixer.dist.php
+++ b/alma/.php-cs-fixer.dist.php
@@ -1,9 +1,86 @@
 <?php
 
-$config = new PrestaShop\CodingStandards\CsFixer\Config();
+use PhpCsFixer\Finder;
+use PhpCsFixer\Config;
 
-/** @var \Symfony\Component\Finder\Finder $finder */
-$finder = $config->setUsingCache(true)->getFinder();
-$finder->in(__DIR__)->exclude('vendor');
+$finder = Finder::create()
+    ->in(__DIR__)
+    ->exclude('tests')
+    ->exclude('php8');
 
-return $config;
+$config = (new Config())->setRules([
+    '@Symfony' => true,
+    'concat_space' => [
+        'spacing' => 'one',
+    ],
+    'cast_spaces' => [
+        'space' => 'single',
+    ],
+    'error_suppression' => [
+        'mute_deprecation_error' => false,
+        'noise_remaining_usages' => false,
+        'noise_remaining_usages_exclude' => [],
+    ],
+    'function_to_constant' => false,
+    'no_alias_functions' => false,
+    'phpdoc_summary' => false,
+    'phpdoc_align' => [
+        'align' => 'left',
+    ],
+    'protected_to_private' => false,
+    'self_accessor' => false,
+    'yoda_style' => false,
+    'non_printable_character' => true,
+    'no_superfluous_phpdoc_tags' => false,
+    # to fix
+    'blank_line_after_opening_tag' => false,
+    'fully_qualified_strict_types' => false,
+    'array_indentation' => false,
+    'operator_linebreak' => false,
+    'trailing_comma_in_multiline' => false,
+    'phpdoc_align' => false,
+    'global_namespace_import' => false,
+    'visibility_required' => false,
+    'phpdoc_order' => false,
+    'phpdoc_separation' => false,
+    'phpdoc_trim' => false,
+    'phpdoc_trim_consecutive_blank_line_separation' => false,
+    'single_line_comment_spacing' => false,
+    'simple_to_complex_string_variable' => false,
+    'phpdoc_no_empty_return' => false,
+    'blank_line_before_statement' => false,
+    'no_null_property_initialization' => false,
+    'statement_indentation' => false,
+]);
+
+return $config->setUsingCache(false)->setFinder($finder);
+
+
+/*
+        $rules = [
+            '@Symfony' => true,
+            'concat_space' => [
+                'spacing' => 'one',
+            ],
+            'cast_spaces' => [
+                'space' => 'single',
+            ],
+            'error_suppression' => [
+                'mute_deprecation_error' => false,
+                'noise_remaining_usages' => false,
+                'noise_remaining_usages_exclude' => [],
+            ],
+            'function_to_constant' => false,
+            'no_alias_functions' => false,
+            'phpdoc_summary' => false,
+            'phpdoc_align' => [
+                'align' => 'left',
+            ],
+            'protected_to_private' => false,
+            'psr4' => false,
+            'self_accessor' => false,
+            'yoda_style' => null,
+            'non_printable_character' => true,
+            'no_superfluous_phpdoc_tags' => false,
+        ];
+        */

--- a/alma/.php-cs-fixer.dist.php
+++ b/alma/.php-cs-fixer.dist.php
@@ -54,33 +54,3 @@ $config = (new Config())->setRules([
 ]);
 
 return $config->setUsingCache(false)->setFinder($finder);
-
-
-/*
-        $rules = [
-            '@Symfony' => true,
-            'concat_space' => [
-                'spacing' => 'one',
-            ],
-            'cast_spaces' => [
-                'space' => 'single',
-            ],
-            'error_suppression' => [
-                'mute_deprecation_error' => false,
-                'noise_remaining_usages' => false,
-                'noise_remaining_usages_exclude' => [],
-            ],
-            'function_to_constant' => false,
-            'no_alias_functions' => false,
-            'phpdoc_summary' => false,
-            'phpdoc_align' => [
-                'align' => 'left',
-            ],
-            'protected_to_private' => false,
-            'psr4' => false,
-            'self_accessor' => false,
-            'yoda_style' => null,
-            'non_printable_character' => true,
-            'no_superfluous_phpdoc_tags' => false,
-        ];
-        */

--- a/alma/.php-cs-fixer.dist.php
+++ b/alma/.php-cs-fixer.dist.php
@@ -24,9 +24,6 @@ $config = (new Config())->setRules([
     'function_to_constant' => false,
     'no_alias_functions' => false,
     'phpdoc_summary' => false,
-    'phpdoc_align' => [
-        'align' => 'left',
-    ],
     'protected_to_private' => false,
     'self_accessor' => false,
     'yoda_style' => false,

--- a/dockerfile.md
+++ b/dockerfile.md
@@ -15,6 +15,8 @@ Used to run the `php-cs-fixer` command by the pre-commit hook or manually with t
 - ```task lint```
 - ```task lint:fix```
 
+- ## PHP Compatibility Dockerfile
+
 Used to run the `phpcs` command to check PHP compatibility by the pre-commit hook or manually with the command
 
 - ```task php-compatibility```

--- a/lint.Dockerfile
+++ b/lint.Dockerfile
@@ -1,20 +1,15 @@
-ARG PHP_IMG_TAG=5.6-alpine
+ARG PHP_IMG_TAG=8.3-alpine
 FROM php:${PHP_IMG_TAG} AS production
 
 WORKDIR /composer
 
+RUN apk add --no-cache php-tokenizer
 RUN apk add --no-cache composer
 RUN composer self-update
 RUN composer init -n --name="alma/php-cs" --description="php-cs" --type="library"
+
+# PHP CS Fixer
 RUN composer require friendsofphp/php-cs-fixer --no-interaction
-RUN composer require prestashop/php-coding-standards --no-interaction
-
-RUN composer config --no-interaction --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-RUN composer require squizlabs/php_codesniffer --no-interaction
-RUN composer require phpcompatibility/php-compatibility --no-interaction
-RUN composer require phpcompatibility/phpcompatibility-paragonie:"*" --no-interaction
-
-RUN /composer/vendor/bin/phpcs --config-set installed_paths /composer/vendor/escapestudios/symfony2-coding-standard,/composer/vendor/squizlabs/php_codesniffer,/composer/vendor/phpcompatibility/php-compatibility,/composer/vendor/phpcompatibility/phpcompatibility-paragonie
 
 WORKDIR /app
 

--- a/php-compatibility.Dockerfile
+++ b/php-compatibility.Dockerfile
@@ -1,0 +1,20 @@
+ARG PHP_IMG_TAG=5.6-alpine
+FROM php:${PHP_IMG_TAG} AS production
+
+WORKDIR /composer
+
+RUN apk add --no-cache composer
+RUN composer self-update
+RUN composer init -n --name="alma/php-cs" --description="php-cs" --type="library"
+
+RUN composer config --no-interaction --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+RUN composer require squizlabs/php_codesniffer --no-interaction
+RUN composer require phpcompatibility/php-compatibility --no-interaction
+RUN composer require phpcompatibility/phpcompatibility-paragonie:"*" --no-interaction
+
+RUN /composer/vendor/bin/phpcs --config-set installed_paths /composer/vendor/escapestudios/symfony2-coding-standard,/composer/vendor/squizlabs/php_codesniffer,/composer/vendor/phpcompatibility/php-compatibility,/composer/vendor/phpcompatibility/phpcompatibility-paragonie
+
+WORKDIR /app
+
+ENTRYPOINT ["/composer/vendor/bin/phpcs"]
+CMD ["--version"]

--- a/scripts/lint-ci.sh
+++ b/scripts/lint-ci.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker run --rm -v "$(pwd)/alma:/app/alma" \
+  lint:ps fix --config=alma/.php-cs-fixer.dist.php --dry-run --diff -v --using-cache=no --allow-risky=yes /app
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "Fix the errors before merging!"
+    exit 1
+fi

--- a/scripts/lint-fix.sh
+++ b/scripts/lint-fix.sh
@@ -5,7 +5,7 @@ if [[ ! -f "$CACHE_FILE" ]]; then
 fi
 
 docker run --rm -v "$(pwd)/alma:/app/alma" -v "$(pwd)/.php_cs.cache:/app/.php_cs.cache" \
-  lint:ps fix --config=alma/.php-cs-fixer.dist.php -v --using-cache=yes --cache-file=/app/.php_cs.cache /app
+  lint:ps fix --config=alma/.php-cs-fixer.dist.php -v --using-cache=yes --cache-file=/app/.php_cs.cache --allow-risky=yes /app
 EXIT_CODE=$?
 
 if [[ $EXIT_CODE -ne 0 ]]; then

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,7 +5,7 @@ if [[ ! -f "$CACHE_FILE" ]]; then
 fi
 
 docker run --rm -v "$(pwd)/alma:/app/alma" -v "$(pwd)/.php_cs.cache:/app/.php_cs.cache" \
-  lint:ps fix --config=alma/.php-cs-fixer.dist.php -v --dry-run --using-cache=yes --cache-file=/app/.php_cs.cache /app
+  lint:ps fix --config=alma/.php-cs-fixer.dist.php -v --dry-run --using-cache=yes --cache-file=/app/.php_cs.cache --allow-risky=yes /app
 EXIT_CODE=$?
 
 if [[ $EXIT_CODE -ne 0 ]]; then

--- a/scripts/php-compatibility.sh
+++ b/scripts/php-compatibility.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 docker run --rm -v "$(pwd)/alma:/app/alma" -v "$(pwd)/.php_cs.cache:/app/.php_cs.cache" --entrypoint /composer/vendor/bin/phpcs \
-  lint:ps -p alma --standard=PHPCompatibility -s --runtime-set testVersion 5.6-8.1 --ignore=\*/vendor/\*,\*/.coverage/\*
+  php-compatibility:ps -p alma --standard=PHPCompatibility -s --runtime-set testVersion 5.6-8.1 --ignore=\*/vendor/\*
 EXIT_CODE=$?
 
 if [[ $EXIT_CODE -ne 0 ]]; then

--- a/scripts/php-compatibility.sh
+++ b/scripts/php-compatibility.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 docker run --rm -v "$(pwd)/alma:/app/alma" -v "$(pwd)/.php_cs.cache:/app/.php_cs.cache" --entrypoint /composer/vendor/bin/phpcs \
-  php-compatibility:ps -p alma --standard=PHPCompatibility -s --runtime-set testVersion 5.6-8.1 --ignore=\*/vendor/\*
+  php-compatibility:ps -p alma --standard=PHPCompatibility -s --runtime-set testVersion 5.6-8.4 --ignore=\*/vendor/\*
 EXIT_CODE=$?
 
 if [[ $EXIT_CODE -ne 0 ]]; then

--- a/scripts/php-compatibility.sh
+++ b/scripts/php-compatibility.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 docker run --rm -v "$(pwd)/alma:/app/alma" -v "$(pwd)/.php_cs.cache:/app/.php_cs.cache" --entrypoint /composer/vendor/bin/phpcs \
-  php-compatibility:ps -p alma --standard=PHPCompatibility -s --runtime-set testVersion 5.6-8.4 --ignore=\*/vendor/\*
+  php-compatibility:ps -p alma --standard=PHPCompatibility -s --runtime-set testVersion 5.6-8.4 --ignore=\*/vendor/\*,\*/.coverage/\*
 EXIT_CODE=$?
 
 if [[ $EXIT_CODE -ne 0 ]]; then


### PR DESCRIPTION
### Reason for change

Fix prestashop linter to allow PHP8 code on the codebase.
Now, we must use a new logger with a modern interface. Our linter was working with an old version of php and crash if we use newer code. We need to use a new version of phpcsfixer.

[Linear task](https://linear.app/almapay/issue/ECOM-2503/fix-prestashop-linter)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

Test if this task works even with php7/8 code:
1. task lint
2. task lint:fix
3. task php-compatibility

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->