### PR TITLE
Feature/ecom 4061 handle duplicate refund

### DIFF
--- a/alma/controllers/admin/AdminAlmaRefunds.php
+++ b/alma/controllers/admin/AdminAlmaRefunds.php
@@ -91,13 +91,14 @@ class AdminAlmaRefundsController extends ModuleAdminController
         $amount = $this->getRefundAmount($refundType, $order);
 
         $refundResult = false;
-        if (!$this->lockService->acquireRefundLock($order->id_cart, (int) round($amount * 100), 3)) {
+        if (!$this->lockService->acquireRefundLock($order->id_cart, (int) round($amount * 100), 0)) {
             $msg = sprintf(
                 '[Alma] A refund is already in progress for Cart: %s and Amount: %s',
                 $order->id_cart,
                 $amount
             );
             LoggerFactory::instance()->warning($msg);
+            // Exit after render
             $this->ajaxFailAndDie(
                 $this->module->l($msg, 'AdminAlmaRefunds'),
                 423

--- a/alma/controllers/admin/AdminAlmaRefunds.php
+++ b/alma/controllers/admin/AdminAlmaRefunds.php
@@ -92,7 +92,7 @@ class AdminAlmaRefundsController extends ModuleAdminController
 
         $refundResult = false;
         $lockId = CartLockService::LOCK_REFUND_KEY_PREFIX . $order->id_cart . '_' . (int) round($amount * 100);
-        if (!$this->lockService->acquireLock($lockId)) {
+        if (!$this->lockService->acquireLock($lockId, 3)) {
             $msg = sprintf(
                 '[Alma] A refund is already in progress for Cart: %s and Amount: %s',
                 $order->id_cart,

--- a/alma/controllers/admin/AdminAlmaRefunds.php
+++ b/alma/controllers/admin/AdminAlmaRefunds.php
@@ -91,8 +91,7 @@ class AdminAlmaRefundsController extends ModuleAdminController
         $amount = $this->getRefundAmount($refundType, $order);
 
         $refundResult = false;
-        $lockId = CartLockService::LOCK_REFUND_KEY_PREFIX . $order->id_cart . '_' . (int) round($amount * 100);
-        if (!$this->lockService->acquireLock($lockId, 3)) {
+        if (!$this->lockService->acquireRefundLock($order->id_cart, (int) round($amount * 100), 3)) {
             $msg = sprintf(
                 '[Alma] A refund is already in progress for Cart: %s and Amount: %s',
                 $order->id_cart,
@@ -115,7 +114,7 @@ class AdminAlmaRefundsController extends ModuleAdminController
         } catch (PrestaShopException $e) {
             LoggerFactory::instance()->error('[Alma] PrestaShopException: ' . $e->getMessage());
         } finally {
-            $this->lockService->releaseLock();
+            $this->lockService->releaseRefundLock();
         }
 
         if (false === $refundResult) {

--- a/alma/controllers/admin/AdminAlmaRefunds.php
+++ b/alma/controllers/admin/AdminAlmaRefunds.php
@@ -91,10 +91,10 @@ class AdminAlmaRefundsController extends ModuleAdminController
         $amount = $this->getRefundAmount($refundType, $order);
 
         $refundResult = false;
-        $lockId = $order->id_cart . '_' . $amount;
-        if (!$this->lockService->acquireLock(CartLockService::LOCK_REFUND_KEY_PREFIX, $lockId)) {
+        $lockId = CartLockService::LOCK_REFUND_KEY_PREFIX . $order->id_cart . '_' . (int) round($amount * 100);
+        if (!$this->lockService->acquireLock($lockId)) {
             $msg = sprintf(
-                '[Alma] A refund was already executed for this Cart: %s and Amount: %s',
+                '[Alma] A refund is already in progress for Cart: %s and Amount: %s',
                 $order->id_cart,
                 $amount
             );
@@ -115,7 +115,7 @@ class AdminAlmaRefundsController extends ModuleAdminController
         } catch (PrestaShopException $e) {
             LoggerFactory::instance()->error('[Alma] PrestaShopException: ' . $e->getMessage());
         } finally {
-            $this->lockService->releaseLock(CartLockService::LOCK_REFUND_KEY_PREFIX);
+            $this->lockService->releaseLock();
         }
 
         if (false === $refundResult) {

--- a/alma/controllers/admin/AdminAlmaRefunds.php
+++ b/alma/controllers/admin/AdminAlmaRefunds.php
@@ -32,6 +32,7 @@ use Alma\PrestaShop\Helpers\ClientHelper;
 use Alma\PrestaShop\Helpers\OrderHelper;
 use Alma\PrestaShop\Helpers\PriceHelper;
 use Alma\PrestaShop\Helpers\RefundHelper;
+use Alma\PrestaShop\Services\CartLockService;
 use Alma\PrestaShop\Traits\AjaxTrait;
 
 if (!defined('_PS_VERSION_')) {
@@ -54,6 +55,10 @@ class AdminAlmaRefundsController extends ModuleAdminController
      * @var PriceHelper
      */
     protected $priceHelper;
+    /**
+     * @var CartLockService
+     */
+    private $lockService;
 
     /**
      * @codeCoverageIgnore
@@ -63,6 +68,7 @@ class AdminAlmaRefundsController extends ModuleAdminController
         parent::__construct();
         $priceHelperBuilder = new PriceHelperBuilder();
         $this->priceHelper = $priceHelperBuilder->getInstance();
+        $this->lockService = new CartLockService();
     }
 
     /**
@@ -85,6 +91,18 @@ class AdminAlmaRefundsController extends ModuleAdminController
         $amount = $this->getRefundAmount($refundType, $order);
 
         $refundResult = false;
+        $lockId = $order->id_cart . '_' . $amount;
+        if (!$this->lockService->acquireLock(CartLockService::LOCK_REFUND_KEY_PREFIX, $lockId)) {
+            $this->ajaxFailAndDie(
+                $this->module->l(sprintf(
+                    'A refund was already executed for this Cart: %s and Amount: %s',
+                    $order->id_cart,
+                    $amount
+                ), 'AdminAlmaRefunds'),
+                423
+            );
+        }
+
         try {
             $refundResult = $this->runRefund($paymentId, $amount, $isTotal);
         } catch (RequestError $e) {
@@ -94,6 +112,8 @@ class AdminAlmaRefundsController extends ModuleAdminController
             LoggerFactory::instance()->error('[Alma] RequestException: ' . $e->getMessage());
         } catch (PrestaShopException $e) {
             LoggerFactory::instance()->error('[Alma] PrestaShopException: ' . $e->getMessage());
+        } finally {
+            $this->lockService->releaseLock(CartLockService::LOCK_REFUND_KEY_PREFIX);
         }
 
         if (false === $refundResult) {

--- a/alma/controllers/admin/AdminAlmaRefunds.php
+++ b/alma/controllers/admin/AdminAlmaRefunds.php
@@ -93,12 +93,14 @@ class AdminAlmaRefundsController extends ModuleAdminController
         $refundResult = false;
         $lockId = $order->id_cart . '_' . $amount;
         if (!$this->lockService->acquireLock(CartLockService::LOCK_REFUND_KEY_PREFIX, $lockId)) {
+            $msg = sprintf(
+                '[Alma] A refund was already executed for this Cart: %s and Amount: %s',
+                $order->id_cart,
+                $amount
+            );
+            LoggerFactory::instance()->warning($msg);
             $this->ajaxFailAndDie(
-                $this->module->l(sprintf(
-                    'A refund was already executed for this Cart: %s and Amount: %s',
-                    $order->id_cart,
-                    $amount
-                ), 'AdminAlmaRefunds'),
+                $this->module->l($msg, 'AdminAlmaRefunds'),
                 423
             );
         }

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -54,19 +54,46 @@ class CartLockService
      * If another process already holds the lock, waits up to $timeout seconds.
      * Returns true if the lock was acquired, false on timeout.
      *
-     * @param string $lockId
+     * @param int $cartId
      * @param int $timeout seconds to wait before giving up (default: 10)
      *
      * @return bool
      */
-    public function acquireLock($lockId, $timeout = self::LOCK_TIMEOUT_SECONDS)
+    public function acquireLock($cartId, $timeout = self::LOCK_TIMEOUT_SECONDS)
     {
+        $lockKey = self::LOCK_ORDER_KEY_PREFIX . $cartId;
         $acquired = (bool) \Db::getInstance()->getValue(
-            "SELECT GET_LOCK('" . $lockId . "', " . (int) $timeout . ')'
+            "SELECT GET_LOCK('" . $lockKey . "', " . (int) $timeout . ')'
         );
 
         if ($acquired) {
-            $this->lockedId = $lockId;
+            $this->lockedId = $cartId;
+        }
+
+        return $acquired;
+    }
+
+    /**
+     * Acquires a MySQL advisory lock for the given cart ID and refund amount.
+     * This is used to prevent concurrent refunds for the same cart and amount.
+     * If another process already holds the lock, waits up to $timeout seconds.
+     * Returns true if the lock was acquired, false on timeout.
+     *
+     * @param int $cartId
+     * @param int $amount
+     * @param int $timeout seconds to wait before giving up (default: 10)
+     *
+     * @return bool
+     */
+    public function acquireRefundLock($cartId, $amount, $timeout = self::LOCK_TIMEOUT_SECONDS)
+    {
+        $lockKey = self::LOCK_REFUND_KEY_PREFIX . $cartId . '_' . $amount;
+        $acquired = (bool) \Db::getInstance()->getValue(
+            "SELECT GET_LOCK('" . $lockKey . "', " . (int) $timeout . ')'
+        );
+
+        if ($acquired) {
+            $this->lockedId = $cartId . '_' . $amount;
         }
 
         return $acquired;
@@ -84,12 +111,39 @@ class CartLockService
             return false;
         }
 
+        $lockKey = self::LOCK_ORDER_KEY_PREFIX . $this->lockedId;
         $released = (bool) \Db::getInstance()->getValue(
-            "SELECT RELEASE_LOCK('" . $this->lockedId . "')"
+            "SELECT RELEASE_LOCK('" . $lockKey . "')"
         );
 
         if ($released === false) {
-            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for Id ' . $this->lockedId);
+            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for Cart Id ' . $this->lockedId);
+        }
+
+        $this->lockedId = null;
+
+        return $released;
+    }
+
+    /**
+     * Releases the advisory lock previously acquired for the refund lock ID.
+     * Safe to call even if the lock was never acquired (returns false in that case).
+     *
+     * @return bool true if the lock was released, false if it was not held by this connection
+     */
+    public function releaseRefundLock()
+    {
+        if ($this->lockedId === null) {
+            return false;
+        }
+
+        $lockKey = self::LOCK_REFUND_KEY_PREFIX . $this->lockedId;
+        $released = (bool) \Db::getInstance()->getValue(
+            "SELECT RELEASE_LOCK('" . $lockKey . "')"
+        );
+
+        if ($released === false) {
+            LoggerFactory::instance()->warning('[Alma] releaseRefundLock failed to release lock for Cart Id and amount' . $this->lockedId);
         }
 
         $this->lockedId = null;

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -63,7 +63,7 @@ class CartLockService
      */
     public function acquireLock($cartId, $timeout = self::LOCK_TIMEOUT_SECONDS)
     {
-        $lockKey = self::LOCK_ORDER_KEY_PREFIX . $cartId;
+        $lockKey = self::LOCK_ORDER_KEY_PREFIX . (int) $cartId;
         $acquired = (bool) \Db::getInstance()->getValue(
             "SELECT GET_LOCK('" . $lockKey . "', " . (int) $timeout . ')'
         );
@@ -145,7 +145,7 @@ class CartLockService
         );
 
         if ($released === false) {
-            LoggerFactory::instance()->warning('[Alma] releaseRefundLock failed to release lock for Cart Id and amount: ' . $this->lockedOrderId);
+            LoggerFactory::instance()->warning('[Alma] releaseRefundLock failed to release lock for Cart Id and amount: ' . $this->lockedRefundId);
         }
 
         $this->lockedRefundId = null;

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -54,17 +54,15 @@ class CartLockService
      * If another process already holds the lock, waits up to $timeout seconds.
      * Returns true if the lock was acquired, false on timeout.
      *
-     * @param string $prefix
      * @param string $lockId
      * @param int $timeout seconds to wait before giving up (default: 10)
      *
      * @return bool
      */
-    public function acquireLock($prefix, $lockId, $timeout = self::LOCK_TIMEOUT_SECONDS)
+    public function acquireLock($lockId, $timeout = self::LOCK_TIMEOUT_SECONDS)
     {
-        $lockKey = $this->getLockKey($prefix, $lockId);
         $acquired = (bool) \Db::getInstance()->getValue(
-            "SELECT GET_LOCK('" . $lockKey . "', " . (int) $timeout . ')'
+            "SELECT GET_LOCK('" . $lockId . "', " . (int) $timeout . ')'
         );
 
         if ($acquired) {
@@ -80,53 +78,22 @@ class CartLockService
      *
      * @return bool true if the lock was released, false if it was not held by this connection
      */
-    public function releaseLock($prefix)
+    public function releaseLock()
     {
         if ($this->lockedId === null) {
             return false;
         }
 
-        $lockKey = $this->getLockKey($prefix, $this->lockedId);
         $released = (bool) \Db::getInstance()->getValue(
-            "SELECT RELEASE_LOCK('" . $lockKey . "')"
+            "SELECT RELEASE_LOCK('" . $this->lockedId . "')"
         );
 
-        if ($this->lockedId !== null && $released === false) {
+        if ($released === false) {
             LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for Id ' . $this->lockedId);
         }
 
         $this->lockedId = null;
 
         return $released;
-    }
-
-    /**
-     * Returns true if this instance currently holds a lock.
-     *
-     * @return bool
-     */
-    public function isLockAcquired()
-    {
-        return $this->lockedId !== null;
-    }
-
-    /**
-     * Returns the lock ID currently locked by this instance, or null.
-     *
-     * @return string|null
-     */
-    public function getLockedId()
-    {
-        return $this->lockedId;
-    }
-
-    /**
-     * @param string $lockId
-     *
-     * @return string
-     */
-    private function getLockKey($prefix, $lockId)
-    {
-        return $prefix . $lockId;
     }
 }

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -36,9 +36,9 @@ if (!defined('_PS_VERSION_')) {
  * infrastructure required, and the lock is automatically released if the DB connection drops.
  *
  * Usage pattern:
- *   1. acquireLock($prefix, $lockId)  → enter critical section
+ *   1. acquireLock($lockId)  → enter critical section
  *   2. check + validateOrder()
- *   3. releaseLock($prefix)  → always in a finally block
+ *   3. releaseLock()  → always in a finally block
  */
 class CartLockService
 {

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -63,7 +63,7 @@ class CartLockService
      */
     public function acquireLock($cartId, $timeout = self::LOCK_TIMEOUT_SECONDS)
     {
-        $lockKey = self::LOCK_ORDER_KEY_PREFIX . (int) $cartId;
+        $lockKey = $this->getOrderKey($cartId);
         $acquired = (bool) \Db::getInstance()->getValue(
             "SELECT GET_LOCK('" . $lockKey . "', " . (int) $timeout . ')'
         );
@@ -89,7 +89,7 @@ class CartLockService
      */
     public function acquireRefundLock($cartId, $amount, $timeout = self::LOCK_TIMEOUT_SECONDS)
     {
-        $lockKey = self::LOCK_REFUND_KEY_PREFIX . $cartId . '_' . $amount;
+        $lockKey = $this->getRefundKey($cartId . '_' . $amount);
         $acquired = (bool) \Db::getInstance()->getValue(
             "SELECT GET_LOCK('" . $lockKey . "', " . (int) $timeout . ')'
         );
@@ -113,7 +113,7 @@ class CartLockService
             return false;
         }
 
-        $lockKey = self::LOCK_ORDER_KEY_PREFIX . $this->lockedOrderId;
+        $lockKey = $this->getOrderKey($this->lockedOrderId);
         $released = (bool) \Db::getInstance()->getValue(
             "SELECT RELEASE_LOCK('" . $lockKey . "')"
         );
@@ -139,7 +139,7 @@ class CartLockService
             return false;
         }
 
-        $lockKey = self::LOCK_REFUND_KEY_PREFIX . $this->lockedRefundId;
+        $lockKey = $this->getRefundKey($this->lockedRefundId);
         $released = (bool) \Db::getInstance()->getValue(
             "SELECT RELEASE_LOCK('" . $lockKey . "')"
         );
@@ -151,5 +151,31 @@ class CartLockService
         $this->lockedRefundId = null;
 
         return $released;
+    }
+
+    /**
+     * Returns the lock key that would be used for a given cart ID.
+     * Useful for logging and debugging purposes.
+     *
+     * @param int $cartId
+     *
+     * @return string
+     */
+    public function getOrderKey($cartId)
+    {
+        return self::LOCK_ORDER_KEY_PREFIX . (int) $cartId;
+    }
+
+    /**
+     * Returns the lock key that would be used for a given cart ID and refund amount.
+     * Useful for logging and debugging purposes.
+     *
+     * @param string $lockKey
+     *
+     * @return string
+     */
+    public function getRefundKey($lockKey)
+    {
+        return self::LOCK_REFUND_KEY_PREFIX . $lockKey;
     }
 }

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -170,12 +170,12 @@ class CartLockService
      * Returns the lock key that would be used for a given cart ID and refund amount.
      * Useful for logging and debugging purposes.
      *
-     * @param string $lockKey
+     * @param string $cartIdAndAmount
      *
      * @return string
      */
-    public function getRefundKey($lockKey)
+    public function getRefundKey($cartIdAndAmount)
     {
-        return self::LOCK_REFUND_KEY_PREFIX . $lockKey;
+        return self::LOCK_REFUND_KEY_PREFIX . $cartIdAndAmount;
     }
 }

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -47,7 +47,9 @@ class CartLockService
     const LOCK_REFUND_KEY_PREFIX = 'alma_refund_cart_';
 
     /** @var string|null Cart ID currently locked by this instance, null if no lock held */
-    private $lockedId = null;
+    private $lockedOrderId = null;
+    /** @var string|null Cart ID and amount currently locked for refund by this instance, null if no lock held */
+    private $lockedRefundId = null;
 
     /**
      * Acquires a MySQL advisory lock for the given lock ID.
@@ -67,7 +69,7 @@ class CartLockService
         );
 
         if ($acquired) {
-            $this->lockedId = $cartId;
+            $this->lockedOrderId = $cartId;
         }
 
         return $acquired;
@@ -93,7 +95,7 @@ class CartLockService
         );
 
         if ($acquired) {
-            $this->lockedId = $cartId . '_' . $amount;
+            $this->lockedRefundId = $cartId . '_' . $amount;
         }
 
         return $acquired;
@@ -107,20 +109,20 @@ class CartLockService
      */
     public function releaseLock()
     {
-        if ($this->lockedId === null) {
+        if ($this->lockedOrderId === null) {
             return false;
         }
 
-        $lockKey = self::LOCK_ORDER_KEY_PREFIX . $this->lockedId;
+        $lockKey = self::LOCK_ORDER_KEY_PREFIX . $this->lockedOrderId;
         $released = (bool) \Db::getInstance()->getValue(
             "SELECT RELEASE_LOCK('" . $lockKey . "')"
         );
 
         if ($released === false) {
-            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for Cart Id ' . $this->lockedId);
+            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for Cart Id ' . $this->lockedOrderId);
         }
 
-        $this->lockedId = null;
+        $this->lockedOrderId = null;
 
         return $released;
     }
@@ -133,20 +135,20 @@ class CartLockService
      */
     public function releaseRefundLock()
     {
-        if ($this->lockedId === null) {
+        if ($this->lockedRefundId === null) {
             return false;
         }
 
-        $lockKey = self::LOCK_REFUND_KEY_PREFIX . $this->lockedId;
+        $lockKey = self::LOCK_REFUND_KEY_PREFIX . $this->lockedRefundId;
         $released = (bool) \Db::getInstance()->getValue(
             "SELECT RELEASE_LOCK('" . $lockKey . "')"
         );
 
         if ($released === false) {
-            LoggerFactory::instance()->warning('[Alma] releaseRefundLock failed to release lock for Cart Id and amount' . $this->lockedId);
+            LoggerFactory::instance()->warning('[Alma] releaseRefundLock failed to release lock for Cart Id and amount: ' . $this->lockedOrderId);
         }
 
-        $this->lockedId = null;
+        $this->lockedRefundId = null;
 
         return $released;
     }

--- a/alma/lib/Services/CartLockService.php
+++ b/alma/lib/Services/CartLockService.php
@@ -36,64 +36,66 @@ if (!defined('_PS_VERSION_')) {
  * infrastructure required, and the lock is automatically released if the DB connection drops.
  *
  * Usage pattern:
- *   1. acquireLock($cartId)  → enter critical section
+ *   1. acquireLock($prefix, $lockId)  → enter critical section
  *   2. check + validateOrder()
- *   3. releaseLock($cartId)  → always in a finally block
+ *   3. releaseLock($prefix)  → always in a finally block
  */
 class CartLockService
 {
     const LOCK_TIMEOUT_SECONDS = 10;
-    const LOCK_KEY_PREFIX = 'alma_order_cart_';
+    const LOCK_ORDER_KEY_PREFIX = 'alma_order_cart_';
+    const LOCK_REFUND_KEY_PREFIX = 'alma_refund_cart_';
 
-    /** @var int|null Cart ID currently locked by this instance, null if no lock held */
-    private $lockedCartId = null;
+    /** @var string|null Cart ID currently locked by this instance, null if no lock held */
+    private $lockedId = null;
 
     /**
-     * Acquires a MySQL advisory lock for the given cart ID.
+     * Acquires a MySQL advisory lock for the given lock ID.
      * If another process already holds the lock, waits up to $timeout seconds.
      * Returns true if the lock was acquired, false on timeout.
      *
-     * @param int $cartId
+     * @param string $prefix
+     * @param string $lockId
      * @param int $timeout seconds to wait before giving up (default: 10)
      *
      * @return bool
      */
-    public function acquireLock($cartId, $timeout = self::LOCK_TIMEOUT_SECONDS)
+    public function acquireLock($prefix, $lockId, $timeout = self::LOCK_TIMEOUT_SECONDS)
     {
-        $lockKey = $this->getLockKey((int) $cartId);
+        $lockKey = $this->getLockKey($prefix, $lockId);
         $acquired = (bool) \Db::getInstance()->getValue(
             "SELECT GET_LOCK('" . $lockKey . "', " . (int) $timeout . ')'
         );
 
         if ($acquired) {
-            $this->lockedCartId = (int) $cartId;
+            $this->lockedId = $lockId;
         }
 
         return $acquired;
     }
 
     /**
-     * Releases the advisory lock previously acquired for the given cart ID.
+     * Releases the advisory lock previously acquired for the given lock ID.
      * Safe to call even if the lock was never acquired (returns false in that case).
      *
      * @return bool true if the lock was released, false if it was not held by this connection
      */
-    public function releaseLock()
+    public function releaseLock($prefix)
     {
-        if ($this->lockedCartId === null) {
+        if ($this->lockedId === null) {
             return false;
         }
 
-        $lockKey = $this->getLockKey((int) $this->lockedCartId);
+        $lockKey = $this->getLockKey($prefix, $this->lockedId);
         $released = (bool) \Db::getInstance()->getValue(
             "SELECT RELEASE_LOCK('" . $lockKey . "')"
         );
 
-        if ($this->lockedCartId !== null && $released === false) {
-            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for cartId ' . $this->lockedCartId);
+        if ($this->lockedId !== null && $released === false) {
+            LoggerFactory::instance()->warning('[Alma] releaseLock failed to release lock for Id ' . $this->lockedId);
         }
 
-        $this->lockedCartId = null;
+        $this->lockedId = null;
 
         return $released;
     }
@@ -105,26 +107,26 @@ class CartLockService
      */
     public function isLockAcquired()
     {
-        return $this->lockedCartId !== null;
+        return $this->lockedId !== null;
     }
 
     /**
-     * Returns the cart ID currently locked by this instance, or null.
+     * Returns the lock ID currently locked by this instance, or null.
      *
-     * @return int|null
+     * @return string|null
      */
-    public function getLockedCartId()
+    public function getLockedId()
     {
-        return $this->lockedCartId;
+        return $this->lockedId;
     }
 
     /**
-     * @param int $cartId
+     * @param string $lockId
      *
      * @return string
      */
-    private function getLockKey($cartId)
+    private function getLockKey($prefix, $lockId)
     {
-        return self::LOCK_KEY_PREFIX . $cartId;
+        return $prefix . $lockId;
     }
 }

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -240,7 +240,7 @@ class PaymentValidation
                 throw new PaymentValidationError($cart, Payment::FRAUD_STATE_ERROR);
             }
 
-            if (!$this->cartLockService->acquireLock((int) $cart->id)) {
+            if (!$this->cartLockService->acquireLock(CartLockService::LOCK_ORDER_KEY_PREFIX, $cart->id)) {
                 if ($this->cartProxy->orderExists((int) $cart->id)) {
                     $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
 
@@ -332,7 +332,7 @@ class PaymentValidation
                     $extraRedirectArgs = '';
                 }
             } finally {
-                $this->cartLockService->releaseLock();
+                $this->cartLockService->releaseLock(CartLockService::LOCK_ORDER_KEY_PREFIX);
             }
         } else {
             $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -240,7 +240,7 @@ class PaymentValidation
                 throw new PaymentValidationError($cart, Payment::FRAUD_STATE_ERROR);
             }
 
-            if (!$this->cartLockService->acquireLock($cart->id)) {
+            if (!$this->cartLockService->acquireLock((int) $cart->id)) {
                 if ($this->cartProxy->orderExists((int) $cart->id)) {
                     $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
 

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -240,7 +240,8 @@ class PaymentValidation
                 throw new PaymentValidationError($cart, Payment::FRAUD_STATE_ERROR);
             }
 
-            if (!$this->cartLockService->acquireLock(CartLockService::LOCK_ORDER_KEY_PREFIX, $cart->id)) {
+            $lockId = CartLockService::LOCK_ORDER_KEY_PREFIX . $cart->id;
+            if (!$this->cartLockService->acquireLock($lockId)) {
                 if ($this->cartProxy->orderExists((int) $cart->id)) {
                     $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
 
@@ -332,7 +333,7 @@ class PaymentValidation
                     $extraRedirectArgs = '';
                 }
             } finally {
-                $this->cartLockService->releaseLock(CartLockService::LOCK_ORDER_KEY_PREFIX);
+                $this->cartLockService->releaseLock();
             }
         } else {
             $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;

--- a/alma/lib/Validators/PaymentValidation.php
+++ b/alma/lib/Validators/PaymentValidation.php
@@ -240,8 +240,7 @@ class PaymentValidation
                 throw new PaymentValidationError($cart, Payment::FRAUD_STATE_ERROR);
             }
 
-            $lockId = CartLockService::LOCK_ORDER_KEY_PREFIX . $cart->id;
-            if (!$this->cartLockService->acquireLock($lockId)) {
+            if (!$this->cartLockService->acquireLock($cart->id)) {
                 if ($this->cartProxy->orderExists((int) $cart->id)) {
                     $this->module->currentOrder = $this->getOrderByCartId((int) $cart->id)->id;
 

--- a/alma/tests/Unit/Services/CartLockServiceTest.php
+++ b/alma/tests/Unit/Services/CartLockServiceTest.php
@@ -51,10 +51,10 @@ class CartLockServiceTest extends TestCase
     {
         $this->dbMock->expects($this->once())
             ->method('getValue')
-            ->with($this->stringContains("GET_LOCK('alma_order_cart_42', 10)"))
+            ->with($this->stringContains("GET_LOCK('prefix_42', 10)"))
             ->willReturn('1');
 
-        $this->assertTrue($this->cartLockService->acquireLock(42));
+        $this->assertTrue($this->cartLockService->acquireLock('prefix_', 42));
     }
 
     public function testAcquireLockReturnsFalseOnTimeout()
@@ -63,79 +63,79 @@ class CartLockServiceTest extends TestCase
             ->method('getValue')
             ->willReturn('0');
 
-        $this->assertFalse($this->cartLockService->acquireLock(42));
+        $this->assertFalse($this->cartLockService->acquireLock('prefix_', 42));
     }
 
     public function testAcquireLockStoresCartId()
     {
         $this->dbMock->method('getValue')->willReturn('1');
 
-        $this->cartLockService->acquireLock(42);
+        $this->cartLockService->acquireLock('prefix_', 42);
 
         $this->assertTrue($this->cartLockService->isLockAcquired());
-        $this->assertSame(42, $this->cartLockService->getLockedCartId());
+        $this->assertSame(42, $this->cartLockService->getLockedId());
     }
 
     public function testAcquireLockDoesNotSetCartIdOnFailure()
     {
         $this->dbMock->method('getValue')->willReturn('0');
 
-        $this->cartLockService->acquireLock(42);
+        $this->cartLockService->acquireLock('prefix_', 42);
 
         $this->assertFalse($this->cartLockService->isLockAcquired());
-        $this->assertNull($this->cartLockService->getLockedCartId());
+        $this->assertNull($this->cartLockService->getLockedId());
     }
 
     public function testReleaseLockReturnsTrueWhenSuccessful()
     {
         $this->dbMock->method('getValue')->willReturnOnConsecutiveCalls('1', '1');
 
-        $this->cartLockService->acquireLock(42);
-        $this->assertTrue($this->cartLockService->releaseLock());
+        $this->cartLockService->acquireLock('prefix_', 42);
+        $this->assertTrue($this->cartLockService->releaseLock('prefix_'));
     }
 
     public function testReleaseLockClearsLockedCartId()
     {
         $this->dbMock->method('getValue')->willReturnOnConsecutiveCalls('1', '1');
 
-        $this->cartLockService->acquireLock(42);
-        $this->cartLockService->releaseLock();
+        $this->cartLockService->acquireLock('prefix_', 42);
+        $this->cartLockService->releaseLock('prefix_');
 
         $this->assertFalse($this->cartLockService->isLockAcquired());
-        $this->assertNull($this->cartLockService->getLockedCartId());
+        $this->assertNull($this->cartLockService->getLockedId());
     }
 
     public function testReleaseLockReturnsFalseWhenLockNotHeld()
     {
         $this->dbMock->method('getValue')->willReturn('0');
 
-        $this->assertFalse($this->cartLockService->releaseLock());
-        $this->assertNull($this->cartLockService->getLockedCartId());
+        $this->assertFalse($this->cartLockService->releaseLock('prefix_'));
+        $this->assertNull($this->cartLockService->getLockedId());
     }
 
     public function testIsLockAcquiredIsFalseByDefault()
     {
         $this->assertFalse($this->cartLockService->isLockAcquired());
-        $this->assertNull($this->cartLockService->getLockedCartId());
+        $this->assertNull($this->cartLockService->getLockedId());
     }
 
     public function testLockKeyContainsCartId()
     {
         $this->dbMock->expects($this->once())
             ->method('getValue')
-            ->with($this->stringContains('alma_order_cart_99'))
+            ->with($this->stringContains('prefix_99'))
             ->willReturn('1');
 
-        $this->cartLockService->acquireLock(99);
+        $this->cartLockService->acquireLock('prefix_', 99);
     }
 
     public function testAcquireLockUsesCustomTimeout()
     {
         $this->dbMock->expects($this->once())
             ->method('getValue')
-            ->with($this->stringContains("GET_LOCK('alma_order_cart_5', 30)"))
+            ->with($this->stringContains("GET_LOCK('prefix_5', 30)"))
             ->willReturn('1');
 
-        $this->cartLockService->acquireLock(5, 30);
+        $this->cartLockService->acquireLock('prefix_', 5, 30);
     }
 }

--- a/alma/tests/Unit/Services/CartLockServiceTest.php
+++ b/alma/tests/Unit/Services/CartLockServiceTest.php
@@ -51,21 +51,24 @@ class CartLockServiceTest extends TestCase
     {
         $this->dbMock->expects($this->once())
             ->method('getValue')
-            ->with($this->stringContains("GET_LOCK('prefix_42', 10)"))
+            ->with($this->stringContains("GET_LOCK('alma_order_cart_42', 10)"))
             ->willReturn('1');
 
-        $this->assertTrue($this->cartLockService->acquireLock('prefix_42'));
+        $this->assertTrue($this->cartLockService->acquireLock(42));
     }
 
     public function testAcquireLockExecutedTwiceWithoutReleaseSecondReturnFalse()
     {
         $this->dbMock->expects($this->exactly(2))
             ->method('getValue')
-            ->withConsecutive([$this->stringContains("GET_LOCK('prefix_42', 10)")], [$this->stringContains("GET_LOCK('prefix_42', 10)")])
+            ->withConsecutive(
+                [$this->stringContains("GET_LOCK('alma_order_cart_42', 10)")],
+                [$this->stringContains("GET_LOCK('alma_order_cart_42', 10)")]
+            )
             ->willReturnOnConsecutiveCalls('1', '0');
 
-        $this->assertTrue($this->cartLockService->acquireLock('prefix_42'));
-        $this->assertFalse($this->cartLockService->acquireLock('prefix_42'));
+        $this->assertTrue($this->cartLockService->acquireLock(42));
+        $this->assertFalse($this->cartLockService->acquireLock(42));
     }
 
     public function testAcquireLockExecutedTwiceWithReleaseSecondReturnTrue()
@@ -73,15 +76,31 @@ class CartLockServiceTest extends TestCase
         $this->dbMock->expects($this->exactly(3))
             ->method('getValue')
             ->withConsecutive(
-                [$this->stringContains("GET_LOCK('prefix_42', 10)")],
-                [$this->stringContains("GET_LOCK('prefix_42', 10)")],
-                [$this->stringContains("SELECT RELEASE_LOCK('prefix_42')")]
+                [$this->stringContains("GET_LOCK('alma_order_cart_42', 10)")],
+                [$this->stringContains("GET_LOCK('alma_order_cart_42', 10)")],
+                [$this->stringContains("RELEASE_LOCK('alma_order_cart_42')")]
             )
             ->willReturnOnConsecutiveCalls('1', '1', '1');
 
-        $this->assertTrue($this->cartLockService->acquireLock('prefix_42'));
-        $this->assertTrue($this->cartLockService->acquireLock('prefix_42'));
+        $this->assertTrue($this->cartLockService->acquireLock(42));
+        $this->assertTrue($this->cartLockService->acquireLock(42));
         $this->assertTrue($this->cartLockService->releaseLock());
+    }
+
+    public function testAcquireRefundLockExecutedTwiceWithReleaseRefundSecondReturnTrue()
+    {
+        $this->dbMock->expects($this->exactly(3))
+            ->method('getValue')
+            ->withConsecutive(
+                [$this->stringContains("GET_LOCK('alma_refund_cart_42_42000', 3)")],
+                [$this->stringContains("GET_LOCK('alma_refund_cart_42_42000', 3)")],
+                [$this->stringContains("RELEASE_LOCK('alma_refund_cart_42_42000')")]
+            )
+            ->willReturnOnConsecutiveCalls('1', '1', '1');
+
+        $this->assertTrue($this->cartLockService->acquireRefundLock(42, 42000, 3));
+        $this->assertTrue($this->cartLockService->acquireRefundLock(42, 42000, 3));
+        $this->assertTrue($this->cartLockService->releaseRefundLock());
     }
 
     public function testAcquireLockReturnsFalseOnTimeout()
@@ -90,7 +109,7 @@ class CartLockServiceTest extends TestCase
             ->method('getValue')
             ->willReturn('0');
 
-        $this->assertFalse($this->cartLockService->acquireLock('prefix_42'));
+        $this->assertFalse($this->cartLockService->acquireLock(42));
     }
 
     public function testReleaseLockReturnsTrueWhenSuccessful()
@@ -99,7 +118,7 @@ class CartLockServiceTest extends TestCase
             ->method('getValue')
             ->willReturnOnConsecutiveCalls('1', '1');
 
-        $this->cartLockService->acquireLock('prefix_42');
+        $this->cartLockService->acquireLock(42);
         $this->assertTrue($this->cartLockService->releaseLock());
     }
 
@@ -115,9 +134,9 @@ class CartLockServiceTest extends TestCase
     {
         $this->dbMock->expects($this->once())
             ->method('getValue')
-            ->with($this->stringContains("GET_LOCK('prefix_5', 30)"))
+            ->with($this->stringContains("GET_LOCK('alma_order_cart_5', 30)"))
             ->willReturn('1');
 
-        $this->cartLockService->acquireLock('prefix_5', 30);
+        $this->cartLockService->acquireLock(5, 30);
     }
 }

--- a/alma/tests/Unit/Services/CartLockServiceTest.php
+++ b/alma/tests/Unit/Services/CartLockServiceTest.php
@@ -139,4 +139,14 @@ class CartLockServiceTest extends TestCase
 
         $this->cartLockService->acquireLock(5, 30);
     }
+
+    public function testGetOrderKeyReturnsCorrectKey()
+    {
+        $this->assertEquals('alma_order_cart_42', $this->cartLockService->getOrderKey(42));
+    }
+
+    public function testGetRefundKeyReturnsCorrectKey()
+    {
+        $this->assertEquals('alma_refund_cart_42_42000', $this->cartLockService->getRefundKey('42_42000'));
+    }
 }

--- a/alma/tests/Unit/Services/CartLockServiceTest.php
+++ b/alma/tests/Unit/Services/CartLockServiceTest.php
@@ -54,7 +54,34 @@ class CartLockServiceTest extends TestCase
             ->with($this->stringContains("GET_LOCK('prefix_42', 10)"))
             ->willReturn('1');
 
-        $this->assertTrue($this->cartLockService->acquireLock('prefix_', 42));
+        $this->assertTrue($this->cartLockService->acquireLock('prefix_42'));
+    }
+
+    public function testAcquireLockExecutedTwiceWithoutReleaseSecondReturnFalse()
+    {
+        $this->dbMock->expects($this->exactly(2))
+            ->method('getValue')
+            ->withConsecutive([$this->stringContains("GET_LOCK('prefix_42', 10)")], [$this->stringContains("GET_LOCK('prefix_42', 10)")])
+            ->willReturnOnConsecutiveCalls('1', '0');
+
+        $this->assertTrue($this->cartLockService->acquireLock('prefix_42'));
+        $this->assertFalse($this->cartLockService->acquireLock('prefix_42'));
+    }
+
+    public function testAcquireLockExecutedTwiceWithReleaseSecondReturnTrue()
+    {
+        $this->dbMock->expects($this->exactly(3))
+            ->method('getValue')
+            ->withConsecutive(
+                [$this->stringContains("GET_LOCK('prefix_42', 10)")],
+                [$this->stringContains("GET_LOCK('prefix_42', 10)")],
+                [$this->stringContains("SELECT RELEASE_LOCK('prefix_42')")]
+            )
+            ->willReturnOnConsecutiveCalls('1', '1', '1');
+
+        $this->assertTrue($this->cartLockService->acquireLock('prefix_42'));
+        $this->assertTrue($this->cartLockService->acquireLock('prefix_42'));
+        $this->assertTrue($this->cartLockService->releaseLock());
     }
 
     public function testAcquireLockReturnsFalseOnTimeout()
@@ -63,70 +90,25 @@ class CartLockServiceTest extends TestCase
             ->method('getValue')
             ->willReturn('0');
 
-        $this->assertFalse($this->cartLockService->acquireLock('prefix_', 42));
-    }
-
-    public function testAcquireLockStoresCartId()
-    {
-        $this->dbMock->method('getValue')->willReturn('1');
-
-        $this->cartLockService->acquireLock('prefix_', 42);
-
-        $this->assertTrue($this->cartLockService->isLockAcquired());
-        $this->assertSame(42, $this->cartLockService->getLockedId());
-    }
-
-    public function testAcquireLockDoesNotSetCartIdOnFailure()
-    {
-        $this->dbMock->method('getValue')->willReturn('0');
-
-        $this->cartLockService->acquireLock('prefix_', 42);
-
-        $this->assertFalse($this->cartLockService->isLockAcquired());
-        $this->assertNull($this->cartLockService->getLockedId());
+        $this->assertFalse($this->cartLockService->acquireLock('prefix_42'));
     }
 
     public function testReleaseLockReturnsTrueWhenSuccessful()
     {
-        $this->dbMock->method('getValue')->willReturnOnConsecutiveCalls('1', '1');
+        $this->dbMock->expects($this->exactly(2))
+            ->method('getValue')
+            ->willReturnOnConsecutiveCalls('1', '1');
 
-        $this->cartLockService->acquireLock('prefix_', 42);
-        $this->assertTrue($this->cartLockService->releaseLock('prefix_'));
-    }
-
-    public function testReleaseLockClearsLockedCartId()
-    {
-        $this->dbMock->method('getValue')->willReturnOnConsecutiveCalls('1', '1');
-
-        $this->cartLockService->acquireLock('prefix_', 42);
-        $this->cartLockService->releaseLock('prefix_');
-
-        $this->assertFalse($this->cartLockService->isLockAcquired());
-        $this->assertNull($this->cartLockService->getLockedId());
+        $this->cartLockService->acquireLock('prefix_42');
+        $this->assertTrue($this->cartLockService->releaseLock());
     }
 
     public function testReleaseLockReturnsFalseWhenLockNotHeld()
     {
-        $this->dbMock->method('getValue')->willReturn('0');
+        $this->dbMock->expects($this->never())
+            ->method('getValue');
 
-        $this->assertFalse($this->cartLockService->releaseLock('prefix_'));
-        $this->assertNull($this->cartLockService->getLockedId());
-    }
-
-    public function testIsLockAcquiredIsFalseByDefault()
-    {
-        $this->assertFalse($this->cartLockService->isLockAcquired());
-        $this->assertNull($this->cartLockService->getLockedId());
-    }
-
-    public function testLockKeyContainsCartId()
-    {
-        $this->dbMock->expects($this->once())
-            ->method('getValue')
-            ->with($this->stringContains('prefix_99'))
-            ->willReturn('1');
-
-        $this->cartLockService->acquireLock('prefix_', 99);
+        $this->assertFalse($this->cartLockService->releaseLock());
     }
 
     public function testAcquireLockUsesCustomTimeout()
@@ -136,6 +118,6 @@ class CartLockServiceTest extends TestCase
             ->with($this->stringContains("GET_LOCK('prefix_5', 30)"))
             ->willReturn('1');
 
-        $this->cartLockService->acquireLock('prefix_', 5, 30);
+        $this->cartLockService->acquireLock('prefix_5', 30);
     }
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4061/handle-duplicate-refund)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
To avoid duplicate refund ou use the CartLockService to use the GET_LOCK SQL

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->