### PR TITLE
feat: Handle Advisory lock GET_LOCK/RELEASE_LOCK

### DIFF
--- a/alma/controllers/front/ipn.php
+++ b/alma/controllers/front/ipn.php
@@ -23,7 +23,6 @@
  */
 
 use Alma\PrestaShop\Builders\Validators\PaymentValidationBuilder;
-use Alma\PrestaShop\Exceptions\OrderException;
 use Alma\PrestaShop\Exceptions\PaymentValidationException;
 use Alma\PrestaShop\Factories\LoggerFactory;
 use Alma\PrestaShop\Helpers\SettingsHelper;
@@ -98,10 +97,6 @@ class AlmaIpnModuleFrontController extends ModuleFrontController
             $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 500);
         } catch (PaymentValidationError $e) {
             LoggerFactory::instance()->error('ipn payment_validation_error - Message : ' . $e->getMessage());
-            $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 500);
-        } catch (OrderException $e) {
-            \Db::getInstance()->execute('ROLLBACK');
-            LoggerFactory::instance()->error('ipn order payment_validation_error - Message : ' . $e->getMessage());
             $this->ajaxRenderAndExit(json_encode(['error' => $e->getMessage()]), 500);
         }
     }

--- a/alma/controllers/front/validation.php
+++ b/alma/controllers/front/validation.php
@@ -23,7 +23,6 @@
  */
 
 use Alma\PrestaShop\Builders\Validators\PaymentValidationBuilder;
-use Alma\PrestaShop\Exceptions\OrderException;
 use Alma\PrestaShop\Exceptions\PaymentValidationException;
 use Alma\PrestaShop\Factories\LoggerFactory;
 use Alma\PrestaShop\Validators\PaymentValidation;
@@ -84,10 +83,6 @@ class AlmaValidationModuleFrontController extends ModuleFrontController
         } catch (PaymentValidationException $e) {
             LoggerFactory::instance()->error('Payment Validation Exception - Message : ' . $e->getMessage());
             $redirect_to = $this->fail($e->cartId, $e->getMessage());
-        } catch (OrderException $e) {
-            \Db::getInstance()->execute('ROLLBACK');
-            LoggerFactory::instance()->error('Order Exception - Message : ' . $e->getMessage());
-            $redirect_to = $this->fail(null, $e->getMessage());
         }
 
         if (is_callable([$this, 'setRedirectAfter'])) {

--- a/alma/lib/Builders/Validators/PaymentValidationBuilder.php
+++ b/alma/lib/Builders/Validators/PaymentValidationBuilder.php
@@ -24,6 +24,7 @@
 
 namespace Alma\PrestaShop\Builders\Validators;
 
+use Alma\PrestaShop\Services\CartLockService;
 use Alma\PrestaShop\Traits\BuilderTrait;
 use Alma\PrestaShop\Validators\PaymentValidation;
 
@@ -46,7 +47,8 @@ class PaymentValidationBuilder
         return new PaymentValidation(
             $this->getContextFactory(),
             $this->getModuleFactory(),
-            $this->getClientPaymentValidator()
+            $this->getClientPaymentValidator(),
+            new CartLockService()
         );
     }
 }

--- a/alma/lib/Proxy/CartProxy.php
+++ b/alma/lib/Proxy/CartProxy.php
@@ -24,7 +24,6 @@
 
 namespace Alma\PrestaShop\Proxy;
 
-use Alma\PrestaShop\Exceptions\OrderException;
 use Alma\PrestaShop\Factories\CartFactory;
 
 if (!defined('_PS_VERSION_')) {
@@ -70,38 +69,6 @@ class CartProxy
 
         $cart = $this->cartFactory->create($cartId);
         return $cart->orderExists();
-    }
-
-    /**
-     * Vérification thread-safe pour les retours de paiement
-     */
-    public function checkOrderExistsForPayment($cartId)
-    {
-        \Db::getInstance()->execute('START TRANSACTION');
-
-        try {
-            $lockResult = \Db::getInstance()->execute(
-                'SELECT id_cart FROM ' . _DB_PREFIX_ . 'cart
-             WHERE id_cart = ' . (int) $cartId . '
-             FOR UPDATE'
-            );
-
-            if (!$lockResult) {
-                throw new OrderException('Unable to lock cart or cart not found');
-            }
-
-            $orderExists = $this->orderExists($cartId);
-
-            if (!$orderExists) {
-                return false;
-            }
-
-            \Db::getInstance()->execute('COMMIT');
-            return true;
-        } catch (OrderException $e) {
-            \Db::getInstance()->execute('ROLLBACK');
-            throw $e;
-        }
     }
 
     /**

--- a/alma/lib/Proxy/PaymentModuleProxy.php
+++ b/alma/lib/Proxy/PaymentModuleProxy.php
@@ -24,7 +24,6 @@
 
 namespace Alma\PrestaShop\Proxy;
 
-use Alma\PrestaShop\Exceptions\OrderException;
 use Alma\PrestaShop\Factories\LoggerFactory;
 use Alma\PrestaShop\Model\AlmaModuleModel;
 
@@ -85,7 +84,7 @@ class PaymentModuleProxy
         $secure_key = false,
         Shop $shop = null
     ) {
-        if ($this->cartProxy->checkOrderExistsForPayment($id_cart)) {
+        if ($this->cartProxy->orderExists($id_cart)) {
             LoggerFactory::instance()->warning('[Alma] Attempting to create a duplicate order for cart ID ' . $id_cart);
             return false;
         }

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -88,8 +88,12 @@ class CartLockService
 
         $lockKey = $this->getLockKey((int) $cartId);
         $released = (bool) \Db::getInstance()->getValue(
-            "SELECT RELEASE_LOCK('" . pSQL($lockKey) . "')"
+            "SELECT RELEASE_LOCK('" . $lockKey . "')"
         );
+
+        if ($this->lockedCartId !== null && $released === false) {
+            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for cartId ' . $cartId);
+        }
 
         if ($released) {
             $this->lockedCartId = null;
@@ -100,7 +104,6 @@ class CartLockService
 
     /**
      * Returns true if this instance currently holds a lock.
-     * Useful for register_shutdown_function cleanup (PR 4).
      *
      * @return bool
      */

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -76,25 +76,21 @@ class CartLockService
      * Releases the advisory lock previously acquired for the given cart ID.
      * Safe to call even if the lock was never acquired (returns false in that case).
      *
-     * @param int $cartId
-     *
      * @return bool true if the lock was released, false if it was not held by this connection
      */
-    public function releaseLock($cartId)
+    public function releaseLock()
     {
-        if ($this->lockedCartId !== null && $this->lockedCartId !== (int) $cartId) {
-            LoggerFactory::instance()->warning('[Alma] releaseLock called with wrong cartId: expected ' . $this->lockedCartId . ', got ' . (int) $cartId);
-
-            $cartId = $this->lockedCartId;
+        if ($this->lockedCartId === null) {
+            return false;
         }
 
-        $lockKey = $this->getLockKey((int) $cartId);
+        $lockKey = $this->getLockKey((int) $this->lockedCartId);
         $released = (bool) \Db::getInstance()->getValue(
             "SELECT RELEASE_LOCK('" . $lockKey . "')"
         );
 
         if ($this->lockedCartId !== null && $released === false) {
-            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for cartId ' . $cartId);
+            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for cartId ' . $this->lockedCartId);
         }
 
         if ($released) {

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Services;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Provides an advisory MySQL lock (GET_LOCK / RELEASE_LOCK) to prevent concurrent order creation
+ * for the same cart. This is the recommended approach for PrestaShop: no Redis or external
+ * infrastructure required, and the lock is automatically released if the DB connection drops.
+ *
+ * Usage pattern:
+ *   1. acquireLock($cartId)  → enter critical section
+ *   2. check + validateOrder()
+ *   3. releaseLock($cartId)  → always in a finally block
+ */
+class CartLockService
+{
+    const LOCK_TIMEOUT_SECONDS = 10;
+    const LOCK_KEY_PREFIX = 'alma_order_cart_';
+
+    /** @var int|null Cart ID currently locked by this instance, null if no lock held */
+    private $lockedCartId = null;
+
+    /**
+     * Acquires a MySQL advisory lock for the given cart ID.
+     * If another process already holds the lock, waits up to $timeout seconds.
+     * Returns true if the lock was acquired, false on timeout.
+     *
+     * @param int $cartId
+     * @param int $timeout seconds to wait before giving up (default: 10)
+     *
+     * @return bool
+     */
+    public function acquireLock($cartId, $timeout = self::LOCK_TIMEOUT_SECONDS)
+    {
+        $lockKey = $this->getLockKey((int) $cartId);
+        $acquired = (bool) \Db::getInstance()->getValue(
+            "SELECT GET_LOCK('" . pSQL($lockKey) . "', " . (int) $timeout . ')'
+        );
+
+        if ($acquired) {
+            $this->lockedCartId = (int) $cartId;
+        }
+
+        return $acquired;
+    }
+
+    /**
+     * Releases the advisory lock previously acquired for the given cart ID.
+     * Safe to call even if the lock was never acquired (returns false in that case).
+     *
+     * @param int $cartId
+     *
+     * @return bool true if the lock was released, false if it was not held by this connection
+     */
+    public function releaseLock($cartId)
+    {
+        $lockKey = $this->getLockKey((int) $cartId);
+        $released = (bool) \Db::getInstance()->getValue(
+            "SELECT RELEASE_LOCK('" . pSQL($lockKey) . "')"
+        );
+
+        if ($released) {
+            $this->lockedCartId = null;
+        }
+
+        return $released;
+    }
+
+    /**
+     * Returns true if this instance currently holds a lock.
+     * Useful for register_shutdown_function cleanup (PR 4).
+     *
+     * @return bool
+     */
+    public function isLockAcquired()
+    {
+        return $this->lockedCartId !== null;
+    }
+
+    /**
+     * Returns the cart ID currently locked by this instance, or null.
+     *
+     * @return int|null
+     */
+    public function getLockedCartId()
+    {
+        return $this->lockedCartId;
+    }
+
+    /**
+     * @param int $cartId
+     *
+     * @return string
+     */
+    private function getLockKey($cartId)
+    {
+        return self::LOCK_KEY_PREFIX . $cartId;
+    }
+}

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -83,7 +83,9 @@ class CartLockService
     public function releaseLock($cartId)
     {
         if ($this->lockedCartId !== null && $this->lockedCartId !== (int) $cartId) {
-            LoggerFactory::instance()->warning('[Alma] releaseLock called with wrong cartId');
+            LoggerFactory::instance()->warning('[Alma] releaseLock called with wrong cartId: expected ' . $this->lockedCartId . ', got ' . (int) $cartId);
+
+            $cartId = $this->lockedCartId;
         }
 
         $lockKey = $this->getLockKey((int) $cartId);

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -93,9 +93,7 @@ class CartLockService
             LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for cartId ' . $this->lockedCartId);
         }
 
-        if ($released) {
-            $this->lockedCartId = null;
-        }
+        $this->lockedCartId = null;
 
         return $released;
     }

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -24,6 +24,8 @@
 
 namespace Alma\PrestaShop\Services;
 
+use Alma\PrestaShop\Factories\LoggerFactory;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -60,7 +62,7 @@ class CartLockService
     {
         $lockKey = $this->getLockKey((int) $cartId);
         $acquired = (bool) \Db::getInstance()->getValue(
-            "SELECT GET_LOCK('" . pSQL($lockKey) . "', " . (int) $timeout . ')'
+            "SELECT GET_LOCK('" . $lockKey . "', " . (int) $timeout . ')'
         );
 
         if ($acquired) {
@@ -80,6 +82,10 @@ class CartLockService
      */
     public function releaseLock($cartId)
     {
+        if ($this->lockedCartId !== null && $this->lockedCartId !== (int) $cartId) {
+            LoggerFactory::instance()->warning('[Alma] releaseLock called with wrong cartId');
+        }
+
         $lockKey = $this->getLockKey((int) $cartId);
         $released = (bool) \Db::getInstance()->getValue(
             "SELECT RELEASE_LOCK('" . pSQL($lockKey) . "')"

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -297,13 +297,7 @@ class PaymentValidation
                         );
                     } catch (\PrestaShopException $e) {
                         LoggerFactory::instance()->warning("[Alma] Error validation Order: {$e->getMessage()}");
-                        return $this->context->link->getPageLink('order-confirmation', true)
-                            . '?id_cart=' . (int) $cart->id
-                            . '&id_module=' . (int) $this->module->id
-                            . '&id_order=' . (int) $this->module->currentOrder
-                            . '&key=' . $customer->secure_key
-                            . '&recover_cart=' . $cart->id
-                            . '&token_cart=' . $tokenCart;
+                        return 'index.php?controller=order&step=1';
                     }
 
                     // Update payment's order reference

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -30,7 +30,6 @@ use Alma\API\RequestError;
 use Alma\PrestaShop\Builders\Helpers\PriceHelperBuilder;
 use Alma\PrestaShop\Builders\Helpers\SettingsHelperBuilder;
 use Alma\PrestaShop\Builders\Services\OrderServiceBuilder;
-use Alma\PrestaShop\Exceptions\OrderException;
 use Alma\PrestaShop\Exceptions\PaymentValidationException;
 use Alma\PrestaShop\Factories\ContextFactory;
 use Alma\PrestaShop\Factories\LoggerFactory;
@@ -156,10 +155,9 @@ class PaymentValidation
      *
      * @return string URL to redirect the customer to
      *
-     * @throws PaymentValidationException
-     * @throws PaymentValidationError
+     * @throws \Alma\PrestaShop\Exceptions\PaymentValidationException
+     * @throws \Alma\PrestaShop\Validators\PaymentValidationError
      * @throws \PrestaShopException
-     * @throws OrderException
      */
     public function validatePayment($almaPaymentId)
     {
@@ -225,6 +223,7 @@ class PaymentValidation
             throw new PaymentValidationError($cart, 'cannot load customer');
         }
 
+        $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
         if (!$this->cartProxy->orderExists((int) $cart->id)) {
             $firstInstalment = $payment->payment_plan[0];
             if (!in_array($payment->state, [Payment::STATE_IN_PROGRESS, Payment::STATE_PAID])) {
@@ -241,33 +240,21 @@ class PaymentValidation
                 throw new PaymentValidationError($cart, Payment::FRAUD_STATE_ERROR);
             }
 
-            // Acquire advisory MySQL lock — prevents concurrent validateOrder() for the same cart.
-            // Uses GET_LOCK which is connection-scoped: automatically released on DB disconnect/crash.
             if (!$this->cartLockService->acquireLock((int) $cart->id)) {
-                // Lock timeout: another process is already handling this cart.
-                // Check if it already created the order and redirect idempotently.
-                if ($this->cartProxy->orderExists((int) $cart->id)) {
-                    $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
-                    $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
+                $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
 
-                    return $this->context->link->getPageLink('order-confirmation', true)
-                        . '?id_cart=' . (int) $cart->id
-                        . '&id_module=' . (int) $this->module->id
-                        . '&id_order=' . (int) $this->module->currentOrder
-                        . '&key=' . $customer->secure_key
-                        . '&recover_cart=' . $cart->id
-                        . '&token_cart=' . $tokenCart;
-                }
-
-                throw new OrderException('Could not acquire lock for cart ' . $cart->id);
+                return $this->context->link->getPageLink('order-confirmation', true)
+                    . '?id_cart=' . (int) $cart->id
+                    . '&id_module=' . (int) $this->module->id
+                    . '&id_order=' . (int) $this->module->currentOrder
+                    . '&key=' . $customer->secure_key
+                    . '&recover_cart=' . $cart->id
+                    . '&token_cart=' . $tokenCart;
             }
 
             try {
-                // Critical section: re-check inside the lock to guard against the race condition
-                // where another process created the order between our first check and lock acquisition.
                 if ($this->cartProxy->orderExists((int) $cart->id)) {
                     $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
-                    $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
                     $extraRedirectArgs = '&recover_cart=' . $cart->id . '&token_cart=' . $tokenCart;
                 } else {
                     $extraVars = ['transaction_id' => $payment->id];
@@ -296,7 +283,7 @@ class PaymentValidation
                     $this->almaBusinessDataService->updateAlmaPaymentId($payment->id, $cart->id);
 
                     try {
-                        // Place order — PaymentModuleProxy does a final defensive orderExists() check
+                        // Place order
                         $this->paymentModuleProxy->validateOrder(
                             (int) $cart->id,
                             \Configuration::get('PS_OS_PAYMENT'),
@@ -310,6 +297,13 @@ class PaymentValidation
                         );
                     } catch (\PrestaShopException $e) {
                         LoggerFactory::instance()->warning("[Alma] Error validation Order: {$e->getMessage()}");
+                        return $this->context->link->getPageLink('order-confirmation', true)
+                            . '?id_cart=' . (int) $cart->id
+                            . '&id_module=' . (int) $this->module->id
+                            . '&id_order=' . (int) $this->module->currentOrder
+                            . '&key=' . $customer->secure_key
+                            . '&recover_cart=' . $cart->id
+                            . '&token_cart=' . $tokenCart;
                     }
 
                     // Update payment's order reference
@@ -344,7 +338,6 @@ class PaymentValidation
             }
         } else {
             $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
-            $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
             $extraRedirectArgs = "&recover_cart={$cart->id}&token_cart={$tokenCart}";
         }
 
@@ -365,6 +358,10 @@ class PaymentValidation
      */
     private function getOrderByCartId($cartId)
     {
+        if (!\Order::getIdByCartId((int) $cartId)) {
+            throw new PaymentValidationException('[Alma] Order does not exist', $cartId);
+        }
+
         if (is_callable(['\Order', 'getByCartId'])) {
             return \Order::getByCartId((int) $cartId);
         }

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -241,15 +241,19 @@ class PaymentValidation
             }
 
             if (!$this->cartLockService->acquireLock((int) $cart->id)) {
-                $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
+                if ($this->cartProxy->orderExists((int) $cart->id)) {
+                    $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
 
-                return $this->context->link->getPageLink('order-confirmation', true)
-                    . '?id_cart=' . (int) $cart->id
-                    . '&id_module=' . (int) $this->module->id
-                    . '&id_order=' . (int) $this->module->currentOrder
-                    . '&key=' . $customer->secure_key
-                    . '&recover_cart=' . $cart->id
-                    . '&token_cart=' . $tokenCart;
+                    return $this->context->link->getPageLink('order-confirmation', true)
+                        . '?id_cart=' . (int) $cart->id
+                        . '&id_module=' . (int) $this->module->id
+                        . '&id_order=' . (int) $this->module->currentOrder
+                        . '&key=' . $customer->secure_key
+                        . '&recover_cart=' . $cart->id
+                        . '&token_cart=' . $tokenCart;
+                }
+
+                throw new PaymentValidationException('[Alma] Unable to acquire lock and order does not exist for cart ' . $cart->id, $cart->id);
             }
 
             try {
@@ -328,7 +332,7 @@ class PaymentValidation
                     $extraRedirectArgs = '';
                 }
             } finally {
-                $this->cartLockService->releaseLock((int) $cart->id);
+                $this->cartLockService->releaseLock();
             }
         } else {
             $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -42,6 +42,7 @@ use Alma\PrestaShop\Helpers\ToolsHelper;
 use Alma\PrestaShop\Proxy\CartProxy;
 use Alma\PrestaShop\Proxy\PaymentModuleProxy;
 use Alma\PrestaShop\Services\AlmaBusinessDataService;
+use Alma\PrestaShop\Services\CartLockService;
 use Alma\PrestaShop\Services\OrderService;
 
 if (!defined('_PS_VERSION_')) {
@@ -90,16 +91,22 @@ class PaymentValidation
      * @var \Alma\PrestaShop\Proxy\CartProxy
      */
     private $cartProxy;
+    /**
+     * @var CartLockService
+     */
+    private $cartLockService;
 
     /**
      * @param ContextFactory $contextFactory
      * @param ModuleFactory $moduleFactory
      * @param PaymentValidator $clientPaymentValidator
+     * @param CartLockService|null $cartLockService
      */
     public function __construct(
         $contextFactory,
         $moduleFactory,
-        $clientPaymentValidator
+        $clientPaymentValidator,
+        $cartLockService = null
     ) {
         $this->context = $contextFactory->getContext();
         $this->module = $moduleFactory->getModule();
@@ -119,6 +126,7 @@ class PaymentValidation
         $this->almaBusinessDataService = new AlmaBusinessDataService();
         $this->cartProxy = new CartProxy();
         $this->paymentModuleProxy = new PaymentModuleProxy();
+        $this->cartLockService = $cartLockService ?: new CartLockService();
     }
 
     /**
@@ -217,7 +225,7 @@ class PaymentValidation
             throw new PaymentValidationError($cart, 'cannot load customer');
         }
 
-        if (!$this->cartProxy->checkOrderExistsForPayment($cart->id)) {
+        if (!$this->cartProxy->orderExists((int) $cart->id)) {
             $firstInstalment = $payment->payment_plan[0];
             if (!in_array($payment->state, [Payment::STATE_IN_PROGRESS, Payment::STATE_PAID])) {
                 try {
@@ -233,76 +241,107 @@ class PaymentValidation
                 throw new PaymentValidationError($cart, Payment::FRAUD_STATE_ERROR);
             }
 
-            $extraVars = ['transaction_id' => $payment->id];
+            // Acquire advisory MySQL lock — prevents concurrent validateOrder() for the same cart.
+            // Uses GET_LOCK which is connection-scoped: automatically released on DB disconnect/crash.
+            if (!$this->cartLockService->acquireLock((int) $cart->id)) {
+                // Lock timeout: another process is already handling this cart.
+                // Check if it already created the order and redirect idempotently.
+                if ($this->cartProxy->orderExists((int) $cart->id)) {
+                    $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
+                    $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
 
-            $installmentCount = $payment->installments_count;
-
-            if ($this->settingsHelper->isDeferred($payment)) {
-                $days = $this->settingsHelper->getDuration($payment);
-                $paymentMode = sprintf(
-                    $this->module->l('Alma - +%d days payment', 'PaymentValidation'),
-                    $days
-                );
-            } else {
-                if (1 === $installmentCount) {
-                    $paymentMode = $this->module->l('Alma - Pay now', 'PaymentValidation');
-                } else {
-                    $paymentMode = sprintf(
-                        $this->module->l('Alma - %d monthly installments', 'PaymentValidation'),
-                        $installmentCount
-                    );
+                    return $this->context->link->getPageLink('order-confirmation', true)
+                        . '?id_cart=' . (int) $cart->id
+                        . '&id_module=' . (int) $this->module->id
+                        . '&id_order=' . (int) $this->module->currentOrder
+                        . '&key=' . $customer->secure_key
+                        . '&recover_cart=' . $cart->id
+                        . '&token_cart=' . $tokenCart;
                 }
-            }
 
-            $planKey = SettingsHelper::planKeyFromPayment($payment);
-            $this->almaBusinessDataService->updatePlanKey($planKey, $cart->id);
-            $this->almaBusinessDataService->updateAlmaPaymentId($payment->id, $cart->id);
-
-            try {
-                // Place order
-                $this->paymentModuleProxy->validateOrder(
-                    (int) $cart->id,
-                    \Configuration::get('PS_OS_PAYMENT'),
-                    $this->priceHelper->convertPriceFromCents($payment->purchase_amount),
-                    $paymentMode,
-                    null,
-                    $extraVars,
-                    (int) $cart->id_currency,
-                    false,
-                    $customer->secure_key
-                );
-            } catch (\PrestaShopException $e) {
-                LoggerFactory::instance()->warning("[Alma] Error validation Order: {$e->getMessage()}");
-            }
-
-            \Db::getInstance()->execute('COMMIT');
-
-            // Update payment's order reference
-            $order = $this->getOrderByCartId((int) $cart->id);
-            $customData = $payment->custom_data;
-            $customData['id_order'] = $order->id;
-
-            try {
-                $alma->payments->edit($payment->id, [
-                    'payment' => [
-                        'custom_data' => $customData,
-                    ],
-                ]);
-            } catch (RequestError $e) {
-                $msg = "[Alma] Error updating order id {$order->id}: {$e->getMessage()}";
-                LoggerFactory::instance()->error($msg);
+                throw new OrderException('Could not acquire lock for cart ' . $cart->id);
             }
 
             try {
-                $alma->payments->addOrder($payment->id, [
-                    'merchant_reference' => $order->reference,
-                ]);
-            } catch (\Exception $e) {
-                $msg = "[Alma] Error updating order reference {$order->reference}: {$e->getMessage()}";
-                LoggerFactory::instance()->error($msg);
-            }
+                // Critical section: re-check inside the lock to guard against the race condition
+                // where another process created the order between our first check and lock acquisition.
+                if ($this->cartProxy->orderExists((int) $cart->id)) {
+                    $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
+                    $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
+                    $extraRedirectArgs = '&recover_cart=' . $cart->id . '&token_cart=' . $tokenCart;
+                } else {
+                    $extraVars = ['transaction_id' => $payment->id];
 
-            $extraRedirectArgs = '';
+                    $installmentCount = $payment->installments_count;
+
+                    if ($this->settingsHelper->isDeferred($payment)) {
+                        $days = $this->settingsHelper->getDuration($payment);
+                        $paymentMode = sprintf(
+                            $this->module->l('Alma - +%d days payment', 'PaymentValidation'),
+                            $days
+                        );
+                    } else {
+                        if (1 === $installmentCount) {
+                            $paymentMode = $this->module->l('Alma - Pay now', 'PaymentValidation');
+                        } else {
+                            $paymentMode = sprintf(
+                                $this->module->l('Alma - %d monthly installments', 'PaymentValidation'),
+                                $installmentCount
+                            );
+                        }
+                    }
+
+                    $planKey = SettingsHelper::planKeyFromPayment($payment);
+                    $this->almaBusinessDataService->updatePlanKey($planKey, $cart->id);
+                    $this->almaBusinessDataService->updateAlmaPaymentId($payment->id, $cart->id);
+
+                    try {
+                        // Place order — PaymentModuleProxy does a final defensive orderExists() check
+                        $this->paymentModuleProxy->validateOrder(
+                            (int) $cart->id,
+                            \Configuration::get('PS_OS_PAYMENT'),
+                            $this->priceHelper->convertPriceFromCents($payment->purchase_amount),
+                            $paymentMode,
+                            null,
+                            $extraVars,
+                            (int) $cart->id_currency,
+                            false,
+                            $customer->secure_key
+                        );
+                    } catch (\PrestaShopException $e) {
+                        LoggerFactory::instance()->warning("[Alma] Error validation Order: {$e->getMessage()}");
+                    }
+
+                    // Update payment's order reference
+                    $order = $this->getOrderByCartId((int) $cart->id);
+                    $customData = $payment->custom_data;
+                    $customData['id_order'] = $order->id;
+
+                    try {
+                        $alma->payments->edit($payment->id, [
+                            'payment' => [
+                                'custom_data' => $customData,
+                            ],
+                        ]);
+                    } catch (RequestError $e) {
+                        $msg = "[Alma] Error updating order id {$order->id}: {$e->getMessage()}";
+                        LoggerFactory::instance()->error($msg);
+                    }
+
+                    try {
+                        $alma->payments->addOrder($payment->id, [
+                            'merchant_reference' => $order->reference,
+                        ]);
+                    } catch (\Exception $e) {
+                        $msg = "[Alma] Error updating order reference {$order->reference}: {$e->getMessage()}";
+                        LoggerFactory::instance()->error($msg);
+                    }
+
+                    $extraRedirectArgs = '';
+                }
+            } finally {
+                $this->cartLockService->releaseLock((int) $cart->id);
+            }
         } else {
             $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
             $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);

--- a/alma/tests/Unit/Proxy/CartProxyTest.php
+++ b/alma/tests/Unit/Proxy/CartProxyTest.php
@@ -33,7 +33,7 @@ class CartProxyTest extends TestCase
     /**
      * @var CartProxy
      */
-    private $cartProxyPsAfter1770;
+    private $cartProxy;
     /**
      * @var CartFactory
      */

--- a/alma/tests/Unit/Proxy/PaymentModuleProxyTest.php
+++ b/alma/tests/Unit/Proxy/PaymentModuleProxyTest.php
@@ -47,7 +47,7 @@ class PaymentModuleProxyTest extends TestCase
     {
         $cartId = 1;
         $this->cartProxyMock->expects($this->once())
-            ->method('checkOrderExistsForPayment')
+            ->method('orderExists')
             ->with($cartId)
             ->willReturn(true);
         $this->moduleMock->expects($this->never())
@@ -72,7 +72,7 @@ class PaymentModuleProxyTest extends TestCase
     {
         $cartId = 1;
         $this->cartProxyMock->expects($this->once())
-            ->method('checkOrderExistsForPayment')
+            ->method('orderExists')
             ->with($cartId)
             ->willReturn(false);
         $this->moduleMock->expects($this->once())

--- a/alma/tests/Unit/Services/CartLockServiceTest.php
+++ b/alma/tests/Unit/Services/CartLockServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Services;
+
+use Alma\PrestaShop\Services\CartLockService;
+use PHPUnit\Framework\TestCase;
+
+class CartLockServiceTest extends TestCase
+{
+    /** @var CartLockService */
+    private $cartLockService;
+
+    /** @var \Db|\PHPUnit\Framework\MockObject\MockObject */
+    private $dbMock;
+
+    public function setUp()
+    {
+        $this->dbMock = $this->createMock(\Db::class);
+        \Db::setInstance($this->dbMock);
+        $this->cartLockService = new CartLockService();
+    }
+
+    public function tearDown()
+    {
+        $this->cartLockService = null;
+    }
+
+    public function testAcquireLockReturnsTrueWhenMySQLGrantsLock()
+    {
+        $this->dbMock->expects($this->once())
+            ->method('getValue')
+            ->with($this->stringContains("GET_LOCK('alma_order_cart_42', 10)"))
+            ->willReturn('1');
+
+        $this->assertTrue($this->cartLockService->acquireLock(42));
+    }
+
+    public function testAcquireLockReturnsFalseOnTimeout()
+    {
+        $this->dbMock->expects($this->once())
+            ->method('getValue')
+            ->willReturn('0');
+
+        $this->assertFalse($this->cartLockService->acquireLock(42));
+    }
+
+    public function testAcquireLockStoresCartId()
+    {
+        $this->dbMock->method('getValue')->willReturn('1');
+
+        $this->cartLockService->acquireLock(42);
+
+        $this->assertTrue($this->cartLockService->isLockAcquired());
+        $this->assertSame(42, $this->cartLockService->getLockedCartId());
+    }
+
+    public function testAcquireLockDoesNotSetCartIdOnFailure()
+    {
+        $this->dbMock->method('getValue')->willReturn('0');
+
+        $this->cartLockService->acquireLock(42);
+
+        $this->assertFalse($this->cartLockService->isLockAcquired());
+        $this->assertNull($this->cartLockService->getLockedCartId());
+    }
+
+    public function testReleaseLockReturnsTrueWhenSuccessful()
+    {
+        $this->dbMock->method('getValue')->willReturnOnConsecutiveCalls('1', '1');
+
+        $this->cartLockService->acquireLock(42);
+        $this->assertTrue($this->cartLockService->releaseLock(42));
+    }
+
+    public function testReleaseLockClearsLockedCartId()
+    {
+        $this->dbMock->method('getValue')->willReturnOnConsecutiveCalls('1', '1');
+
+        $this->cartLockService->acquireLock(42);
+        $this->cartLockService->releaseLock(42);
+
+        $this->assertFalse($this->cartLockService->isLockAcquired());
+        $this->assertNull($this->cartLockService->getLockedCartId());
+    }
+
+    public function testReleaseLockReturnsFalseWhenLockNotHeld()
+    {
+        $this->dbMock->method('getValue')->willReturn('0');
+
+        $this->assertFalse($this->cartLockService->releaseLock(42));
+        $this->assertNull($this->cartLockService->getLockedCartId());
+    }
+
+    public function testIsLockAcquiredIsFalseByDefault()
+    {
+        $this->assertFalse($this->cartLockService->isLockAcquired());
+        $this->assertNull($this->cartLockService->getLockedCartId());
+    }
+
+    public function testLockKeyContainsCartId()
+    {
+        $this->dbMock->expects($this->once())
+            ->method('getValue')
+            ->with($this->stringContains('alma_order_cart_99'))
+            ->willReturn('1');
+
+        $this->cartLockService->acquireLock(99);
+    }
+
+    public function testAcquireLockUsesCustomTimeout()
+    {
+        $this->dbMock->expects($this->once())
+            ->method('getValue')
+            ->with($this->stringContains("GET_LOCK('alma_order_cart_5', 30)"))
+            ->willReturn('1');
+
+        $this->cartLockService->acquireLock(5, 30);
+    }
+}

--- a/alma/tests/Unit/Services/CartLockServiceTest.php
+++ b/alma/tests/Unit/Services/CartLockServiceTest.php
@@ -38,7 +38,7 @@ class CartLockServiceTest extends TestCase
     public function setUp()
     {
         $this->dbMock = $this->createMock(\Db::class);
-        \Db::setInstance($this->dbMock);
+        \Db::setInstanceForTesting($this->dbMock);
         $this->cartLockService = new CartLockService();
     }
 

--- a/alma/tests/Unit/Services/CartLockServiceTest.php
+++ b/alma/tests/Unit/Services/CartLockServiceTest.php
@@ -91,7 +91,7 @@ class CartLockServiceTest extends TestCase
         $this->dbMock->method('getValue')->willReturnOnConsecutiveCalls('1', '1');
 
         $this->cartLockService->acquireLock(42);
-        $this->assertTrue($this->cartLockService->releaseLock(42));
+        $this->assertTrue($this->cartLockService->releaseLock());
     }
 
     public function testReleaseLockClearsLockedCartId()
@@ -99,7 +99,7 @@ class CartLockServiceTest extends TestCase
         $this->dbMock->method('getValue')->willReturnOnConsecutiveCalls('1', '1');
 
         $this->cartLockService->acquireLock(42);
-        $this->cartLockService->releaseLock(42);
+        $this->cartLockService->releaseLock();
 
         $this->assertFalse($this->cartLockService->isLockAcquired());
         $this->assertNull($this->cartLockService->getLockedCartId());
@@ -109,7 +109,7 @@ class CartLockServiceTest extends TestCase
     {
         $this->dbMock->method('getValue')->willReturn('0');
 
-        $this->assertFalse($this->cartLockService->releaseLock(42));
+        $this->assertFalse($this->cartLockService->releaseLock());
         $this->assertNull($this->cartLockService->getLockedCartId());
     }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](feature/ecom-4060-handle-advisory-lock-get_lockrelease_lock)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
The first step to avoid order duplicate, we add a GET_LOCK in SQL to lock the similar request of validation.
The first request make the GET_LOCK for 10s. The second is locked and if the first one is finish we RELEASE the LOCK.
Finally the second will not be created because the order will have time to be created in DB.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->