### PR TITLE
fix: handle In-page if payment option is checked before page loaded

### DIFF
--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -25,10 +25,6 @@ let paymentButtonEvents = [];
 let inPageSettings = {};
 
 window.addEventListener("load", function() {
-    console.log('Alma Inpage loaded');
-    requestIdleCallback(() => {
-        console.log("Tout est chargé et le navigateur est au repos.");
-    });
     if (!document.getElementById('alma-inpage-global')) {
         throw new Error('[Alma] In Page Settings is missing.');
     }
@@ -50,35 +46,11 @@ function onloadAlma() {
 
     //Prestashop 1.7+
     radioButtons.forEach(function (input) {
-        input.addEventListener("change", function () {
-            let paymentOptionId = input.getAttribute('id');
-            let blockForm = document.querySelector('#pay-with-' + paymentOptionId + '-form');
+        input.addEventListener("change", () => handleSelectedPaymentOption(input));
 
-            removeAlmaEventsFromPaymentButton();
-            if (inPage !== undefined) {
-                inPage.unmount();
-            }
-            if ($(input).is(inPageSettings.paymentButtonSelector)) {
-                let formInpage = blockForm.querySelector('.alma-inpage');
-                if (this.checked && formInpage) {
-                    let installment = formInpage.dataset.installment;
-                    let deferredDays = formInpage.dataset.deferreddays;
-                    let deferredMonths = formInpage.dataset.deferredmonths;
-
-                    if (
-                        installment === '1'
-                        && deferredDays === '0'
-                        && deferredMonths === '0'
-                    ) {
-                        blockForm.hidden = true;
-                    }
-                    let url = formInpage.dataset.action;
-
-                    inPage = createAlmaIframe(formInpage);
-                    mapPaymentButtonToAlmaPaymentCreation(url, inPage, input);
-                }
-            }
-        });
+        if (input.checked) {
+            handleSelectedPaymentOption(input);
+        }
     });
 
     //Prestashop 1.6-
@@ -99,6 +71,40 @@ function onloadAlma() {
             createAlmaIframe(settingInpage, true, url);
         });
     });
+}
+
+/**
+ * Handle the change of the payment option for Prestashop 1.7+
+ * @param input
+ */
+function handleSelectedPaymentOption(input) {
+    let paymentOptionId = input.getAttribute('id');
+    let blockForm = document.querySelector('#pay-with-' + paymentOptionId + '-form');
+
+    removeAlmaEventsFromPaymentButton();
+    if (inPage !== undefined) {
+        inPage.unmount();
+    }
+    if ($(input).is(inPageSettings.paymentButtonSelector)) {
+        let formInpage = blockForm.querySelector('.alma-inpage');
+        if (input.checked && formInpage) {
+            let installment = formInpage.dataset.installment;
+            let deferredDays = formInpage.dataset.deferreddays;
+            let deferredMonths = formInpage.dataset.deferredmonths;
+
+            if (
+                installment === '1'
+                && deferredDays === '0'
+                && deferredMonths === '0'
+            ) {
+                blockForm.hidden = true;
+            }
+            let url = formInpage.dataset.action;
+
+            inPage = createAlmaIframe(formInpage);
+            mapPaymentButtonToAlmaPaymentCreation(url, inPage, input);
+        }
+    }
 }
 
 function createAlmaIframe(form, showPayButton = false, url = '') {

--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -25,6 +25,10 @@ let paymentButtonEvents = [];
 let inPageSettings = {};
 
 window.addEventListener("load", function() {
+    console.log('Alma Inpage loaded');
+    requestIdleCallback(() => {
+        console.log("Tout est chargé et le navigateur est au repos.");
+    });
     if (!document.getElementById('alma-inpage-global')) {
         throw new Error('[Alma] In Page Settings is missing.');
     }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2508/prestashop-integration-the-basket-does-not-load)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We execute in-page when in payment option is checked even after load page instead of only when the page in loaded

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Test in the merchant store

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->