### PR TITLE
fix: Handle the in-page event button for multiple payment buttons

### DIFF
--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -23,12 +23,14 @@
 let inPage = undefined;
 let paymentButtonEvents = [];
 let inPageSettings = {};
+let paymentButtons = [];
 
 window.addEventListener("load", function() {
     if (!document.getElementById('alma-inpage-global')) {
         throw new Error('[Alma] In Page Settings is missing.');
     }
     inPageSettings = JSON.parse(document.querySelector('#alma-inpage-global').dataset.settings);
+    paymentButtons = document.querySelectorAll(inPageSettings.placeOrderButtonSelector);
     onloadAlma();
     window.__alma_refreshInpage = onloadAlma;
 });
@@ -151,8 +153,6 @@ function createAlmaIframe(form, showPayButton = false, url = '') {
 }
 
 function mapPaymentButtonToAlmaPaymentCreation(url, inPage, input) {
-    let paymentButton = document.querySelector(inPageSettings.placeOrderButtonSelector);
-
     const eventAlma = async function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -160,7 +160,9 @@ function mapPaymentButtonToAlmaPaymentCreation(url, inPage, input) {
     };
 
     paymentButtonEvents.push(eventAlma);
-    paymentButton.addEventListener('click', eventAlma);
+    paymentButtons.forEach((paymentButton) => {
+        paymentButton.addEventListener('click', eventAlma);
+    })
 }
 
 async function createPayment(url, inPage, input = null) {
@@ -208,7 +210,9 @@ async function createPayment(url, inPage, input = null) {
 function removeAlmaEventsFromPaymentButton() {
     let event = paymentButtonEvents.shift();
     while (event) {
-        document.querySelector(inPageSettings.placeOrderButtonSelector).removeEventListener('click', event);
+        paymentButtons.forEach((paymentButton) => {
+            paymentButton.removeEventListener('click', event);
+        })
         event = paymentButtonEvents.shift();
     }
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2856/beausoleil-maroquinerie-payment-on-mobile)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Handle the event in-page modal if the merchant created multiple payment button (with responsive for exemple)

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Tested in the merchant website

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->