### PR TITLE
Feature/ecom 3967 handle the old position if used for product

### DIFF
--- a/alma/src/Application/Service/FormService.php
+++ b/alma/src/Application/Service/FormService.php
@@ -125,8 +125,8 @@ class FormService
             $templateRefund = $this->refundService->createTemplate();
             $form = [
                 $this->feePlansAdminForm->build($templateTabs, $this->feePlansService->feePlansFields()),
-                $this->productWidgetAdminForm->build($templateWidget),
-                $this->cartWidgetAdminForm->build('', $this->widgetService->getOldWidgetPositionForm()),
+                $this->productWidgetAdminForm->build($templateWidget, $this->widgetService->getOldProductWidgetPositionForm()),
+                $this->cartWidgetAdminForm->build('', $this->widgetService->getOldCartWidgetPositionForm()),
                 $this->paymentButtonAdminForm->build($templatePaymentButton),
                 $this->excludedCategoriesAdminForm->build($templateExcludedCategories),
                 $this->refundAdminForm->build($templateRefund, $this->refundService->refundStateOrder()),

--- a/alma/src/Application/Service/SettingsService.php
+++ b/alma/src/Application/Service/SettingsService.php
@@ -109,7 +109,7 @@ class SettingsService
     public function getFieldsValue(array $languages = []): array
     {
         $feePlansFieldsValue = $this->feePlansService->fieldsValue();
-        $widgetFieldsValue = $this->widgetService->fieldsValueOldCartWidgetPosition();
+        $widgetFieldsValue = $this->widgetService->fieldsValueOldWidgetPosition();
         $fieldsValue = $this->authenticationSettingsProvider->getAllFields();
 
         foreach ($fieldsValue as $field => $param) {
@@ -167,7 +167,7 @@ class SettingsService
         $notificationSuccess = $this->translator->trans('Settings successfully updated', [], 'Modules.Alma.Notifications');
         $overrideValues = [];
         $feePlansFieldsValue = $this->feePlansService->fieldsToSaveFromPost($allValuesFromPost);
-        $widgetFieldsValue = $this->widgetService->fieldsValueOldCartWidgetPosition();
+        $widgetFieldsValue = $this->widgetService->fieldsValueOldWidgetPosition();
 
         if ($this->hasNewKey($allValuesFromPost)) {
             $merchantIds = $this->authenticationService->isValidKeys();

--- a/alma/src/Application/Service/WidgetFrontendService.php
+++ b/alma/src/Application/Service/WidgetFrontendService.php
@@ -78,8 +78,9 @@ class WidgetFrontendService
                 $container = str_replace('.', '-', $hookName);
                 $products = $cart->getProducts();
                 $productEmbeddedAttributes = [];
-                $containerId = $this->configurationRepository->getCartWidgetOldPositionCustom()
-                    ? $this->configurationRepository->getCartWidgetOldPositionSelector()
+                $legacySelector = $this->configurationRepository->getCartWidgetOldPositionSelector();
+                $containerId = ($this->configurationRepository->getCartWidgetOldPositionCustom() && !empty($legacySelector))
+                    ? $legacySelector
                     : '#' . $container;
                 $hideIfNotEligible = (int) !$this->configurationRepository->getCartWidgetDisplayNotEligible();
                 break;
@@ -108,7 +109,10 @@ class WidgetFrontendService
                 /** @var \Product $products */
                 $products = [$product];
                 $productEmbeddedAttributes = $controller->getTemplateVarProduct()->getEmbeddedAttributes();
-                $containerId = '#' . $container;
+                $legacySelector = $this->configurationRepository->getProductWidgetOldPositionSelector();
+                $containerId = ($this->configurationRepository->getProductWidgetOldPositionCustom() && !empty($legacySelector))
+                    ? $legacySelector
+                    : '#' . $container;
                 $hideIfNotEligible = (int) !$this->configurationRepository->getProductWidgetDisplayNotEligible();
                 break;
             default:

--- a/alma/src/Application/Service/WidgetFrontendService.php
+++ b/alma/src/Application/Service/WidgetFrontendService.php
@@ -86,7 +86,7 @@ class WidgetFrontendService
                 break;
             case self::WIDGET_HOOK_PRODUCT_PRICE_BLOCK:
             case self::WIDGET_PRODUCT:
-            /** @var \ProductControllerCore $controller */
+                /** @var \ProductControllerCore $controller */
                 $controller = $this->context->controller;
 
                 if (!method_exists($controller, 'getProduct')) {

--- a/alma/src/Application/Service/WidgetFrontendService.php
+++ b/alma/src/Application/Service/WidgetFrontendService.php
@@ -105,6 +105,7 @@ class WidgetFrontendService
 
                 $purchaseAmount = $product->getPrice();
                 $container = str_replace('.', '-', $hookName);
+                /** @var \Product $products */
                 $products = [$product];
                 $productEmbeddedAttributes = $controller->getTemplateVarProduct()->getEmbeddedAttributes();
                 $containerId = '#' . $container;

--- a/alma/src/Application/Service/WidgetService.php
+++ b/alma/src/Application/Service/WidgetService.php
@@ -69,7 +69,7 @@ class WidgetService
      * Get the old widget position field to migrate the configuration from our module v5.
      * @return array
      */
-    public function getOldWidgetPositionForm(): array
+    public function getOldCartWidgetPositionForm(): array
     {
         if (!$this->configurationRepository->getCartWidgetOldPositionCustom()) {
             return [];
@@ -102,17 +102,57 @@ class WidgetService
     }
 
     /**
-     * Get the value of the old widget position field to migrate the configuration from our module v5.
+     * Get the old product widget position field to migrate the configuration from our module v5.
      * @return array
      */
-    public function fieldsValueOldCartWidgetPosition(): array
+    public function getOldProductWidgetPositionForm(): array
     {
-        if (empty($this->configurationRepository->getCartWidgetOldPositionCustom())) {
+        if (!$this->configurationRepository->getProductWidgetOldPositionCustom()) {
             return [];
         }
 
         return [
-            CartWidgetAdminForm::KEY_FIELD_CART_WIDGET_POSITION_CUSTOM => 1
+            ProductWidgetAdminForm::KEY_FIELD_PRODUCT_WIDGET_POSITION_CUSTOM => [
+                'type' => 'switch',
+                'label' => $this->translator->trans('Old Custom position', [], 'Modules.Alma.Settings'),
+                'required' => false,
+                'form' => 'product_widget',
+                'encrypted' => false,
+                'options' => [
+                    'values' => [
+                        [
+                            'id' => 'ENABLE',
+                            'value' => 1,
+                            'label' => $this->translator->trans('Enabled', [], 'Modules.Alma.Settings'),
+                        ],
+                        [
+                            'id' => 'DISABLE',
+                            'value' => 0,
+                            'label' => $this->translator->trans('Disabled', [], 'Modules.Alma.Settings')
+                        ]
+                    ],
+                    'desc' => $this->translator->trans('Used for disabled old custom position of widget', [], 'Modules.Alma.Settings'),
+                ],
+            ]
         ];
+    }
+
+    /**
+     * Get the value of the old widget position field to migrate the configuration from our module v5.
+     * @return array
+     */
+    public function fieldsValueOldWidgetPosition(): array
+    {
+        $fieldsValue = [];
+
+        if (!empty($this->configurationRepository->getCartWidgetOldPositionCustom())) {
+            $fieldsValue[CartWidgetAdminForm::KEY_FIELD_CART_WIDGET_POSITION_CUSTOM] = 1;
+        }
+
+        if (!empty($this->configurationRepository->getProductWidgetOldPositionCustom())) {
+            $fieldsValue[ProductWidgetAdminForm::KEY_FIELD_PRODUCT_WIDGET_POSITION_CUSTOM] = 1;
+        }
+
+        return $fieldsValue;
     }
 }

--- a/alma/src/Infrastructure/Form/ProductWidgetAdminForm.php
+++ b/alma/src/Infrastructure/Form/ProductWidgetAdminForm.php
@@ -6,6 +6,8 @@ class ProductWidgetAdminForm extends AbstractAdminForm
 {
     public const KEY_FIELD_PRODUCT_WIDGET_STATE = 'ALMA_PRODUCT_WIDGET_STATE';
     public const KEY_FIELD_PRODUCT_WIDGET_DISPLAY_NOT_ELIGIBLE = 'ALMA_PRODUCT_WIDGET_DISPLAY_NOT_ELIGIBLE';
+    public const KEY_FIELD_PRODUCT_WIDGET_POSITION_CUSTOM = 'ALMA_WIDGET_POSITION_CUSTOM'; // Old key for custom position on our module v5
+    public const KEY_FIELD_PRODUCT_WIDGET_POSITION_SELECTOR = 'ALMA_WIDGET_POSITION_SELECTOR'; // Old key for custom position selector on our module v5
 
     public static function title(): string
     {
@@ -17,7 +19,7 @@ class ProductWidgetAdminForm extends AbstractAdminForm
     {
         $translator = \Context::getContext()->getTranslator();
 
-        return [
+        $arrayForm = [
             'ALMA_EMBED_WIDGET_HTML' => [
                 'type' => 'html',
                 'label' => '',
@@ -71,5 +73,7 @@ class ProductWidgetAdminForm extends AbstractAdminForm
                 ],
             ]
         ];
+
+        return array_merge($arrayForm, $dynamicForm);
     }
 }

--- a/alma/src/Infrastructure/Repository/ConfigurationRepository.php
+++ b/alma/src/Infrastructure/Repository/ConfigurationRepository.php
@@ -82,6 +82,22 @@ class ConfigurationRepository
     /**
      * @return bool
      */
+    public function getProductWidgetOldPositionCustom(): bool
+    {
+        return (bool) $this->get(ProductWidgetAdminForm::KEY_FIELD_PRODUCT_WIDGET_POSITION_CUSTOM);
+    }
+
+    /**
+     * @return string
+     */
+    public function getProductWidgetOldPositionSelector(): string
+    {
+        return $this->get(ProductWidgetAdminForm::KEY_FIELD_PRODUCT_WIDGET_POSITION_SELECTOR);
+    }
+
+    /**
+     * @return bool
+     */
     public function getProductWidgetState(): bool
     {
         return (bool) $this->get(ProductWidgetAdminForm::KEY_FIELD_PRODUCT_WIDGET_STATE);

--- a/alma/src/Infrastructure/Repository/ConfigurationRepository.php
+++ b/alma/src/Infrastructure/Repository/ConfigurationRepository.php
@@ -13,11 +13,16 @@ class ConfigurationRepository
     /**
      * @param string $key
      *
-     * @return string|false
+     * @return string
      */
     public function get(string $key): string
     {
-        return Configuration::get($key);
+        $getValue = Configuration::get($key);
+        if (false === $getValue) {
+            return '';
+        }
+
+        return $getValue;
     }
 
     /**

--- a/alma/tests/Unit/Application/Service/WidgetFrontendServiceTest.php
+++ b/alma/tests/Unit/Application/Service/WidgetFrontendServiceTest.php
@@ -412,7 +412,7 @@ class WidgetFrontendServiceTest extends TestCase
         $this->configurationRepository->expects($this->once())
             ->method('getCartWidgetOldPositionCustom')
             ->willReturn(false);
-        $this->configurationRepository->expects($this->never())
+        $this->configurationRepository->expects($this->once())
             ->method('getCartWidgetOldPositionSelector');
         $this->context->smarty = $this->createMock(\Smarty::class);
         $tpl = $this->createMock(\Smarty_Internal_Template::class);

--- a/alma/tests/Unit/Application/Service/WidgetServiceTest.php
+++ b/alma/tests/Unit/Application/Service/WidgetServiceTest.php
@@ -125,6 +125,21 @@ class WidgetServiceTest extends TestCase
         $this->assertEquals($expected, $this->widgetService->fieldsValueOldWidgetPosition());
     }
 
+    public function testFieldsValueOldWidgetPositionWithProductCustomPositionSaved()
+    {
+        $expected = [
+            ProductWidgetAdminForm::KEY_FIELD_PRODUCT_WIDGET_POSITION_CUSTOM => 1,
+        ];
+
+        $this->configurationRepository->expects($this->once())
+            ->method('getCartWidgetOldPositionCustom')
+            ->willReturn(false);
+        $this->configurationRepository->expects($this->once())
+            ->method('getProductWidgetOldPositionCustom')
+            ->willReturn(true);
+        $this->assertEquals($expected, $this->widgetService->fieldsValueOldWidgetPosition());
+    }
+
     public function testFieldsValueOldWidgetPositionWithCartAndProductCustomPositionSaved()
     {
         $expected = [

--- a/alma/tests/Unit/Application/Service/WidgetServiceTest.php
+++ b/alma/tests/Unit/Application/Service/WidgetServiceTest.php
@@ -63,7 +63,7 @@ class WidgetServiceTest extends TestCase
         $this->configurationRepository->expects($this->once())
             ->method('getCartWidgetOldPositionCustom')
             ->willReturn(false);
-        $this->assertEquals([], $this->widgetService->getOldWidgetPositionForm());
+        $this->assertEquals([], $this->widgetService->getOldCartWidgetPositionForm());
     }
 
     public function testGetOldWidgetPositionFormWithCustomPositionSaved()
@@ -96,18 +96,21 @@ class WidgetServiceTest extends TestCase
         $this->configurationRepository->expects($this->once())
             ->method('getCartWidgetOldPositionCustom')
             ->willReturn(true);
-        $this->assertEquals($expected, $this->widgetService->getOldWidgetPositionForm());
+        $this->assertEquals($expected, $this->widgetService->getOldCartWidgetPositionForm());
     }
 
-    public function testFieldsValueOldCartWidgetPositionWithoutCustomPositionSaved()
+    public function testFieldsValueOldWidgetPositionWithoutCustomPositionSaved()
     {
         $this->configurationRepository->expects($this->once())
             ->method('getCartWidgetOldPositionCustom')
             ->willReturn(false);
-        $this->assertEquals([], $this->widgetService->fieldsValueOldCartWidgetPosition());
+        $this->configurationRepository->expects($this->once())
+            ->method('getProductWidgetOldPositionCustom')
+            ->willReturn(false);
+        $this->assertEquals([], $this->widgetService->fieldsValueOldWidgetPosition());
     }
 
-    public function testFieldsValueOldCartWidgetPositionWithCustomPositionSaved()
+    public function testFieldsValueOldWidgetPositionWithCartCustomPositionSaved()
     {
         $expected = [
             CartWidgetAdminForm::KEY_FIELD_CART_WIDGET_POSITION_CUSTOM => 1,
@@ -116,6 +119,66 @@ class WidgetServiceTest extends TestCase
         $this->configurationRepository->expects($this->once())
             ->method('getCartWidgetOldPositionCustom')
             ->willReturn(true);
-        $this->assertEquals($expected, $this->widgetService->fieldsValueOldCartWidgetPosition());
+        $this->configurationRepository->expects($this->once())
+            ->method('getProductWidgetOldPositionCustom')
+            ->willReturn(false);
+        $this->assertEquals($expected, $this->widgetService->fieldsValueOldWidgetPosition());
+    }
+
+    public function testFieldsValueOldWidgetPositionWithCartAndProductCustomPositionSaved()
+    {
+        $expected = [
+            CartWidgetAdminForm::KEY_FIELD_CART_WIDGET_POSITION_CUSTOM => 1,
+            ProductWidgetAdminForm::KEY_FIELD_PRODUCT_WIDGET_POSITION_CUSTOM => 1,
+        ];
+
+        $this->configurationRepository->expects($this->once())
+            ->method('getCartWidgetOldPositionCustom')
+            ->willReturn(true);
+        $this->configurationRepository->expects($this->once())
+            ->method('getProductWidgetOldPositionCustom')
+            ->willReturn(true);
+        $this->assertEquals($expected, $this->widgetService->fieldsValueOldWidgetPosition());
+    }
+
+    public function testGetOldProductWidgetPositionFormWithoutCustomPositionSaved()
+    {
+        $this->configurationRepository->expects($this->once())
+            ->method('getProductWidgetOldPositionCustom')
+            ->willReturn(false);
+        $this->assertEquals([], $this->widgetService->getOldProductWidgetPositionForm());
+    }
+
+    public function testGetOldProductWidgetPositionFormWithCustomPositionSaved()
+    {
+        $expected = [
+            ProductWidgetAdminForm::KEY_FIELD_PRODUCT_WIDGET_POSITION_CUSTOM => [
+                'type' => 'switch',
+                'label' => '',
+                'required' => false,
+                'form' => 'product_widget',
+                'encrypted' => false,
+                'options' => [
+                    'values' => [
+                        [
+                            'id' => 'ENABLE',
+                            'value' => 1,
+                            'label' => '',
+                        ],
+                        [
+                            'id' => 'DISABLE',
+                            'value' => 0,
+                            'label' => ''
+                        ]
+                    ],
+                    'desc' => '',
+                ]
+            ],
+        ];
+
+        $this->configurationRepository->expects($this->once())
+            ->method('getProductWidgetOldPositionCustom')
+            ->willReturn(true);
+        $this->assertEquals($expected, $this->widgetService->getOldProductWidgetPositionForm());
     }
 }

--- a/alma/tests/Unit/Infrastructure/Repository/ConfigurationRepositoryTest.php
+++ b/alma/tests/Unit/Infrastructure/Repository/ConfigurationRepositoryTest.php
@@ -12,6 +12,11 @@ class ConfigurationRepositoryTest extends TestCase
         $this->configurationRepository = new ConfigurationRepository();
     }
 
+    public function testGetFalseReturnEmptyString()
+    {
+        $this->assertSame('', $this->configurationRepository->get('non_existent_key'));
+    }
+
     public function testGetMode()
     {
         $this->assertIsString($this->configurationRepository->getMode());

--- a/alma/views/js/alma-widget.js
+++ b/alma/views/js/alma-widget.js
@@ -19,14 +19,27 @@ function toCents(amount) {
     return Math.round(parseFloat(amount) * 100);
 }
 
-// Returns the total product amount in cents from the embedded data-product attribute.
-// If quantity is provided (e.g. from the qty input on manual change), it overrides quantity_wanted.
-function getProductAmountFromProductData(productData, quantity) {
-    if (!productData || productData.price_amount === undefined) return null;
-    const unitPriceInCents = toCents(productData.price_amount);
+// Returns the unit price in cents by parsing the product_prices HTML fragment
+// Reads .current-price-value[content] which the theme updates on combination change.
+function getProductUnitPriceFromEventData(eventData, $) {
+    if (!eventData || !eventData.product_prices) return null;
+
+    const $html = $('<div>').html(eventData.product_prices);
+
+    const priceEl = $html.find('.current-price-value').get(0);
+    const content = priceEl ? priceEl.getAttribute('content') : undefined;
+    if (content !== undefined && !isNaN(parseFloat(content))) {
+        return Math.round(parseFloat(content) * 100);
+    }
+
+    return null;
+}
+
+// Returns the total product amount in cents given the unit price and the current quantity.
+function getProductAmountInCents($, unitPriceInCents) {
     if (!unitPriceInCents) return null;
-    const qty = quantity !== undefined ? parseInt(quantity, 10) : parseInt(productData.quantity_wanted, 10);
-    return unitPriceInCents * (qty || 1);
+    const quantity = parseInt($('[name="qty"]').val(), 10) || 1;
+    return unitPriceInCents * quantity;
 }
 
 function getCartAmountInCents() {
@@ -87,7 +100,7 @@ function initAlmaWidget($, Alma) {
 // module is defined in Node.js environments, but not in browsers.
 // This check allows the code to be used for unit test and browser contexts.
 if (typeof module !== 'undefined') {
-    module.exports = { initAlmaWidget, findWidgetContainer, initAlmaWidgetFromContainer, getCartAmountInCents, getProductAmountFromProductData, toCents };
+    module.exports = { initAlmaWidget, findWidgetContainer, initAlmaWidgetFromContainer, getCartAmountInCents, getProductAmountInCents, getProductUnitPriceFromEventData, toCents };
 } else {
     (function ($) {
         $(function () {
@@ -111,29 +124,36 @@ if (typeof module !== 'undefined') {
                     initAlmaWidget($, Alma);
                 });
 
+                // Product unit price in cents, initialized from the widget config (price for qty=1).
+                let productUnitPriceInCents = (function () {
+                    const $widgetContainer = findWidgetContainer($, ['#alma-widget-product', '#alma-widget-ProductPriceBlock']);
+                    if (!$widgetContainer) return null;
+                    const config = $widgetContainer.data('widget-config');
+                    return config ? config.purchaseAmount : null;
+                })();
+
                 function updateProductWidget(newAmount) {
-                    const $widget = findWidgetContainer($, ALMA_PRODUCT_WIDGET_SELECTORS);
+                    const $widget = findWidgetContainer($, ['#alma-widget-product', '#alma-widget-ProductPriceBlock']);
                     if (!$widget) return;
                     const config = $widget.data('widget-config');
                     if (!config) return;
                     config.purchaseAmount = newAmount;
                     $widget.data('widget-config', config);
-                    initAlmaWidget($, Alma);
+                    initAlmaProductWidget($, Alma);
                 }
 
-                prestashop.on('updatedProduct', function () {
-                    const $widget = findWidgetContainer($, ALMA_PRODUCT_WIDGET_SELECTORS);
-                    if (!$widget) return;
-                    const newAmount = getProductAmountFromProductData($widget.data('product'));
+                prestashop.on('updatedProduct', function (eventData) {
+                    const newUnitPrice = getProductUnitPriceFromEventData(eventData, $);
+                    if (newUnitPrice !== null) {
+                        productUnitPriceInCents = newUnitPrice;
+                    }
+                    const newAmount = getProductAmountInCents($, productUnitPriceInCents);
                     if (newAmount === null) return;
                     updateProductWidget(newAmount);
                 });
 
                 $(document).on('change', '[name="qty"]', function () {
-                    const $widget = findWidgetContainer($, ALMA_PRODUCT_WIDGET_SELECTORS);
-                    if (!$widget) return;
-                    const newQty = parseInt($(this).val(), 10) || 1;
-                    const newAmount = getProductAmountFromProductData($widget.data('product'), newQty);
+                    const newAmount = getProductAmountInCents($, productUnitPriceInCents);
                     if (newAmount === null) return;
                     updateProductWidget(newAmount);
                 });

--- a/alma/views/js/alma-widget.js
+++ b/alma/views/js/alma-widget.js
@@ -19,27 +19,14 @@ function toCents(amount) {
     return Math.round(parseFloat(amount) * 100);
 }
 
-// Returns the unit price in cents by parsing the product_prices HTML fragment
-// Reads .current-price-value[content] which the theme updates on combination change.
-function getProductUnitPriceFromEventData(eventData, $) {
-    if (!eventData || !eventData.product_prices) return null;
-
-    const $html = $('<div>').html(eventData.product_prices);
-
-    const priceEl = $html.find('.current-price-value').get(0);
-    const content = priceEl ? priceEl.getAttribute('content') : undefined;
-    if (content !== undefined && !isNaN(parseFloat(content))) {
-        return Math.round(parseFloat(content) * 100);
-    }
-
-    return null;
-}
-
-// Returns the total product amount in cents given the unit price and the current quantity.
-function getProductAmountInCents($, unitPriceInCents) {
+// Returns the total product amount in cents from the embedded data-product attribute.
+// If quantity is provided (e.g. from the qty input on manual change), it overrides quantity_wanted.
+function getProductAmountFromProductData(productData, quantity) {
+    if (!productData || productData.price_amount === undefined) return null;
+    const unitPriceInCents = toCents(productData.price_amount);
     if (!unitPriceInCents) return null;
-    const quantity = parseInt($('[name="qty"]').val(), 10) || 1;
-    return unitPriceInCents * quantity;
+    const qty = quantity !== undefined ? parseInt(quantity, 10) : parseInt(productData.quantity_wanted, 10);
+    return unitPriceInCents * (qty || 1);
 }
 
 function getCartAmountInCents() {
@@ -100,7 +87,7 @@ function initAlmaWidget($, Alma) {
 // module is defined in Node.js environments, but not in browsers.
 // This check allows the code to be used for unit test and browser contexts.
 if (typeof module !== 'undefined') {
-    module.exports = { initAlmaWidget, findWidgetContainer, initAlmaWidgetFromContainer, getCartAmountInCents, getProductAmountInCents, getProductUnitPriceFromEventData, toCents };
+    module.exports = { initAlmaWidget, findWidgetContainer, initAlmaWidgetFromContainer, getCartAmountInCents, getProductAmountFromProductData, toCents };
 } else {
     (function ($) {
         $(function () {
@@ -133,27 +120,28 @@ if (typeof module !== 'undefined') {
                 })();
 
                 function updateProductWidget(newAmount) {
-                    const $widget = findWidgetContainer($, ['#alma-widget-product', '#alma-widget-ProductPriceBlock']);
+                    const $widget = findWidgetContainer($, ALMA_PRODUCT_WIDGET_SELECTORS);
                     if (!$widget) return;
                     const config = $widget.data('widget-config');
                     if (!config) return;
                     config.purchaseAmount = newAmount;
                     $widget.data('widget-config', config);
-                    initAlmaProductWidget($, Alma);
+                    initAlmaWidget($, Alma);
                 }
 
-                prestashop.on('updatedProduct', function (eventData) {
-                    const newUnitPrice = getProductUnitPriceFromEventData(eventData, $);
-                    if (newUnitPrice !== null) {
-                        productUnitPriceInCents = newUnitPrice;
-                    }
-                    const newAmount = getProductAmountInCents($, productUnitPriceInCents);
+                prestashop.on('updatedProduct', function () {
+                    const $widget = findWidgetContainer($, ALMA_PRODUCT_WIDGET_SELECTORS);
+                    if (!$widget) return;
+                    const newAmount = getProductAmountFromProductData($widget.data('product'));
                     if (newAmount === null) return;
                     updateProductWidget(newAmount);
                 });
 
                 $(document).on('change', '[name="qty"]', function () {
-                    const newAmount = getProductAmountInCents($, productUnitPriceInCents);
+                    const $widget = findWidgetContainer($, ALMA_PRODUCT_WIDGET_SELECTORS);
+                    if (!$widget) return;
+                    const newQty = parseInt($('[name="qty"]').val(), 10) || 1;
+                    const newAmount = getProductAmountFromProductData($widget.data('product'), newQty);
                     if (newAmount === null) return;
                     updateProductWidget(newAmount);
                 });

--- a/doc/widget.md
+++ b/doc/widget.md
@@ -70,10 +70,17 @@ When both the hook and the widget tag containers are present on the page, the wi
 
 Module v5 allowed merchants to define a custom CSS selector to control where the cart widget was injected in the DOM. This setting is preserved and still honored in the current version.
 
-When `ALMA_CART_WIDGET_POSITION_CUSTOM` is enabled, `WidgetFrontendService` uses the CSS selector stored in `ALMA_WDGT_POS_SELECTOR` as the widget's `containerId` instead of the default `#alma-widget-cart`. If the option is disabled, the standard container ID is used.
+When `ALMA_CART_WIDGET_POSITION_CUSTOM` is enabled, `WidgetFrontendService` uses the CSS selector stored in `ALMA_CART_WDGT_POS_SELECTOR` as the widget's `containerId` instead of the default `#alma-widget-cart`. If the option is disabled, the standard container ID is used.
 
 - `ConfigurationRepository::getCartWidgetOldPositionCustom()` — returns `true` if the legacy custom position is active.
 - `ConfigurationRepository::getCartWidgetOldPositionSelector()` — returns the saved CSS selector (e.g. `#my-custom-selector`).
+
+The same backward compatibility exists for the product widget. When `ALMA_WIDGET_POSITION_CUSTOM` is enabled, `WidgetFrontendService` uses the CSS selector stored in `ALMA_WIDGET_POSITION_SELECTOR` as the widget's `containerId` instead of the default `#alma-widget-product`.
+
+- `ConfigurationRepository::getProductWidgetOldPositionCustom()` — returns `true` if the legacy custom position is active.
+- `ConfigurationRepository::getProductWidgetOldPositionSelector()` — returns the saved CSS selector (e.g. `#my-custom-product-selector`).
+
+In both cases, `WidgetService::getOldProductWidgetPositionForm()` and `WidgetService::fieldsValueOldWidgetPosition()` expose a toggle in the admin configuration page to let merchants disable the legacy position and switch to the standard one. The toggle is only displayed if the legacy configuration key exists in the database.
 
 ### Cart refresh
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-3967/handle-the-old-position-if-used)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
As the widget Cart we handle the legacy position.
If this option is enabled in previous module we handle the position and display an option in form for disable it

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->