### PR TITLE
feat: Add check payment converted before create PS Order

### DIFF
--- a/alma/alma.php
+++ b/alma/alma.php
@@ -236,6 +236,7 @@ class Alma extends PaymentModule
     {
         $tabsHelper = new \Alma\PrestaShop\Helpers\Admin\TabsHelper();
         $almaBusinessDataRepository = new \Alma\PrestaShop\Repositories\AlmaBusinessDataRepository();
+        $almaPaymentRepository = new \Alma\PrestaShop\Repositories\AlmaPaymentRepository();
 
         try {
             $this->checkPsAccountsPresence();
@@ -261,6 +262,7 @@ class Alma extends PaymentModule
         }
 
         $almaBusinessDataRepository->createTable();
+        $almaPaymentRepository->createTable();
 
         return $tabsHelper->installTabs($this->dataTabs());
     }

--- a/alma/controllers/front/payment.php
+++ b/alma/controllers/front/payment.php
@@ -28,6 +28,7 @@ use Alma\PrestaShop\Factories\LoggerFactory;
 use Alma\PrestaShop\Helpers\ClientHelper;
 use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Model\PaymentData;
+use Alma\PrestaShop\Repositories\AlmaPaymentRepository;
 use Alma\PrestaShop\Traits\AjaxTrait;
 
 if (!defined('_PS_VERSION_')) {
@@ -54,6 +55,11 @@ class AlmaPaymentModuleFrontController extends ModuleFrontController
     protected $settingsHelper;
 
     /**
+     * @var AlmaPaymentRepository
+     */
+    protected $almaPaymentRepository;
+
+    /**
      * @codeCoverageIgnore
      */
     public function __construct()
@@ -67,6 +73,8 @@ class AlmaPaymentModuleFrontController extends ModuleFrontController
 
         $paymentDataBuilder = new PaymentDataBuilder();
         $this->paymentData = $paymentDataBuilder->getInstance();
+
+        $this->almaPaymentRepository = new AlmaPaymentRepository();
     }
 
     /**
@@ -156,6 +164,7 @@ class AlmaPaymentModuleFrontController extends ModuleFrontController
             }
 
             $payment = $alma->payments->create($data);
+            $this->almaPaymentRepository->trackInitialPayment((int) $cart->id, $payment->id, $payment->state);
         } catch (Exception $e) {
             $msg = sprintf(
                 '[Alma] ERROR when creating payment for Cart %s: %s - Trace %s',

--- a/alma/controllers/front/payment.php
+++ b/alma/controllers/front/payment.php
@@ -164,7 +164,14 @@ class AlmaPaymentModuleFrontController extends ModuleFrontController
             }
 
             $payment = $alma->payments->create($data);
-            $this->almaPaymentRepository->trackInitialPayment((int) $cart->id, $payment->id, $payment->state);
+            if (!$this->almaPaymentRepository->trackInitialPayment((int) $cart->id, $payment->id, $payment->state)) {
+                LoggerFactory::instance()->warning(sprintf(
+                    '[Alma] Failed to track initial payment for Cart %s, Payment %s and status %s',
+                    $cart->id,
+                    $payment->id,
+                    $payment->state
+                ));
+            }
         } catch (Exception $e) {
             $msg = sprintf(
                 '[Alma] ERROR when creating payment for Cart %s: %s - Trace %s',

--- a/alma/controllers/front/payment.php
+++ b/alma/controllers/front/payment.php
@@ -164,7 +164,9 @@ class AlmaPaymentModuleFrontController extends ModuleFrontController
             }
 
             $payment = $alma->payments->create($data);
-            if (!$this->almaPaymentRepository->trackInitialPayment((int) $cart->id, $payment->id, $payment->state)) {
+            try {
+                $this->almaPaymentRepository->trackInitialPayment((int) $cart->id, $payment->id, $payment->state);
+            } catch (\Exception $e) {
                 LoggerFactory::instance()->warning(sprintf(
                     '[Alma] Failed to track initial payment for Cart %s, Payment %s and status %s',
                     $cart->id,

--- a/alma/lib/Factories/LoggerFactory.php
+++ b/alma/lib/Factories/LoggerFactory.php
@@ -34,12 +34,21 @@ if (!defined('_PS_VERSION_')) {
 class LoggerFactory
 {
     /**
+     * @var LoggerPsr1|LoggerPsr3|\Psr\Log\LoggerInterface|null
+     */
+    private static $testInstance = null;
+
+    /**
      * Need to return the correct logger depending on the PrestaShop version.
      *
      * @return LoggerPsr1|LoggerPsr3
      */
     public static function instance()
     {
+        if (self::$testInstance !== null) {
+            return self::$testInstance;
+        }
+
         static $instance;
         if (!$instance) {
             if (version_compare(_PS_VERSION_, '9', '>=')) {
@@ -50,5 +59,17 @@ class LoggerFactory
         }
 
         return $instance;
+    }
+
+    /**
+     * For testing purposes only. Allows injecting a mock logger.
+     *
+     * @param \Psr\Log\LoggerInterface|null $logger
+     *
+     * @return void
+     */
+    public static function setInstanceForTesting($logger)
+    {
+        self::$testInstance = $logger;
     }
 }

--- a/alma/lib/Repositories/AlmaPaymentRepository.php
+++ b/alma/lib/Repositories/AlmaPaymentRepository.php
@@ -24,6 +24,7 @@
 
 namespace Alma\PrestaShop\Repositories;
 
+use Alma\PrestaShop\Exceptions\PaymentValidationException;
 use Alma\PrestaShop\Factories\LoggerFactory;
 
 if (!defined('_PS_VERSION_')) {
@@ -34,26 +35,27 @@ if (!defined('_PS_VERSION_')) {
  * Repository for the ps_alma_payment table.
  *
  * This table is a SQL-level safety net against duplicate order creation.
- * The UNIQUE KEY on (id_cart, status) makes it impossible to insert two
- * CAPTURED rows for the same cart — even under concurrent load — because
+ * The UNIQUE KEY on (alma_payment_id, status) makes it impossible to insert two
+ * CAPTURED rows for the same Alma payment — even under concurrent load — because
  * the second INSERT will raise a MySQL 1062 error before validateOrder() is
  * ever called.
  *
  * It works as a complement to the advisory lock (CartLockService): the lock
  * handles the common race condition, while this constraint handles the edge
  * case where two processes both pass the lock (e.g. abnormal lock timeout).
+ * Using alma_payment_id (not id_cart) as the key ensures the protection is
+ * tied to the actual payment entity, which is globally unique at Alma's side.
  */
 class AlmaPaymentRepository
 {
-    const STATUS_PENDING = 'PENDING';
     const STATUS_CAPTURED = 'CAPTURED';
-    const STATUS_FAILED = 'FAILED';
     const MYSQL_DUPLICATE_ENTRY_CODE = 1062;
 
     /**
      * Creates the ps_alma_payment table.
-     * The UNIQUE KEY uq_cart_captured on (id_cart, status) guarantees that
-     * a given cart cannot have more than one CAPTURED row — blocking SQL-level duplicates.
+     * The UNIQUE KEY uq_payment_status on (alma_payment_id, status) guarantees that
+     * a given Alma payment cannot have more than one CAPTURED row — blocking SQL-level duplicates.
+     * alma_payment_id is globally unique at Alma's side and is the correct entity identifier.
      *
      * @return bool
      */
@@ -66,27 +68,53 @@ class AlmaPaymentRepository
             `status`           VARCHAR(50)  NOT NULL,
             `created_at`       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (`id_alma_payment`),
-            UNIQUE KEY `uq_cart_captured` (`id_cart`, `status`)
+            UNIQUE KEY `uq_payment_status` (`alma_payment_id`, `status`)
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4;';
 
         return \Db::getInstance()->execute($sql);
     }
 
     /**
-     * Attempts to insert a CAPTURED row for the given cart before validateOrder() is called.
+     * Records the initial payment state right after creation in payment.php, before the customer
+     * is redirected to Alma's checkout. This creates the row that will later be updated to CAPTURED
+     * when the customer returns. Uses INSERT ... ON DUPLICATE KEY UPDATE so it is safely idempotent
+     * (browser retries, network glitches).
+     *
+     * @param int    $cartId
+     * @param string $almaPaymentId
+     * @param string $status        The initial state returned by Alma (e.g. "not_started")
+     *
+     * @return bool
+     */
+    public function trackInitialPayment($cartId, $almaPaymentId, $status)
+    {
+        $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'alma_payment`
+                    (`id_cart`, `alma_payment_id`, `status`)
+                VALUES
+                    (' . (int) $cartId . ', \'' . pSQL($almaPaymentId) . '\', \'' . pSQL($status) . '\')
+                ON DUPLICATE KEY UPDATE
+                    `status` = VALUES(`status`),
+                    `created_at` = `created_at`';
+
+        return \Db::getInstance()->execute($sql);
+    }
+
+    /**
+     * Attempts to insert a CAPTURED row for the given payment before validateOrder() is called.
      *
      * Returns true if the INSERT succeeded (this process is the sole owner of the capture).
      * Returns false if a UNIQUE KEY violation is raised (MySQL 1062), meaning another process
-     * already inserted a CAPTURED row for this cart — validateOrder() must NOT be called.
+     * already inserted a CAPTURED row for this payment — validateOrder() must NOT be called.
      *
-     * Any other database exception is re-thrown so the caller can handle it appropriately.
+     * Any other database exception is wrapped in a PaymentValidationException so the caller
+     * can handle it explicitly (e.g. redirect to error page) without leaking DB internals.
      *
      * @param int    $cartId
      * @param string $almaPaymentId
      *
      * @return bool true if INSERT succeeded, false on duplicate
      *
-     * @throws \PrestaShopDatabaseException on unexpected DB errors
+     * @throws PaymentValidationException on unexpected DB errors
      */
     public function insertCapture($cartId, $almaPaymentId)
     {
@@ -95,37 +123,25 @@ class AlmaPaymentRepository
                 'alma_payment',
                 [
                     'id_cart' => (int) $cartId,
-                    'alma_payment_id' => pSQL($almaPaymentId),
-                    'status' => pSQL(self::STATUS_CAPTURED),
+                    'alma_payment_id' => $almaPaymentId,
+                    'status' => self::STATUS_CAPTURED,
                 ]
             );
         } catch (\PrestaShopDatabaseException $e) {
             if ($this->isDuplicateEntryError($e)) {
                 LoggerFactory::instance()->warning(
-                    '[Alma] Duplicate CAPTURED row blocked for cart ' . $cartId . ' — order already being created by another process'
+                    '[Alma] Duplicate CAPTURED row blocked for payment ' . $almaPaymentId . ' — order already being created by another process'
                 );
 
                 return false;
             }
 
-            throw $e;
-        }
-    }
+            LoggerFactory::instance()->error(
+                '[Alma] Unexpected DB error in insertCapture for payment ' . $almaPaymentId . ': ' . $e->getMessage()
+            );
 
-    /**
-     * Removes all payment rows for a given cart.
-     * Useful for cleanup in tests or error recovery.
-     *
-     * @param int $cartId
-     *
-     * @return bool
-     */
-    public function deleteByCartId($cartId)
-    {
-        return \Db::getInstance()->delete(
-            'alma_payment',
-            '`id_cart` = ' . (int) $cartId
-        );
+            throw new PaymentValidationException('[Alma] DB error during capture insert for payment ' . $almaPaymentId, (int) $cartId, 0, $e);
+        }
     }
 
     /**

--- a/alma/lib/Repositories/AlmaPaymentRepository.php
+++ b/alma/lib/Repositories/AlmaPaymentRepository.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Repositories;
+
+use Alma\PrestaShop\Factories\LoggerFactory;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Repository for the ps_alma_payment table.
+ *
+ * This table is a SQL-level safety net against duplicate order creation.
+ * The UNIQUE KEY on (id_cart, status) makes it impossible to insert two
+ * CAPTURED rows for the same cart — even under concurrent load — because
+ * the second INSERT will raise a MySQL 1062 error before validateOrder() is
+ * ever called.
+ *
+ * It works as a complement to the advisory lock (CartLockService): the lock
+ * handles the common race condition, while this constraint handles the edge
+ * case where two processes both pass the lock (e.g. abnormal lock timeout).
+ */
+class AlmaPaymentRepository
+{
+    const STATUS_PENDING = 'PENDING';
+    const STATUS_CAPTURED = 'CAPTURED';
+    const STATUS_FAILED = 'FAILED';
+    const MYSQL_DUPLICATE_ENTRY_CODE = 1062;
+
+    /**
+     * Creates the ps_alma_payment table.
+     * The UNIQUE KEY uq_cart_captured on (id_cart, status) guarantees that
+     * a given cart cannot have more than one CAPTURED row — blocking SQL-level duplicates.
+     *
+     * @return bool
+     */
+    public function createTable()
+    {
+        $sql = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'alma_payment` (
+            `id_alma_payment`  INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `id_cart`          INT UNSIGNED NOT NULL,
+            `alma_payment_id`  VARCHAR(255) NOT NULL,
+            `status`           VARCHAR(50)  NOT NULL,
+            `created_at`       DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (`id_alma_payment`),
+            UNIQUE KEY `uq_cart_captured` (`id_cart`, `status`)
+        ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4;';
+
+        return \Db::getInstance()->execute($sql);
+    }
+
+    /**
+     * Attempts to insert a CAPTURED row for the given cart before validateOrder() is called.
+     *
+     * Returns true if the INSERT succeeded (this process is the sole owner of the capture).
+     * Returns false if a UNIQUE KEY violation is raised (MySQL 1062), meaning another process
+     * already inserted a CAPTURED row for this cart — validateOrder() must NOT be called.
+     *
+     * Any other database exception is re-thrown so the caller can handle it appropriately.
+     *
+     * @param int    $cartId
+     * @param string $almaPaymentId
+     *
+     * @return bool true if INSERT succeeded, false on duplicate
+     *
+     * @throws \PrestaShopDatabaseException on unexpected DB errors
+     */
+    public function insertCapture($cartId, $almaPaymentId)
+    {
+        try {
+            return \Db::getInstance()->insert(
+                'alma_payment',
+                [
+                    'id_cart' => (int) $cartId,
+                    'alma_payment_id' => pSQL($almaPaymentId),
+                    'status' => pSQL(self::STATUS_CAPTURED),
+                ]
+            );
+        } catch (\PrestaShopDatabaseException $e) {
+            if ($this->isDuplicateEntryError($e)) {
+                LoggerFactory::instance()->warning(
+                    '[Alma] Duplicate CAPTURED row blocked for cart ' . $cartId . ' — order already being created by another process'
+                );
+
+                return false;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Removes all payment rows for a given cart.
+     * Useful for cleanup in tests or error recovery.
+     *
+     * @param int $cartId
+     *
+     * @return bool
+     */
+    public function deleteByCartId($cartId)
+    {
+        return \Db::getInstance()->delete(
+            'alma_payment',
+            '`id_cart` = ' . (int) $cartId
+        );
+    }
+
+    /**
+     * Returns true if the given exception was caused by a MySQL duplicate entry error (1062).
+     *
+     * @param \PrestaShopDatabaseException $e
+     *
+     * @return bool
+     */
+    private function isDuplicateEntryError(\PrestaShopDatabaseException $e)
+    {
+        return strpos($e->getMessage(), (string) self::MYSQL_DUPLICATE_ENTRY_CODE) !== false
+            || strpos($e->getMessage(), 'Duplicate entry') !== false;
+    }
+}

--- a/alma/lib/Repositories/AlmaPaymentRepository.php
+++ b/alma/lib/Repositories/AlmaPaymentRepository.php
@@ -87,13 +87,10 @@ class AlmaPaymentRepository
      */
     public function trackInitialPayment($cartId, $almaPaymentId, $status)
     {
-        $sql = 'INSERT INTO `' . _DB_PREFIX_ . 'alma_payment`
+        $sql = 'INSERT IGNORE INTO `' . _DB_PREFIX_ . 'alma_payment`
                     (`id_cart`, `alma_payment_id`, `status`)
                 VALUES
-                    (' . (int) $cartId . ', \'' . pSQL($almaPaymentId) . '\', \'' . pSQL($status) . '\')
-                ON DUPLICATE KEY UPDATE
-                    `status` = VALUES(`status`),
-                    `created_at` = `created_at`';
+                    (' . (int) $cartId . ', \'' . pSQL($almaPaymentId) . '\', \'' . pSQL($status) . '\')';
 
         return \Db::getInstance()->execute($sql);
     }

--- a/alma/lib/Repositories/AlmaPaymentRepository.php
+++ b/alma/lib/Repositories/AlmaPaymentRepository.php
@@ -153,7 +153,7 @@ class AlmaPaymentRepository
      */
     private function isDuplicateEntryError(\PrestaShopDatabaseException $e)
     {
-        return strpos($e->getMessage(), (string) self::MYSQL_DUPLICATE_ENTRY_CODE) !== false
+        return strpos($e->getCode(), self::MYSQL_DUPLICATE_ENTRY_CODE) !== false
             || strpos($e->getMessage(), 'Duplicate entry') !== false;
     }
 }

--- a/alma/lib/Repositories/AlmaPaymentRepository.php
+++ b/alma/lib/Repositories/AlmaPaymentRepository.php
@@ -49,7 +49,6 @@ if (!defined('_PS_VERSION_')) {
 class AlmaPaymentRepository
 {
     const STATUS_CAPTURED = 'CAPTURED';
-    const MYSQL_DUPLICATE_ENTRY_CODE = 1062;
 
     /**
      * Creates the ps_alma_payment table.
@@ -153,7 +152,6 @@ class AlmaPaymentRepository
      */
     private function isDuplicateEntryError(\PrestaShopDatabaseException $e)
     {
-        return strpos($e->getCode(), self::MYSQL_DUPLICATE_ENTRY_CODE) !== false
-            || strpos($e->getMessage(), 'Duplicate entry') !== false;
+        return strpos($e->getMessage(), 'Duplicate entry') !== false;
     }
 }

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -298,9 +298,13 @@ class PaymentValidation
                         LoggerFactory::instance()->warning(
                             "[Alma] Duplicate capture blocked by UNIQUE constraint for cart {$cart->id} — skipping validateOrder()"
                         );
-                        $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
-                        $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
-                        $extraRedirectArgs = '&recover_cart=' . $cart->id . '&token_cart=' . $tokenCart;
+                        if ($this->cartProxy->orderExists((int) $cart->id)) {
+                            $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
+                            $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
+                            $extraRedirectArgs = '&recover_cart=' . $cart->id . '&token_cart=' . $tokenCart;
+                        } else {
+                            throw new PaymentValidationException('[Alma] Duplicate capture blocked but order not yet created for cart ' . $cart->id, $cart->id);
+                        }
                     } else {
                         try {
                             // Place order

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -40,6 +40,7 @@ use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Helpers\ToolsHelper;
 use Alma\PrestaShop\Proxy\CartProxy;
 use Alma\PrestaShop\Proxy\PaymentModuleProxy;
+use Alma\PrestaShop\Repositories\AlmaPaymentRepository;
 use Alma\PrestaShop\Services\AlmaBusinessDataService;
 use Alma\PrestaShop\Services\CartLockService;
 use Alma\PrestaShop\Services\OrderService;
@@ -94,18 +95,24 @@ class PaymentValidation
      * @var CartLockService
      */
     private $cartLockService;
+    /**
+     * @var AlmaPaymentRepository
+     */
+    private $almaPaymentRepository;
 
     /**
      * @param ContextFactory $contextFactory
      * @param ModuleFactory $moduleFactory
      * @param PaymentValidator $clientPaymentValidator
      * @param CartLockService|null $cartLockService
+     * @param AlmaPaymentRepository|null $almaPaymentRepository
      */
     public function __construct(
         $contextFactory,
         $moduleFactory,
         $clientPaymentValidator,
-        $cartLockService = null
+        $cartLockService = null,
+        $almaPaymentRepository = null
     ) {
         $this->context = $contextFactory->getContext();
         $this->module = $moduleFactory->getModule();
@@ -126,6 +133,7 @@ class PaymentValidation
         $this->cartProxy = new CartProxy();
         $this->paymentModuleProxy = new PaymentModuleProxy();
         $this->cartLockService = $cartLockService ?: new CartLockService();
+        $this->almaPaymentRepository = $almaPaymentRepository ?: new AlmaPaymentRepository();
     }
 
     /**
@@ -286,50 +294,59 @@ class PaymentValidation
                     $this->almaBusinessDataService->updatePlanKey($planKey, $cart->id);
                     $this->almaBusinessDataService->updateAlmaPaymentId($payment->id, $cart->id);
 
-                    try {
-                        // Place order
-                        $this->paymentModuleProxy->validateOrder(
-                            (int) $cart->id,
-                            \Configuration::get('PS_OS_PAYMENT'),
-                            $this->priceHelper->convertPriceFromCents($payment->purchase_amount),
-                            $paymentMode,
-                            null,
-                            $extraVars,
-                            (int) $cart->id_currency,
-                            false,
-                            $customer->secure_key
+                    if (!$this->almaPaymentRepository->insertCapture((int) $cart->id, $payment->id)) {
+                        LoggerFactory::instance()->warning(
+                            "[Alma] Duplicate capture blocked by UNIQUE constraint for cart {$cart->id} — skipping validateOrder()"
                         );
-                    } catch (\PrestaShopException $e) {
-                        LoggerFactory::instance()->warning("[Alma] Error validation Order: {$e->getMessage()}");
-                        return 'index.php?controller=order&step=1';
+                        $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
+                        $tokenCart = md5(_COOKIE_KEY_ . 'recover_cart_' . $cart->id);
+                        $extraRedirectArgs = '&recover_cart=' . $cart->id . '&token_cart=' . $tokenCart;
+                    } else {
+                        try {
+                            // Place order
+                            $this->paymentModuleProxy->validateOrder(
+                                (int) $cart->id,
+                                \Configuration::get('PS_OS_PAYMENT'),
+                                $this->priceHelper->convertPriceFromCents($payment->purchase_amount),
+                                $paymentMode,
+                                null,
+                                $extraVars,
+                                (int) $cart->id_currency,
+                                false,
+                                $customer->secure_key
+                            );
+                        } catch (\PrestaShopException $e) {
+                            LoggerFactory::instance()->warning("[Alma] Error validation Order: {$e->getMessage()}");
+                            return 'index.php?controller=order&step=1';
+                        }
+
+                        // Update payment's order reference
+                        $order = $this->getOrderByCartId((int) $cart->id);
+                        $customData = $payment->custom_data;
+                        $customData['id_order'] = $order->id;
+
+                        try {
+                            $alma->payments->edit($payment->id, [
+                                'payment' => [
+                                    'custom_data' => $customData,
+                                ],
+                            ]);
+                        } catch (RequestError $e) {
+                            $msg = "[Alma] Error updating order id {$order->id}: {$e->getMessage()}";
+                            LoggerFactory::instance()->error($msg);
+                        }
+
+                        try {
+                            $alma->payments->addOrder($payment->id, [
+                                'merchant_reference' => $order->reference,
+                            ]);
+                        } catch (\Exception $e) {
+                            $msg = "[Alma] Error updating order reference {$order->reference}: {$e->getMessage()}";
+                            LoggerFactory::instance()->error($msg);
+                        }
+
+                        $extraRedirectArgs = '';
                     }
-
-                    // Update payment's order reference
-                    $order = $this->getOrderByCartId((int) $cart->id);
-                    $customData = $payment->custom_data;
-                    $customData['id_order'] = $order->id;
-
-                    try {
-                        $alma->payments->edit($payment->id, [
-                            'payment' => [
-                                'custom_data' => $customData,
-                            ],
-                        ]);
-                    } catch (RequestError $e) {
-                        $msg = "[Alma] Error updating order id {$order->id}: {$e->getMessage()}";
-                        LoggerFactory::instance()->error($msg);
-                    }
-
-                    try {
-                        $alma->payments->addOrder($payment->id, [
-                            'merchant_reference' => $order->reference,
-                        ]);
-                    } catch (\Exception $e) {
-                        $msg = "[Alma] Error updating order reference {$order->reference}: {$e->getMessage()}";
-                        LoggerFactory::instance()->error($msg);
-                    }
-
-                    $extraRedirectArgs = '';
                 }
             } finally {
                 $this->cartLockService->releaseLock();

--- a/alma/tests/Unit/Repositories/AlmaPaymentRepositoryTest.php
+++ b/alma/tests/Unit/Repositories/AlmaPaymentRepositoryTest.php
@@ -25,8 +25,10 @@
 namespace Alma\PrestaShop\Tests\Unit\Repositories;
 
 use Alma\PrestaShop\Exceptions\PaymentValidationException;
+use Alma\PrestaShop\Factories\LoggerFactory;
 use Alma\PrestaShop\Repositories\AlmaPaymentRepository;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class AlmaPaymentRepositoryTest extends TestCase
 {
@@ -46,6 +48,7 @@ class AlmaPaymentRepositoryTest extends TestCase
     public function tearDown()
     {
         $this->repository = null;
+        LoggerFactory::setInstanceForTesting(null);
     }
 
     public function testCreateTableExecutesCreateStatement()
@@ -89,19 +92,14 @@ class AlmaPaymentRepositoryTest extends TestCase
         $this->assertTrue($this->repository->insertCapture(42, 'pay_test_123'));
     }
 
-    public function testInsertCaptureReturnsFalseOnDuplicateEntry1062()
-    {
-        $duplicateException = new \PrestaShopDatabaseException('Duplicate entry for key uq_payment_status — 1062');
-
-        $this->dbMock->expects($this->once())
-            ->method('insert')
-            ->willThrowException($duplicateException);
-
-        $this->assertFalse($this->repository->insertCapture(42, 'pay_test_123'));
-    }
-
     public function testInsertCaptureReturnsFalseOnDuplicateEntryMessage()
     {
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())
+            ->method('warning');
+
+        LoggerFactory::setInstanceForTesting($loggerMock);
+
         $duplicateException = new \PrestaShopDatabaseException('Duplicate entry \'payment_123-CAPTURED\' for key \'uq_payment_status\'');
 
         $this->dbMock->expects($this->once())
@@ -113,6 +111,12 @@ class AlmaPaymentRepositoryTest extends TestCase
 
     public function testInsertCaptureRethrowsUnexpectedDatabaseException()
     {
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())
+            ->method('error');
+
+        LoggerFactory::setInstanceForTesting($loggerMock);
+
         $unexpectedException = new \PrestaShopDatabaseException('Table does not exist');
 
         $this->dbMock->expects($this->once())

--- a/alma/tests/Unit/Repositories/AlmaPaymentRepositoryTest.php
+++ b/alma/tests/Unit/Repositories/AlmaPaymentRepositoryTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * 2018-2024 Alma SAS.
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma SAS <contact@getalma.eu>
+ * @copyright 2018-2024 Alma SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\PrestaShop\Tests\Unit\Repositories;
+
+use Alma\PrestaShop\Repositories\AlmaPaymentRepository;
+use PHPUnit\Framework\TestCase;
+
+class AlmaPaymentRepositoryTest extends TestCase
+{
+    /** @var AlmaPaymentRepository */
+    private $repository;
+
+    /** @var \Db|\PHPUnit\Framework\MockObject\MockObject */
+    private $dbMock;
+
+    public function setUp()
+    {
+        $this->dbMock = $this->createMock(\Db::class);
+        \Db::setInstance($this->dbMock);
+        $this->repository = new AlmaPaymentRepository();
+    }
+
+    public function tearDown()
+    {
+        $this->repository = null;
+    }
+
+    public function testCreateTableExecutesCreateStatement()
+    {
+        $this->dbMock->expects($this->once())
+            ->method('execute')
+            ->with($this->stringContains('CREATE TABLE IF NOT EXISTS'))
+            ->willReturn(true);
+
+        $this->assertTrue($this->repository->createTable());
+    }
+
+    public function testCreateTableIncludesUniqueKeyConstraint()
+    {
+        $this->dbMock->expects($this->once())
+            ->method('execute')
+            ->with($this->stringContains('uq_cart_captured'))
+            ->willReturn(true);
+
+        $this->repository->createTable();
+    }
+
+    public function testInsertCaptureReturnsTrueOnSuccess()
+    {
+        $this->dbMock->expects($this->once())
+            ->method('insert')
+            ->with(
+                'alma_payment',
+                $this->callback(function ($data) {
+                    return $data['id_cart'] === 42
+                        && $data['alma_payment_id'] === 'pay_test_123'
+                        && $data['status'] === AlmaPaymentRepository::STATUS_CAPTURED;
+                })
+            )
+            ->willReturn(true);
+
+        $this->assertTrue($this->repository->insertCapture(42, 'pay_test_123'));
+    }
+
+    public function testInsertCaptureReturnsFalseOnDuplicateEntry1062()
+    {
+        $duplicateException = new \PrestaShopDatabaseException('Duplicate entry for key uq_cart_captured — 1062');
+
+        $this->dbMock->expects($this->once())
+            ->method('insert')
+            ->willThrowException($duplicateException);
+
+        $this->assertFalse($this->repository->insertCapture(42, 'pay_test_123'));
+    }
+
+    public function testInsertCaptureReturnsFalseOnDuplicateEntryMessage()
+    {
+        $duplicateException = new \PrestaShopDatabaseException('Duplicate entry \'42-CAPTURED\' for key \'uq_cart_captured\'');
+
+        $this->dbMock->expects($this->once())
+            ->method('insert')
+            ->willThrowException($duplicateException);
+
+        $this->assertFalse($this->repository->insertCapture(42, 'pay_test_456'));
+    }
+
+    public function testInsertCaptureRethrowsUnexpectedDatabaseException()
+    {
+        $unexpectedException = new \PrestaShopDatabaseException('Table does not exist');
+
+        $this->dbMock->expects($this->once())
+            ->method('insert')
+            ->willThrowException($unexpectedException);
+
+        $this->expectException(\PrestaShopDatabaseException::class);
+        $this->expectExceptionMessage('Table does not exist');
+
+        $this->repository->insertCapture(42, 'pay_test_789');
+    }
+
+    public function testDeleteByCartIdExecutesDeleteStatement()
+    {
+        $this->dbMock->expects($this->once())
+            ->method('delete')
+            ->with('alma_payment', '`id_cart` = 42')
+            ->willReturn(true);
+
+        $this->assertTrue($this->repository->deleteByCartId(42));
+    }
+
+    public function testStatusConstantsAreCorrect()
+    {
+        $this->assertSame('PENDING', AlmaPaymentRepository::STATUS_PENDING);
+        $this->assertSame('CAPTURED', AlmaPaymentRepository::STATUS_CAPTURED);
+        $this->assertSame('FAILED', AlmaPaymentRepository::STATUS_FAILED);
+    }
+}

--- a/alma/tests/Unit/Repositories/AlmaPaymentRepositoryTest.php
+++ b/alma/tests/Unit/Repositories/AlmaPaymentRepositoryTest.php
@@ -24,6 +24,7 @@
 
 namespace Alma\PrestaShop\Tests\Unit\Repositories;
 
+use Alma\PrestaShop\Exceptions\PaymentValidationException;
 use Alma\PrestaShop\Repositories\AlmaPaymentRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -38,7 +39,7 @@ class AlmaPaymentRepositoryTest extends TestCase
     public function setUp()
     {
         $this->dbMock = $this->createMock(\Db::class);
-        \Db::setInstance($this->dbMock);
+        \Db::setInstanceForTesting($this->dbMock);
         $this->repository = new AlmaPaymentRepository();
     }
 
@@ -61,7 +62,11 @@ class AlmaPaymentRepositoryTest extends TestCase
     {
         $this->dbMock->expects($this->once())
             ->method('execute')
-            ->with($this->stringContains('uq_cart_captured'))
+            ->with($this->logicalAnd(
+                $this->stringContains('uq_payment_status'),
+                $this->stringContains('alma_payment_id'),
+                $this->stringContains('status')
+            ))
             ->willReturn(true);
 
         $this->repository->createTable();
@@ -73,11 +78,11 @@ class AlmaPaymentRepositoryTest extends TestCase
             ->method('insert')
             ->with(
                 'alma_payment',
-                $this->callback(function ($data) {
-                    return $data['id_cart'] === 42
-                        && $data['alma_payment_id'] === 'pay_test_123'
-                        && $data['status'] === AlmaPaymentRepository::STATUS_CAPTURED;
-                })
+                [
+                    'id_cart' => 42,
+                    'alma_payment_id' => 'pay_test_123',
+                    'status' => AlmaPaymentRepository::STATUS_CAPTURED,
+                ]
             )
             ->willReturn(true);
 
@@ -86,7 +91,7 @@ class AlmaPaymentRepositoryTest extends TestCase
 
     public function testInsertCaptureReturnsFalseOnDuplicateEntry1062()
     {
-        $duplicateException = new \PrestaShopDatabaseException('Duplicate entry for key uq_cart_captured — 1062');
+        $duplicateException = new \PrestaShopDatabaseException('Duplicate entry for key uq_payment_status — 1062');
 
         $this->dbMock->expects($this->once())
             ->method('insert')
@@ -97,7 +102,7 @@ class AlmaPaymentRepositoryTest extends TestCase
 
     public function testInsertCaptureReturnsFalseOnDuplicateEntryMessage()
     {
-        $duplicateException = new \PrestaShopDatabaseException('Duplicate entry \'42-CAPTURED\' for key \'uq_cart_captured\'');
+        $duplicateException = new \PrestaShopDatabaseException('Duplicate entry \'payment_123-CAPTURED\' for key \'uq_payment_status\'');
 
         $this->dbMock->expects($this->once())
             ->method('insert')
@@ -114,26 +119,14 @@ class AlmaPaymentRepositoryTest extends TestCase
             ->method('insert')
             ->willThrowException($unexpectedException);
 
-        $this->expectException(\PrestaShopDatabaseException::class);
-        $this->expectExceptionMessage('Table does not exist');
+        $this->expectException(PaymentValidationException::class);
+        $this->expectExceptionMessage('DB error during capture insert for payment pay_test_789');
 
         $this->repository->insertCapture(42, 'pay_test_789');
     }
 
-    public function testDeleteByCartIdExecutesDeleteStatement()
+    public function testStatusConstantCapturedIsCorrect()
     {
-        $this->dbMock->expects($this->once())
-            ->method('delete')
-            ->with('alma_payment', '`id_cart` = 42')
-            ->willReturn(true);
-
-        $this->assertTrue($this->repository->deleteByCartId(42));
-    }
-
-    public function testStatusConstantsAreCorrect()
-    {
-        $this->assertSame('PENDING', AlmaPaymentRepository::STATUS_PENDING);
         $this->assertSame('CAPTURED', AlmaPaymentRepository::STATUS_CAPTURED);
-        $this->assertSame('FAILED', AlmaPaymentRepository::STATUS_FAILED);
     }
 }

--- a/alma/upgrade/upgrade-4.12.0.php
+++ b/alma/upgrade/upgrade-4.12.0.php
@@ -41,7 +41,9 @@ function upgrade_module_4_12_0($module)
     // The UNIQUE KEY on (alma_payment_id, status) prevents duplicate order creation
     // at the SQL level, as a complement to the advisory lock (CartLockService).
     $almaPaymentRepository = new \Alma\PrestaShop\Repositories\AlmaPaymentRepository();
-    $almaPaymentRepository->createTable();
+    if (!$almaPaymentRepository->createTable()) {
+        return false;
+    }
 
     if (version_compare(_PS_VERSION_, ConstantsHelper::PRESTASHOP_VERSION_1_7_0_2, '>')) {
         Tools::clearAllCache();

--- a/alma/upgrade/upgrade-4.12.0.php
+++ b/alma/upgrade/upgrade-4.12.0.php
@@ -38,7 +38,7 @@ function upgrade_module_4_12_0($module)
     require_once _PS_MODULE_DIR_ . 'alma/upgrade/autoload_upgrade.php';
 
     // Create the anti-duplication payment tracking table.
-    // The UNIQUE KEY on (id_cart, status) prevents duplicate order creation
+    // The UNIQUE KEY on (alma_payment_id, status) prevents duplicate order creation
     // at the SQL level, as a complement to the advisory lock (CartLockService).
     $almaPaymentRepository = new \Alma\PrestaShop\Repositories\AlmaPaymentRepository();
     $almaPaymentRepository->createTable();

--- a/alma/upgrade/upgrade-4.12.0.php
+++ b/alma/upgrade/upgrade-4.12.0.php
@@ -22,35 +22,31 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
 
-namespace Alma\PrestaShop\Builders\Validators;
-
-use Alma\PrestaShop\Repositories\AlmaPaymentRepository;
-use Alma\PrestaShop\Services\CartLockService;
-use Alma\PrestaShop\Traits\BuilderTrait;
-use Alma\PrestaShop\Validators\PaymentValidation;
+use Alma\PrestaShop\Helpers\ConstantsHelper;
 
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 
 /**
- * PaymentValidationBuilder.
+ * @param \Alma $module
+ *
+ * @return bool
  */
-class PaymentValidationBuilder
+function upgrade_module_4_12_0($module)
 {
-    use BuilderTrait;
+    require_once _PS_MODULE_DIR_ . 'alma/upgrade/autoload_upgrade.php';
 
-    /**
-     * @return PaymentValidation
-     */
-    public function getInstance()
-    {
-        return new PaymentValidation(
-            $this->getContextFactory(),
-            $this->getModuleFactory(),
-            $this->getClientPaymentValidator(),
-            new CartLockService(),
-            new AlmaPaymentRepository()
-        );
+    // Create the anti-duplication payment tracking table.
+    // The UNIQUE KEY on (id_cart, status) prevents duplicate order creation
+    // at the SQL level, as a complement to the advisory lock (CartLockService).
+    $almaPaymentRepository = new \Alma\PrestaShop\Repositories\AlmaPaymentRepository();
+    $almaPaymentRepository->createTable();
+
+    if (version_compare(_PS_VERSION_, ConstantsHelper::PRESTASHOP_VERSION_1_7_0_2, '>')) {
+        Tools::clearAllCache();
+        Tools::clearXMLCache();
     }
+
+    return true;
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4059/add-check-payment-converted-before-create-ps-order)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Second LOCK to avoid order duplication
- Create new db ps_alma_payment to track payment status
- Insert payment status in DB on created payment
- Insert payment status in DB on payment converted
- Check if payment converted before to create the PS order

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->