### PR TITLE
Define and use constant in SettingsHelper

### DIFF
--- a/alma/controllers/hook/ActionCartSaveHookController.php
+++ b/alma/controllers/hook/ActionCartSaveHookController.php
@@ -41,7 +41,7 @@ class ActionCartSaveHookController extends FrontendHookController
 
     public function canRun()
     {
-        $isLive = SettingsHelper::getActiveMode() === ALMA_MODE_LIVE;
+        $isLive = SettingsHelper::getActiveMode() === SettingsHelper::ALMA_MODE_LIVE;
 
         // Front controllers can run if the module is properly configured ...
         return SettingsHelper::isFullyConfigured()

--- a/alma/controllers/hook/DisplayAdminAfterHeaderHookController.php
+++ b/alma/controllers/hook/DisplayAdminAfterHeaderHookController.php
@@ -40,7 +40,7 @@ class DisplayAdminAfterHeaderHookController extends FrontendHookController
      */
     public function canRun()
     {
-        $isLive = SettingsHelper::getActiveMode() === ALMA_MODE_LIVE;
+        $isLive = SettingsHelper::getActiveMode() === SettingsHelper::ALMA_MODE_LIVE;
 
         return parent::canRun()
             && (\Tools::strtolower($this->currentControllerName()) == 'admindashboard'

--- a/alma/lib/Forms/ApiAdminFormBuilder.php
+++ b/alma/lib/Forms/ApiAdminFormBuilder.php
@@ -24,6 +24,7 @@
 
 namespace Alma\PrestaShop\Forms;
 
+use Alma\PrestaShop\Helpers\SettingsHelper;
 use Alma\PrestaShop\Model\AlmaApiKeyModel;
 
 if (!defined('_PS_VERSION_')) {
@@ -64,8 +65,8 @@ class ApiAdminFormBuilder extends AbstractAlmaAdminFormBuilder
                 $this->module->l('API Mode', 'ApiAdminFormBuilder'),
                 $this->module->l('Use Test mode until you are ready to take real orders with Alma. In Test mode, only admins can see Alma on cart/checkout pages.', 'ApiAdminFormBuilder'),
                 [
-                    ['api_mode' => ALMA_MODE_LIVE, 'name' => 'Live'],
-                    ['api_mode' => ALMA_MODE_TEST, 'name' => 'Test'],
+                    ['api_mode' => SettingsHelper::ALMA_MODE_LIVE, 'name' => 'Live'],
+                    ['api_mode' => SettingsHelper::ALMA_MODE_TEST, 'name' => 'Test'],
                 ],
                 'api_mode'
             ),

--- a/alma/lib/Helpers/Admin/AdminInsuranceHelper.php
+++ b/alma/lib/Helpers/Admin/AdminInsuranceHelper.php
@@ -185,7 +185,7 @@ class AdminInsuranceHelper
      */
     public function envUrl()
     {
-        if (SettingsHelper::getActiveMode() === ALMA_MODE_LIVE) {
+        if (SettingsHelper::getActiveMode() === SettingsHelper::ALMA_MODE_LIVE) {
             return ConstantsHelper::DOMAIN_URL_INSURANCE_LIVE;
         }
 

--- a/alma/lib/Helpers/SettingsHelper.php
+++ b/alma/lib/Helpers/SettingsHelper.php
@@ -28,14 +28,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-if (!defined('ALMA_MODE_TEST')) {
-    define('ALMA_MODE_TEST', 'test');
-}
-
-if (!defined('ALMA_MODE_LIVE')) {
-    define('ALMA_MODE_LIVE', 'live');
-}
-
 use Alma\API\Endpoints\Results\Eligibility;
 use Alma\API\Entities\Payment;
 use Alma\PrestaShop\Exceptions\AlmaException;
@@ -54,6 +46,9 @@ use Alma\PrestaShop\Forms\ShareOfCheckoutAdminFormBuilder;
  */
 class SettingsHelper
 {
+    public const ALMA_MODE_TEST = 'test';
+    public const ALMA_MODE_LIVE = 'live';
+
     const ALMA_FULLY_CONFIGURED = 'ALMA_FULLY_CONFIGURED';
     const ALMA_EXCLUDED_CATEGORIES = 'ALMA_EXCLUDED_CATEGORIES';
     /**
@@ -347,9 +342,9 @@ class SettingsHelper
      */
     public static function shouldHideShareOfCheckoutForm()
     {
-        return (SettingsHelper::isShareOfCheckoutNoAnswered() && ALMA_MODE_LIVE === SettingsHelper::getActiveMode())
-                || (!SettingsHelper::isShareOfCheckoutSetting() && ALMA_MODE_LIVE === SettingsHelper::getActiveMode())
-                || ALMA_MODE_LIVE !== SettingsHelper::getActiveMode();
+        return (SettingsHelper::isShareOfCheckoutNoAnswered() && SettingsHelper::ALMA_MODE_LIVE === SettingsHelper::getActiveMode())
+                || (!SettingsHelper::isShareOfCheckoutSetting() && SettingsHelper::ALMA_MODE_LIVE === SettingsHelper::getActiveMode())
+                || SettingsHelper::ALMA_MODE_LIVE !== SettingsHelper::getActiveMode();
     }
 
     /**
@@ -393,7 +388,7 @@ class SettingsHelper
      */
     public static function getActiveMode()
     {
-        return static::get('ALMA_API_MODE', ALMA_MODE_TEST);
+        return static::get('ALMA_API_MODE', SettingsHelper::ALMA_MODE_TEST);
     }
 
     /**
@@ -403,7 +398,7 @@ class SettingsHelper
      */
     public function getModeActive()
     {
-        return $this->getKey('ALMA_API_MODE', ALMA_MODE_TEST);
+        return $this->getKey('ALMA_API_MODE', SettingsHelper::ALMA_MODE_TEST);
     }
 
     /**
@@ -413,7 +408,7 @@ class SettingsHelper
      */
     public static function getActiveAPIKey()
     {
-        if (ALMA_MODE_LIVE == static::getActiveMode()) {
+        if (SettingsHelper::ALMA_MODE_LIVE == static::getActiveMode()) {
             return static::getLiveKey();
         }
 

--- a/alma/lib/Hooks/FrontendHookController.php
+++ b/alma/lib/Hooks/FrontendHookController.php
@@ -34,7 +34,7 @@ abstract class FrontendHookController extends HookController
 {
     public function canRun()
     {
-        $isLive = SettingsHelper::getActiveMode() === ALMA_MODE_LIVE;
+        $isLive = SettingsHelper::getActiveMode() === SettingsHelper::ALMA_MODE_LIVE;
 
         // Front controllers can run if the module is properly configured ...
         return SettingsHelper::isFullyConfigured()

--- a/alma/lib/Model/AlmaApiKeyModel.php
+++ b/alma/lib/Model/AlmaApiKeyModel.php
@@ -182,7 +182,7 @@ class AlmaApiKeyModel
      */
     public function getActiveApiKey()
     {
-        if (ALMA_MODE_LIVE == $this->configurationProxy->get(ApiAdminFormBuilder::ALMA_API_MODE)) {
+        if (SettingsHelper::ALMA_MODE_LIVE == $this->configurationProxy->get(ApiAdminFormBuilder::ALMA_API_MODE)) {
             return SettingsHelper::getLiveKey();
         }
 


### PR DESCRIPTION
### Reason for change

Problem solved: The global PHP constants ALMA_MODE_TEST and ALMA_MODE_LIVE (defined as 'test' and 'live') were not reliably available in all contexts where they were used, leading to potential undefined constant errors.
                                                                                                                                                                                              
Solution: Replaced the global constants with proper class constants on SettingsHelper.

[Linear task](https://linear.app/almapay/issue/802)

### Code changes

What changed:                                                                                                                                                                               
                  
  1. SettingsHelper.php — Removed the global define() calls (guarded by !defined(...)) and replaced them with two public const class constants: SettingsHelper::ALMA_MODE_TEST and SettingsHelper::ALMA_MODE_LIVE.
  2. 6 other files — Updated all usages of the bare ALMA_MODE_LIVE / ALMA_MODE_TEST global constants to reference the new class constants (SettingsHelper::ALMA_MODE_LIVE / SettingsHelper::ALMA_MODE_TEST). These were spread across hook controllers, a form builder, a model, and helper classes.                                                                    
   
  Net effect: The values are identical ('test' / 'live'), so there is no behavioral change — this is a pure refactor that makes the constants reliably accessible via the class, regardless of PHP include/load order.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

As an administrator with the Alma module well configured, I can create a new order with a new client on the same workflow

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [X] The tests are relevant, and cover the corner/error cases, not only the happy path
- [X] You understand the impact of this PR on existing code/features
- [X] The changes include adequate logging and Datadog traces
- [X] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->