### PR TITLE
feat: poc widget with widget interface

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -25,6 +25,7 @@
 use PrestaShop\Module\Alma\Application\Service\ModuleInstallerService;
 use PrestaShop\Module\Alma\Application\Service\ModuleService;
 use PrestaShop\Module\Alma\Infrastructure\Repository\LanguageRepository;
+use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 use PrestaShop\PsAccountsInstaller\Installer\Installer;
 use PrestaShopBundle\Translation\TranslatorInterface;
 
@@ -38,7 +39,7 @@ if (file_exists($autoloadPath)) {
     require_once $autoloadPath;
 }
 
-class Alma extends PaymentModule
+class Alma extends PaymentModule implements WidgetInterface
 {
     public $_path;
     public $local_path;
@@ -158,5 +159,42 @@ class Alma extends PaymentModule
     public function isUsingNewTranslationSystem(): bool
     {
         return true;
+    }
+
+    // TODO: Check if it's better to centralize name of the hook or keep the native name and remove this function
+    public function hookDisplayProductAdditionalInfo($params): string
+    {
+        return $this->renderWidget('alma.widget.ProductAdditionalInfo', $params);
+    }
+
+    /**
+     * @param string $hookName
+     * @param array $configuration
+     * @return string
+     */
+    public function renderWidget($hookName, array $configuration): string
+    {
+        // TODO: Create a switch between product and cart to fetch the template in function of the hook
+        $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
+
+        return $this->fetch('module:' . $this->name . '/views/templates/widget/product.tpl');
+    }
+
+    public function getWidgetVariables($hookName, array $configuration): array
+    {
+        switch ($hookName) {
+            case 'alma.widget.product':
+                $idProduct = $configuration['product']['id_product'];
+                break;
+            case 'alma.widget.cart':
+                $idProduct = $configuration['cart']['products'][0]['id_product'];
+                break;
+            default:
+                $idProduct = null;
+        }
+
+        return [
+            'my_custom_data' => 'Hello product ' . $idProduct,
+        ];
     }
 }

--- a/alma/src/Application/Service/ModuleInstallerService.php
+++ b/alma/src/Application/Service/ModuleInstallerService.php
@@ -10,6 +10,8 @@ class ModuleInstallerService
 {
     private const HOOK_LIST = [
         'actionFrontControllerSetMedia', // Hook used for load assets
+        'displayProductAdditionalInfo', // Hook used for display widget in the product page
+        'displayShoppingCartFooter' // Hook used for display widget in the product page
     ];
 
     /**

--- a/alma/views/templates/widget/product.tpl
+++ b/alma/views/templates/widget/product.tpl
@@ -1,0 +1,2 @@
+Widget Product Template
+{$my_custom_data}

--- a/doc/widget.md
+++ b/doc/widget.md
@@ -1,0 +1,19 @@
+Render Widget
+===================================
+
+## Context
+We will use the widget Interface to display our widget in the front office.
+
+## How it works
+By default, we will set the widget in the hook used natively `displayProductAdditionalInfo` for the product page and `displayShoppingCartFooter` for the cart page,
+but the merchant cans use our tag `alma.widget.product` and `alma.widget.cart` to customize the position of the widget in the template.
+If our tags is used, we will not display the widget in the default hooks.
+// TODO: Need to validate this process with Product and EM.
+
+```tpl
+// Widget tag to display the widget in a template product
+{widget name='alma' hook="alma.widget.product" product=$product}
+
+// Widget tag to display the widget in a template cart
+{widget name='alma' hook="alma.widget.cart" cart=$cart}
+```


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-3839/poc-class-widget)

## Context
We will use the widget Interface to display our widget in the front office.

## How it works
By default, we will set the widget in the hook used natively `displayProductAdditionalInfo` for the product page and `displayShoppingCartFooter` for the cart page,
but the merchant cans use our tag `alma.widget.product` and `alma.widget.cart` to customize the position of the widget in the template.
If our tags is used, we will not display the widget in the default hooks.
// TODO: Need to validate this process with Product and EM.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->