### PR TITLE
fix: load payment button in page on one page checkout

### DIFF
--- a/alma/views/js/alma-inpage.js
+++ b/alma/views/js/alma-inpage.js
@@ -30,7 +30,6 @@ window.addEventListener("load", function() {
         throw new Error('[Alma] In Page Settings is missing.');
     }
     inPageSettings = JSON.parse(document.querySelector('#alma-inpage-global').dataset.settings);
-    paymentButtons = document.querySelectorAll(inPageSettings.placeOrderButtonSelector);
     onloadAlma();
     window.__alma_refreshInpage = onloadAlma;
 });
@@ -45,6 +44,7 @@ function removeLoaderButtonPayment(button) {
 
 function onloadAlma() {
     let radioButtons = document.querySelectorAll('input[name="payment-option"]');
+    paymentButtons = document.querySelectorAll(inPageSettings.placeOrderButtonSelector);
 
     //Prestashop 1.7+
     radioButtons.forEach(function (input) {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-3315/prestashop-811-no-redirection-at-checkout)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We moved the paymentButton var in the onLoadAlma because some merchant have a loader in the checkout page and the payment wasn't load before the onLoadAlma loaded.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Specific for a merchant

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->