### PR TITLE
fix: Unregister hook DisplayProductActions

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -372,17 +372,13 @@ class Alma extends PaymentModule
      *
      * @param $params
      *
-     * @return mixed|null
+     * @return mixed|void|null
      */
     public function hookDisplayProductButtons($params)
     {
-        // @todo find another hook for prestashop 1.5
         if (version_compare(_PS_VERSION_, '1.6', '<')) {
             return $this->runHookController('displayProductPriceBlock', $params);
         }
-
-        // until version 1.7.6
-        return $this->runHookController('displayProductActions', $params);
     }
 
     /**

--- a/alma/lib/Helpers/HookHelper.php
+++ b/alma/lib/Helpers/HookHelper.php
@@ -89,7 +89,7 @@ class HookHelper
             'operand' => '>=',
         ],
         'displayProductButtons' => [
-            'version' => '1.7.6',
+            'version' => '1.6',
             'operand' => '<',
         ],
         'actionCartSave' => 'all',


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2746/prestashop-174-displayproductactionshookcontrollerphp)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We removed the call to the hook DisplayProductActions because it removed from Insurance removed

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Install Prestashop before 1.7.6 from an old version of our module (2.12.0) and update it to the last version

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->