### PR TITLE
fix: Shipment data type error

### DIFF
--- a/alma/lib/Services/OrderService.php
+++ b/alma/lib/Services/OrderService.php
@@ -77,10 +77,10 @@ class OrderService
                 $paymentTransactionId,
                 $order->reference,
                 $stateName,
-                $orderState->shipped
+                (bool) $orderState->shipped
             );
         } catch (OrderServiceException $e) {
-            $this->logger->warning('Impossible to update order status: ' . $e->getMessage());
+            $this->logger->warning('[Alma] Impossible to update order status: ' . $e->getMessage());
 
             return;
         }
@@ -89,10 +89,10 @@ class OrderService
     /**
      * Call the clientHelper to send the order status and handle the exceptions
      *
-     * @param $paymentTransactionId
-     * @param $reference
-     * @param $stateName
-     * @param $shipped
+     * @param string $paymentTransactionId
+     * @param string $reference
+     * @param string $stateName
+     * @param bool|null $shipped
      *
      * @return void
      *
@@ -113,8 +113,8 @@ class OrderService
         } catch (RequestError $e) {
             $errorMessage = $e->getMessage();
         }
-        $this->logger->warning('Error while sending order status: ' . $errorMessage);
-        throw new OrderServiceException('Error while sending order status');
+        $this->logger->warning('[Alma] Error while sending order status: ' . $errorMessage);
+        throw new OrderServiceException('[Alma] Error while sending order status');
     }
 
     /**
@@ -122,7 +122,7 @@ class OrderService
      *
      * @param \OrderState $orderState
      *
-     * @return mixed
+     * @return string
      *
      * @throws OrderServiceException
      */

--- a/alma/tests/Unit/Services/OrderServiceTest.php
+++ b/alma/tests/Unit/Services/OrderServiceTest.php
@@ -132,7 +132,7 @@ class OrderServiceTest extends TestCase
         $order->method('getOrderPayments')->willReturn([$orderPayment]);
 
         $this->orderStateWithStatus();
-        $this->orderStateMock->shipped = false;
+        $this->orderStateMock->shipped = '0';
 
         $this->clientHelperMock
             ->expects($this->once())


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2737/investigate-drop-in-order-status-data-coverage-on-prestashop)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Our data about is_shipped return by Prestashop was O or 1, but our request needed bool, we added type force in bool and update test

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Make an order, change the status and check the data send

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->