### PR TITLE
fix: Validate injection for old Prestashop version

### DIFF
--- a/alma/controllers/hook/ActionCartSaveHookController.php
+++ b/alma/controllers/hook/ActionCartSaveHookController.php
@@ -31,7 +31,6 @@ if (!defined('_PS_VERSION_')) {
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Hooks\FrontendHookController;
 use Alma\PrestaShop\Services\AlmaBusinessDataService;
-use PrestaShop\PrestaShop\Adapter\Entity\Validate;
 
 class ActionCartSaveHookController extends FrontendHookController
 {
@@ -72,7 +71,7 @@ class ActionCartSaveHookController extends FrontendHookController
     public function run($params)
     {
         $cart = $params['cart'];
-        if (!Validate::isLoadedObject($cart)) {
+        if (!\Validate::isLoadedObject($cart)) {
             return;
         }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2626/merchant-has-an-issue-with-the-module)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Inject Validate without `use`  but add \ for validate with old Prestashop version

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Add to cart in old prestashop version < 1.7

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->