### PR TITLE
Feature/ecom 2368 ps explo lock in our module to avoid duplicate order in cas

### DIFF
--- a/alma/.php-cs-fixer.dist.php
+++ b/alma/.php-cs-fixer.dist.php
@@ -47,6 +47,7 @@ $config = (new Config())->setRules([
     'blank_line_before_statement' => false,
     'no_null_property_initialization' => false,
     'statement_indentation' => false,
+    'nullable_type_declaration_for_default_null_value' => false,
 ]);
 
 return $config->setUsingCache(false)->setFinder($finder);

--- a/alma/.php-cs-fixer.dist.php
+++ b/alma/.php-cs-fixer.dist.php
@@ -9,6 +9,7 @@ $finder = Finder::create()
 
 $config = (new Config())->setRules([
     '@Symfony' => true,
+    # To check
     'concat_space' => [
         'spacing' => 'one',
     ],
@@ -28,7 +29,9 @@ $config = (new Config())->setRules([
     'yoda_style' => false,
     'non_printable_character' => true,
     'no_superfluous_phpdoc_tags' => false,
-    # to fix
+    # Can't fix - rules no applicable to PHP 5.6
+    'nullable_type_declaration_for_default_null_value' => false,
+    # To fix
     'blank_line_after_opening_tag' => false,
     'fully_qualified_strict_types' => false,
     'array_indentation' => false,
@@ -47,7 +50,6 @@ $config = (new Config())->setRules([
     'blank_line_before_statement' => false,
     'no_null_property_initialization' => false,
     'statement_indentation' => false,
-    'nullable_type_declaration_for_default_null_value' => false,
 ]);
 
 return $config->setUsingCache(false)->setFinder($finder);

--- a/alma/controllers/front/validation.php
+++ b/alma/controllers/front/validation.php
@@ -68,6 +68,7 @@ class AlmaValidationModuleFrontController extends ModuleFrontController
 
     /**
      * @return void
+     * @throws \PrestaShopException
      */
     public function postProcess()
     {

--- a/alma/lib/Model/AlmaModuleModel.php
+++ b/alma/lib/Model/AlmaModuleModel.php
@@ -109,4 +109,12 @@ class AlmaModuleModel
 
         return $almaPosition['position'];
     }
+
+    /**
+     * @return false|\Module
+     */
+    public function getModule()
+    {
+        return $this->moduleProxy->getModule($this->moduleName);
+    }
 }

--- a/alma/lib/Proxy/CartProxy.php
+++ b/alma/lib/Proxy/CartProxy.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Proxy;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class CartProxy
+{
+    /**
+     * Check if order has already been placed with fix without cache for Prestashop versions < 1.7.7.0
+     *
+     * @param \Cart $cart
+     * @return bool
+     */
+    public static function orderExists($cart)
+    {
+        if (version_compare(_PS_VERSION_, '1.7.7.0', '<')) {
+            return (bool) \Db::getInstance()->getValue(
+                'SELECT count(*) FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_cart` = ' . (int) $cart->id,
+                false
+            );
+        }
+
+        return $cart->orderExists();
+    }
+}

--- a/alma/lib/Proxy/PaymentModuleProxy.php
+++ b/alma/lib/Proxy/PaymentModuleProxy.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Proxy;
+
+use Alma\PrestaShop\Factories\LoggerFactory;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class PaymentModuleProxy
+{
+    /**
+     * @var \Alma
+     */
+    private $module;
+
+    public function __construct($module)
+    {
+        $this->module = $module;
+    }
+
+    /**
+     * @param $id_cart
+     * @param $id_order_state
+     * @param $amount_paid
+     * @param $payment_method
+     * @param $message
+     * @param $extra_vars
+     * @param $currency_special
+     * @param $dont_touch_amount
+     * @param $secure_key
+     * @param \Alma\PrestaShop\Proxy\Shop|null $shop
+     * @return false|void
+     * @throws \PrestaShopException
+     */
+    public function validateOrder(
+        $id_cart,
+        $id_order_state,
+        $amount_paid,
+        $payment_method = 'Unknown',
+        $message = null,
+        $extra_vars = [],
+        $currency_special = null,
+        $dont_touch_amount = false,
+        $secure_key = false,
+        Shop $shop = null
+    ) {
+        $cart = new \Cart($id_cart);
+        if (CartProxy::orderExists($cart)) {
+            LoggerFactory::instance()->warning('Tentative de création d\'une commande en double pour le panier ID ' . $id_cart);
+            return false;
+        }
+
+        $this->module->validateOrder(
+            $id_cart,
+            $id_order_state,
+            $amount_paid,
+            $payment_method,
+            $message,
+            $extra_vars,
+            $currency_special,
+            $dont_touch_amount,
+            $secure_key,
+            $shop
+        );
+    }
+}

--- a/alma/lib/Proxy/PaymentModuleProxy.php
+++ b/alma/lib/Proxy/PaymentModuleProxy.php
@@ -25,6 +25,7 @@
 namespace Alma\PrestaShop\Proxy;
 
 use Alma\PrestaShop\Factories\LoggerFactory;
+use Alma\PrestaShop\Model\AlmaModuleModel;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -36,10 +37,21 @@ class PaymentModuleProxy
      * @var \Alma
      */
     private $module;
+    /**
+     * @var \Alma\PrestaShop\Proxy\CartProxy
+     */
+    private $cartProxy;
 
-    public function __construct($module)
+    public function __construct($module = null, $cartProxy = null)
     {
+        if (!$module) {
+            $module = (new AlmaModuleModel())->getModule();
+        }
         $this->module = $module;
+        if (!$cartProxy) {
+            $cartProxy = new CartProxy();
+        }
+        $this->cartProxy = $cartProxy;
     }
 
     /**
@@ -68,9 +80,8 @@ class PaymentModuleProxy
         $secure_key = false,
         Shop $shop = null
     ) {
-        $cart = new \Cart($id_cart);
-        if (CartProxy::orderExists($cart)) {
-            LoggerFactory::instance()->warning('Tentative de création d\'une commande en double pour le panier ID ' . $id_cart);
+        if ($this->cartProxy->orderExists($id_cart)) {
+            LoggerFactory::instance()->warning('[Alma] Attempting to create a duplicate order for cart ID ' . $id_cart);
             return false;
         }
 

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -88,6 +88,10 @@ class PaymentValidation
      * @var \Alma\PrestaShop\Proxy\PaymentModuleProxy
      */
     private $paymentModuleProxy;
+    /**
+     * @var \Alma\PrestaShop\Proxy\CartProxy
+     */
+    private $cartProxy;
 
     /**
      * @param ContextFactory $contextFactory
@@ -115,7 +119,8 @@ class PaymentValidation
 
         $this->orderService = $orderServiceBuilder->getInstance();
         $this->almaBusinessDataService = new AlmaBusinessDataService();
-        $this->paymentModuleProxy = new PaymentModuleProxy($this->module);
+        $this->cartProxy = new CartProxy();
+        $this->paymentModuleProxy = new PaymentModuleProxy();
     }
 
     /**
@@ -146,8 +151,9 @@ class PaymentValidation
      * @return string URL to redirect the customer to
      *
      * @throws MismatchException
-     * @throws PaymentValidationError
      * @throws PaymentValidationException
+     * @throws PaymentValidationError
+     * @throws \PrestaShopException
      */
     public function validatePayment($almaPaymentId)
     {
@@ -213,7 +219,7 @@ class PaymentValidation
             throw new PaymentValidationError($cart, 'cannot load customer');
         }
 
-        if (!CartProxy::orderExists($cart)) {
+        if (!$this->cartProxy->orderExists($cart->id)) {
             try {
                 $cartTotals = $this->toolsHelper->psRound((float) $this->getCartTotals($cart, $customer), 2);
             } catch (\Exception $e) {

--- a/alma/tests/Unit/Model/AlmaModuleModelTest.php
+++ b/alma/tests/Unit/Model/AlmaModuleModelTest.php
@@ -49,9 +49,14 @@ class AlmaModuleModelTest extends TestCase
      * @var \DbQuery
      */
     protected $dbQueryMock;
+    /**
+     * @var \Module
+     */
+    protected $moduleMock;
 
     public function setUp()
     {
+        $this->moduleMock = $this->createMock(\Module::class);
         $this->moduleProxyMock = $this->createMock(ModuleProxy::class);
         $this->dbQueryMock = $this->createMock(DbQuery::class);
         $this->dbMock = $this->createMock(\Db::class);
@@ -147,5 +152,17 @@ class AlmaModuleModelTest extends TestCase
                 'expected' => '',
             ],
         ];
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetModule()
+    {
+        $this->moduleProxyMock->expects($this->once())
+            ->method('getModule')
+            ->with(ConstantsHelper::ALMA_MODULE_NAME)
+            ->willReturn($this->moduleMock);
+        $this->almaModuleModel->getModule();
     }
 }

--- a/alma/tests/Unit/Proxy/CartProxyTest.php
+++ b/alma/tests/Unit/Proxy/CartProxyTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Proxy;
+
+use Alma\PrestaShop\Factories\CartFactory;
+use Alma\PrestaShop\Proxy\CartProxy;
+use PHPUnit\Framework\TestCase;
+
+class CartProxyTest extends TestCase
+{
+    /**
+     * @var CartProxy
+     */
+    private $cartProxyPsAfter1770;
+    /**
+     * @var CartFactory
+     */
+    private $cartFactoryMock;
+    /**
+     * @var \Cart
+     */
+    private $cartMock;
+
+    public function setUp()
+    {
+        $this->cartMock = $this->createMock(\Cart::class);
+        $this->cartFactoryMock = $this->createMock(CartFactory::class);
+        $this->cartProxy = new CartProxy($this->cartFactoryMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testOrderExistsAfterPs1770()
+    {
+        $this->cartProxy->setPsVersion('1.7.7.7');
+        $this->cartMock->id = 1;
+        $this->cartFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(1)
+            ->willReturn($this->cartMock);
+        $this->cartMock->expects($this->once())
+            ->method('orderExists')
+            ->willReturn(false);
+        $this->assertFalse($this->cartProxy->orderExists($this->cartMock->id));
+    }
+
+    /**
+     * @return void
+     */
+    public function testOrderExistsBeforePs1770()
+    {
+        $this->cartProxy->setPsVersion('1.7.6.7');
+        $this->cartMock->id = 1;
+        $this->cartFactoryMock->expects($this->never())
+            ->method('create')
+            ->with(1)
+            ->willReturn($this->cartMock);
+        $this->cartMock->expects($this->never())
+            ->method('orderExists')
+            ->willReturn(false);
+        $this->cartProxy->orderExists($this->cartMock->id);
+    }
+}

--- a/alma/tests/Unit/Proxy/PaymentModuleProxyTest.php
+++ b/alma/tests/Unit/Proxy/PaymentModuleProxyTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Proxy;
+
+use Alma\PrestaShop\Proxy\CartProxy;
+use Alma\PrestaShop\Proxy\PaymentModuleProxy;
+use PHPUnit\Framework\TestCase;
+
+class PaymentModuleProxyTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->cartProxyMock = $this->createMock(CartProxy::class);
+        $this->moduleMock = $this->createMock(\Alma::class);
+        $this->paymentModuleProxy = new PaymentModuleProxy(
+            $this->moduleMock,
+            $this->cartProxyMock
+        );
+    }
+
+    /**
+     * @throws \PrestaShopException
+     */
+    public function testValidateOrderWithOrderAlreadyExist()
+    {
+        $cartId = 1;
+        $this->cartProxyMock->expects($this->once())
+            ->method('orderExists')
+            ->with($cartId)
+            ->willReturn(true);
+        $this->moduleMock->expects($this->never())
+            ->method('validateOrder');
+        $this->assertFalse($this->paymentModuleProxy->validateOrder(
+            $cartId,
+            2,
+            10000,
+            'Alma - Pay now',
+            null,
+            ['transaction_id' => 'payment_id'],
+            1,
+            false,
+            'secure_key'
+        ));
+    }
+
+    /**
+     * @throws \PrestaShopException
+     */
+    public function testValidateOrderWithoutOrderAlreadyExist()
+    {
+        $cartId = 1;
+        $this->cartProxyMock->expects($this->once())
+            ->method('orderExists')
+            ->with($cartId)
+            ->willReturn(false);
+        $this->moduleMock->expects($this->once())
+            ->method('validateOrder');
+        $this->assertNull($this->paymentModuleProxy->validateOrder(
+            $cartId,
+            2,
+            10000,
+            'Alma - Pay now',
+            null,
+            ['transaction_id' => 'payment_id'],
+            1,
+            false,
+            'secure_key'
+        ));
+    }
+}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2368/[-ps]-explo-lock-in-our-module-to-avoid-duplicate-order-in-cas-of-two)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We proxyfy the Cart and PaymentModule Prestashop to fix the issue of duplicate in the prestashop version before 1.7.7.0
The fix is in he function `orderExists()`
https://github.com/PrestaShop/PrestaShop/blob/aab3f53c9c31d79a6c60d9744d2a175c4d6c5194/classes/Cart.php#L1667

Now we check the version of Prestashop env and we use the proxy if needed

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Add sleep(10)  before the call function `$this->paymentModuleProxy->validateOrder()` in the file `PaymentValidation.php`
Mount an old Prestashop version (before 1.7.7.0)
Create a payment and before to finish the payment create an other checkout for the same cart anbd payment both payment in the same time
Check the order dashboard

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->