### PR TITLE
Fix timeout for E2E tests trigger job

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -73,7 +73,7 @@ jobs:
                   \"check_id\": \"${{ steps.create-github-check.outputs.id  }}\"
                   }"
               }'
-          workflow_timeout_seconds: 120 # Default: 300
+          workflow_timeout_seconds: 300
 
     - name: Hide deprecated E2E test run info message
       uses: int128/hide-comment-action@dba8ef7116a5609731b75a2ceb566d561c0e57f5 # v1.40.0


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->
cc @Benjamin-Freoua-Alma 
The E2E test launch job failed with an error `Failed: Timeout exceeded while attempting to get Run ID` : https://github.com/alma/alma-installments-prestashop/actions/runs/14882895866/job/41794979632?pr=693

It failed because the deploy-cms job started at `12:08:27 GMT` on integration-infrastructure, whereas it was triggered at `12:05:40 GMT` on prestashop.
It currently waits for 120s before giving up

This is the second time that someone from integrations squad reports the issue, so I think we should increase the timeout.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
The timeout is now set to 300s. (To be honest I don't know why I did not set it to 300s directly as it is the default value)

